### PR TITLE
Add layer masking, profile tool, theme toggle, buffer visualization, and prepare-disp-s1 fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gdal-bin libgdal-dev gcc g++ git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python deps first (layer-cached separately from source)
+COPY pyproject.toml ./
+COPY src/bowser/_version.py src/bowser/_version.py
+RUN pip install --no-cache-dir \
+        "gdal==$(gdal-config --version)" \
+        s3fs \
+        fsspec \
+    && pip install --no-cache-dir -e ".[widget]" || true
+
+# Copy full source + pre-built frontend dist
+COPY src/ src/
+COPY src/bowser/dist/ src/bowser/dist/
+
+RUN pip install --no-cache-dir --no-build-isolation -e .
+
+ENV BOWSER_HOST=0.0.0.0
+ENV BOWSER_PORT=8000
+
+EXPOSE 8000
+
+ENTRYPOINT ["bowser", "run"]

--- a/build/lib/bowser/_prepare_disp_s1.py
+++ b/build/lib/bowser/_prepare_disp_s1.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+
+from .titiler import Algorithm
+
+CORE_DATASETS = [
+    "displacement",
+    "short_wavelength_displacement",
+    "recommended_mask",
+    "connected_component_labels",
+    "temporal_coherence",
+    "estimated_phase_quality",
+    "persistent_scatterer_mask",
+    "shp_counts",
+    "water_mask",
+    "phase_similarity",
+    "timeseries_inversion_residuals",
+]
+CORRECTION_DATASETS = [
+    "corrections/ionospheric_delay",
+    "corrections/perpendicular_baseline",
+    "corrections/solid_earth_tide",
+]
+
+
+def get_disp_s1_outputs(disp_s1_dir: Path | str):
+    def _glob(pattern: str, subdir: str) -> list[str]:
+        return [str(p) for p in sorted((Path(disp_s1_dir) / subdir).glob(pattern))]
+
+    return [
+        {
+            "name": "Displacement",
+            "file_list": _glob("*.vrt", subdir="displacement"),
+            "uses_spatial_ref": True,
+            "algorithm": Algorithm.SHIFT.value,
+            "mask_file_list": _glob("*.vrt", subdir="connected_component_labels"),
+        },
+        {
+            "name": "Short Wavelength Displacement",
+            "file_list": _glob("*.vrt", subdir="short_wavelength_displacement"),
+        },
+        {
+            "name": "Connected Component Labels",
+            "file_list": _glob("*.vrt", subdir="connected_component_labels"),
+        },
+        {
+            "name": "Re-wrapped phase",
+            "file_list": _glob("*.vrt", subdir="displacement"),
+            "algorithm": Algorithm.REWRAP.value,
+        },
+        {
+            "name": "Persistent Scatterer Mask",
+            "file_list": _glob("*.vrt", subdir="persistent_scatterer_mask"),
+        },
+        {
+            "name": "Temporal Coherence",
+            "file_list": _glob("*.vrt", subdir="temporal_coherence"),
+        },
+        {
+            "name": "Phase Similarity",
+            "file_list": _glob("*.vrt", subdir="phase_similarity"),
+        },
+        {
+            "name": "Timeseries Inversion Residuals",
+            "file_list": _glob("*.vrt", subdir="timeseries_inversion_residuals"),
+        },
+        {
+            "name": "Estimated Phase quality",
+            "file_list": _glob("*.vrt", subdir="estimated_phase_quality"),
+        },
+        {
+            "name": "SHP counts",
+            "file_list": _glob("*.vrt", subdir="shp_counts"),
+        },
+        {
+            "name": "Water Mask",
+            "file_list": _glob("*.vrt", subdir="water_mask"),
+        },
+        {
+            "name": "Unwrapper Mask",
+            "file_list": _glob("*.vrt", subdir="unwrapper_mask"),
+        },
+        {
+            "name": "Ionospheric Delay",
+            "file_list": _glob("*vrt", subdir="corrections/ionospheric_delay"),
+            "uses_spatial_ref": True,
+            "algorithm": Algorithm.SHIFT.value,
+        },
+        {
+            "name": "Perpendicular Baseline",
+            "file_list": _glob("*vrt", subdir="corrections/perpendicular_baseline"),
+        },
+        {
+            "name": "Solid Earth Tide",
+            "file_list": _glob("*vrt", subdir="corrections/solid_earth_tide"),
+            "uses_spatial_ref": True,
+            "algorithm": Algorithm.SHIFT.value,
+        },
+    ]
+
+
+def get_aligned_disp_s1_outputs(aligned_dir: Path | str):
+    from glob import glob
+
+    return [
+        {
+            "name": "Displacement",
+            "file_list": sorted(glob(str(Path(aligned_dir) / "displacement*.tif"))),
+            "uses_spatial_ref": True,
+            "algorithm": Algorithm.SHIFT.value,
+            "mask_file_list": sorted(
+                glob(str(Path(aligned_dir) / "recommended_mask*.tif"))
+            ),
+        },
+        {
+            "name": "Short Wavelength Displacement",
+            "file_list": sorted(
+                glob(str(Path(aligned_dir) / "short_wavelength_displacement*.tif"))
+            ),
+        },
+        {
+            "name": "Connected Component Labels",
+            "file_list": sorted(
+                glob(str(Path(aligned_dir) / "connected_component_labels*.tif"))
+            ),
+        },
+        {
+            "name": "Re-wrapped phase",
+            "file_list": sorted(glob(str(Path(aligned_dir) / "displacement*.tif"))),
+            "algorithm": Algorithm.REWRAP.value,
+        },
+        {
+            "name": "Persistent Scatterer Mask",
+            "file_list": sorted(
+                glob(str(Path(aligned_dir) / "persistent_scatterer_mask*.tif"))
+            ),
+        },
+        {
+            "name": "Temporal Coherence",
+            "file_list": sorted(
+                glob((str(Path(aligned_dir) / "temporal_coherence*.tif")))
+            ),
+        },
+        {
+            "name": "Phase Similarity",
+            "file_list": sorted(
+                glob((str(Path(aligned_dir) / "phase_similarity*.tif")))
+            ),
+        },
+        {
+            "name": "Timeseries Inversion Residuals",
+            "file_list": sorted(
+                glob(str(Path(aligned_dir) / "timeseries_inversion_residuals*.tif"))
+            ),
+        },
+        {
+            "name": "Estimated Phase quality",
+            "file_list": sorted(
+                glob(str(Path(aligned_dir) / "estimated_phase_quality*.tif"))
+            ),
+        },
+        {
+            "name": "SHP counts",
+            "file_list": sorted(glob((str(Path(aligned_dir) / "shp_counts*.tif")))),
+        },
+        {
+            "name": "Water Mask",
+            "file_list": sorted(glob((str(Path(aligned_dir) / "water_mask.tif")))),
+        },
+    ]

--- a/build/lib/bowser/_prepare_nisar.py
+++ b/build/lib/bowser/_prepare_nisar.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from .titiler import Algorithm
+
+# Define NISAR GUNW datasets to extract
+NISAR_BASE_PATH = "/science/LSAR/GUNW/grids"
+NISAR_FREQ_A_PATH = f"{NISAR_BASE_PATH}/frequencyA"
+NISAR_GUNW_A_HH_PATH = f"{NISAR_FREQ_A_PATH}/unwrappedInterferogram/HH"
+NISAR_IFGW_A_HH_PATH = f"{NISAR_FREQ_A_PATH}/wrappedInterferogram/HH"
+NISAR_GOFF_A_HH_PATH = f"{NISAR_FREQ_A_PATH}/pixelOffsets/HH"
+NISAR_GUNW_DATASETS = [
+    f"{NISAR_GUNW_A_HH_PATH}/unwrappedPhase",
+    f"{NISAR_GUNW_A_HH_PATH}/coherenceMagnitude",
+    f"{NISAR_GUNW_A_HH_PATH}/connectedComponents",
+    f"{NISAR_GUNW_A_HH_PATH}/ionospherePhaseScreen",
+    f"{NISAR_GUNW_A_HH_PATH}/ionospherePhaseScreenUncertainty",
+    f"{NISAR_IFGW_A_HH_PATH}/wrappedInterferogram",
+    f"{NISAR_IFGW_A_HH_PATH}/coherenceMagnitude",
+    f"{NISAR_GOFF_A_HH_PATH}/alongTrackOffset",
+    f"{NISAR_GOFF_A_HH_PATH}/slantRangeOffset",
+    f"{NISAR_GOFF_A_HH_PATH}/correlationSurfacePeak",
+]
+
+
+def get_nisar_outputs(nisar_dir: Path | str):
+    def _glob(pattern: str, subdir: str) -> list[str]:
+        return [str(p) for p in sorted((Path(nisar_dir) / subdir).glob(pattern))]
+
+    return [
+        {
+            "name": "Unwrapped Phase",
+            "file_list": _glob("*.vrt", subdir="unwrappedPhase"),
+            "uses_spatial_ref": True,
+            "algorithm": Algorithm.SHIFT.value,
+            "mask_file_list": _glob("*.vrt", subdir="connectedComponents"),
+        },
+        {
+            "name": "Coherence Magnitude",
+            "file_list": _glob("*.vrt", subdir="coherenceMagnitude"),
+        },
+        {
+            "name": "Connected Components",
+            "file_list": _glob("*.vrt", subdir="connectedComponents"),
+        },
+        {
+            "name": "Ionosphere Phase Screen",
+            "file_list": _glob("*.vrt", subdir="ionospherePhaseScreen"),
+            "uses_spatial_ref": True,
+            "algorithm": Algorithm.SHIFT.value,
+        },
+        {
+            "name": "Ionosphere Phase Uncertainty",
+            "file_list": _glob("*.vrt", subdir="ionospherePhaseScreenUncertainty"),
+        },
+        {
+            "name": "Wrapped Interferogram",
+            "file_list": _glob("*.vrt", subdir="wrappedInterferogram"),
+            "algorithm": Algorithm.PHASE.value,
+        },
+        {
+            "name": "Wrapped Coherence",
+            "file_list": _glob("*.vrt", subdir="coherenceMagnitude"),
+        },
+        {
+            "name": "Re-wrapped Phase",
+            "file_list": _glob("*.vrt", subdir="unwrappedPhase"),
+            "algorithm": Algorithm.REWRAP.value,
+        },
+        {
+            "name": "Along-Track Offset",
+            "file_list": _glob("*.vrt", subdir="alongTrackOffset"),
+        },
+        {
+            "name": "Slant Range Offset",
+            "file_list": _glob("*.vrt", subdir="slantRangeOffset"),
+        },
+        {
+            "name": "Correlation Surface Peak",
+            "file_list": _glob("*.vrt", subdir="correlationSurfacePeak"),
+        },
+    ]

--- a/build/lib/bowser/_prepare_utils.py
+++ b/build/lib/bowser/_prepare_utils.py
@@ -1,0 +1,144 @@
+import logging
+from functools import partial
+from pathlib import Path
+from typing import Sequence
+
+import h5py
+from opera_utils import get_dates
+from opera_utils.credentials import ASFCredentialEndpoints, AWSCredentials
+from opera_utils.disp import open_h5
+from osgeo import gdal
+from tqdm.contrib.concurrent import process_map
+
+from bowser.add_overviews import add_overviews
+
+logger = logging.getLogger("bowser")
+
+
+def process_netcdf_files(
+    netcdf_files: Sequence[Path | str],
+    output_dir: Path,
+    datasets: list[str],
+    max_workers: int = 5,
+    strip_group_path: bool = False,
+) -> None:
+    """Process NetCDF files in the input directory, create VRT files, build overviews.
+
+    Parameters
+    ----------
+    netcdf_files : Sequence[Path]
+        Paths to input NetCDF files.
+    output_dir : Path
+        Path to the directory where output VRT files will be saved.
+    datasets : list[str]
+        list of dataset names to process from each NetCDF file.
+    max_workers : int
+        Number of parallel files to process.
+        Default is 5.
+    strip_group_path : bool
+        If True, the output directory for the VRTs is only one level deep.
+        Otherwise, uses the full HDF5 path as VRT path.
+        Default is False.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    This function processes all NetCDF files in the input directory, creates VRT files
+    for each specified dataset, and builds overviews for the created VRT files.
+
+    """
+    # Ensure output directory exists
+    out_path = Path(output_dir)
+    out_path.mkdir(exist_ok=True, parents=True)
+
+    if any(str(f).startswith("s3://") for f in netcdf_files):
+        aws_credentials = AWSCredentials.from_asf(endpoint=ASFCredentialEndpoints.OPERA)
+    else:
+        aws_credentials = None
+
+    func = partial(
+        process_single_file,
+        output_dir=output_dir,
+        datasets=datasets,
+        aws_credentials=aws_credentials,
+        strip_group_path=strip_group_path,
+    )
+
+    process_map(
+        func,
+        netcdf_files,
+        max_workers=max_workers,
+    )
+
+
+def process_single_file(
+    netcdf_file: str,
+    output_dir: Path,
+    datasets: list[str],
+    aws_credentials: AWSCredentials | None,
+    strip_group_path: bool = False,
+) -> None:
+    """Create VRT files from subdatasets and build overviews.
+
+    Parameters
+    ----------
+    netcdf_file : str
+        Path to the input NetCDF file.
+    output_dir : Path
+        Path to the directory where output VRT files will be saved.
+    datasets : list[str]
+        list of dataset names to process from the NetCDF file.
+    aws_credentials : AWSCredentials, optional
+        Object containing temporary S3 credentials for remote datasets.
+        Only usable on in-region EC2 instances.
+    strip_group_path : bool
+        If True, the output directory for the VRTs is only one level deep.
+        Otherwise, uses the full HDF5 path as VRT path.
+        Default is False.
+
+    Returns
+    -------
+    None
+
+    """
+    # Extract date information from the filename
+
+    try:
+        fmt = "%Y%m%d"
+        # TODO: NISAR ifgs may have 4 dates in them
+        # Rethink how to make this filename here for multiple products
+        dates = get_dates(netcdf_file, fmt=fmt)[:2]
+        vrt_filename = f"{dates[0].strftime(fmt)}_{dates[1].strftime(fmt)}.vrt"
+    except IndexError:
+        # Date parsing failed: just use stem
+        # TODO: NISAR holds ref/secondary as
+        # /science/LSAR/identification/secondaryZeroDopplerEndTime
+        vrt_filename = f"{str(netcdf_file).replace('/', '_')}.vrt"
+
+    if str(netcdf_file).startswith("s3://"):
+        hf = open_h5(netcdf_file, aws_credentials=aws_credentials)
+        logger.debug(f"Read remote {netcdf_file}")
+    else:
+        hf = h5py.File(netcdf_file)
+
+    for in_dataset in datasets:
+        if in_dataset not in hf:
+            continue
+        out_dataset = in_dataset if not strip_group_path else in_dataset.split("/")[-1]
+        cur_output_dir = output_dir / out_dataset
+        cur_output_dir.mkdir(exist_ok=True, parents=True)
+
+        vrt_path = cur_output_dir / vrt_filename
+
+        # Create VRT file
+        gdal.Translate(
+            str(vrt_path),
+            f"netcdf:{netcdf_file.replace('s3://', '/vsis3/')}:{in_dataset}",
+            callback=gdal.TermProgress_nocb,
+        )
+
+        # Build overviews using GDAL function with compression
+        add_overviews(vrt_path, external=True)

--- a/build/lib/bowser/_server.py
+++ b/build/lib/bowser/_server.py
@@ -1,0 +1,197 @@
+"""Server utilities for running Bowser FastAPI app programmatically."""
+
+import logging
+import os
+import socket
+import threading
+import time
+from contextlib import contextmanager
+from typing import Optional
+
+import uvicorn
+
+logger = logging.getLogger(__name__)
+
+
+def _find_available_port(start_port: int = 8000) -> int:
+    """Find an available port starting from start_port."""
+    port = start_port - 1
+    while True:
+        port += 1
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            result = s.connect_ex(("127.0.0.1", port))
+            if result != 0:
+                return port
+
+
+def _setup_gdal_env(ignore_sidecar_files: bool = False):
+    """Set up GDAL environment variables for optimal performance."""
+    cfg = {
+        "GDAL_HTTP_MULTIPLEX": "YES",
+        "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
+        "GDAL_CACHEMAX": "800",
+        "CPL_VSIL_CURL_CACHE_SIZE": "800",
+        "VSI_CACHE": "TRUE",
+        "VSI_CACHE_SIZE": "5000000",
+    }
+    for k, v in cfg.items():
+        os.environ[k] = v
+    if ignore_sidecar_files:
+        os.environ["GDAL_DISABLE_READDIR_ON_OPEN"] = "EMPTY_DIR"
+
+
+class BowserServer:
+    """A Bowser server that can be started/stopped programmatically."""
+
+    def __init__(
+        self,
+        stack_file: Optional[str] = None,
+        rasters_file: Optional[str] = None,
+        port: int = 0,
+        ignore_sidecar_files: bool = False,
+        no_spatial_reference: bool = False,
+        no_recommended_mask: bool = False,
+    ):
+        self.stack_file = stack_file
+        self.rasters_file = rasters_file or "bowser_rasters.json"
+        self.port = port or _find_available_port(8000)
+        self.ignore_sidecar_files = ignore_sidecar_files
+        self.no_spatial_reference = no_spatial_reference
+        self.no_recommended_mask = no_recommended_mask
+
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+        self._should_exit = threading.Event()
+
+    @property
+    def url(self) -> str:
+        """Get the server URL."""
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self) -> None:
+        """Start the server in a background thread."""
+        if self._server is not None:
+            raise RuntimeError("Server is already running")
+
+        # Set up environment
+        _setup_gdal_env(self.ignore_sidecar_files)
+
+        if self.stack_file:
+            os.environ["BOWSER_STACK_DATA_FILE"] = self.stack_file
+        else:
+            os.environ["BOWSER_DATASET_CONFIG_FILE"] = self.rasters_file
+
+        os.environ["BOWSER_SPATIAL_REFERENCE_DISP"] = (
+            "NO" if self.no_spatial_reference else "YES"
+        )
+        os.environ["BOWSER_USE_RECOMMENDED_MASK"] = (
+            "NO" if self.no_recommended_mask else "YES"
+        )
+
+        # If port was 0, find an available one
+        if self.port == 0:
+            self.port = _find_available_port(8000)
+
+        logger.info(f"Starting Bowser server on {self.url}")
+
+        # Create uvicorn config
+        config = uvicorn.Config(
+            "bowser.main:app",
+            host="127.0.0.1",
+            port=self.port,
+            log_level="warning",
+        )
+
+        self._server = uvicorn.Server(config)
+
+        # Start server in background thread
+        self._thread = threading.Thread(target=self._run_server, daemon=True)
+        assert self._thread is not None
+        self._thread.start()
+
+        # Wait for server to start
+        timeout = 60
+        start_time = time.time()
+        while not self._server_is_ready() and time.time() - start_time < timeout:
+            time.sleep(0.1)
+
+        if not self._server_is_ready():
+            raise RuntimeError(f"Server failed to start within {timeout} seconds")
+
+    def _run_server(self):
+        """Run the uvicorn server."""
+        try:
+            self._server.run()
+        except Exception as e:
+            logger.error(f"Server error: {e}")
+
+    def _server_is_ready(self) -> bool:
+        """Check if server is ready to accept connections."""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(1)
+                result = s.connect_ex(("127.0.0.1", self.port))
+                return result == 0
+        except Exception:
+            return False
+
+    def stop(self) -> None:
+        """Stop the server."""
+        if self._server is not None:
+            logger.info("Stopping Bowser server")
+            self._should_exit.set()
+            self._server.should_exit = True
+            if self._thread and self._thread.is_alive():
+                self._thread.join(timeout=5)
+            self._server = None
+            self._thread = None
+
+
+@contextmanager
+def running(
+    stack_file: Optional[str] = None,
+    rasters_file: Optional[str] = None,
+    port: int = 0,
+    ignore_sidecar_files: bool = False,
+    no_spatial_reference: bool = False,
+    no_recommended_mask: bool = False,
+):
+    """Context manager for running a Bowser server.
+
+    Args:
+    ----
+        stack_file: Path to zarr/netcdf stack file
+        rasters_file: Path to JSON file with raster configurations
+        port: Port to run on (0 for automatic)
+        ignore_sidecar_files: Ignore GDAL sidecar files
+        no_spatial_reference: Don't use spatial reference for displacement
+        no_recommended_mask: Don't use recommended mask
+
+    Yields:
+    ------
+        BowserServer: The running server instance
+    """
+    server = BowserServer(
+        stack_file=stack_file,
+        rasters_file=rasters_file,
+        port=port,
+        ignore_sidecar_files=ignore_sidecar_files,
+        no_spatial_reference=no_spatial_reference,
+        no_recommended_mask=no_recommended_mask,
+    )
+    try:
+        server.start()
+        yield server
+    finally:
+        server.stop()
+
+
+def create_app():
+    """Create the FastAPI app instance.
+
+    This is a factory function that can be imported and used
+    independently of the CLI.
+    """
+    from .main import app
+
+    return app

--- a/build/lib/bowser/_widget.py
+++ b/build/lib/bowser/_widget.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+import ipywidgets as widgets
+import pandas as pd
+import requests
+
+## MODIFIED: Use CircleMarker for better styling and import specific bqplot items
+from bqplot import Axis, DateScale, Figure, LinearScale, Lines, Scatter
+from ipyleaflet import (
+    DivIcon,
+    LayersControl,
+    Map,
+    Marker,
+    ScaleControl,
+    TileLayer,
+    basemaps,
+)
+from IPython.display import display
+from titiler.core.models.mapbox import TileJSON
+
+from ._server import BowserServer
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# (Constants like DEFAULT_VMIN, CMAPS, etc. remain unchanged)
+DEFAULT_VMIN = -0.2
+DEFAULT_VMAX = 0.2
+DEFAULT_CMAP = "rdbu_r"
+CMAPS = ["rdbu_r", "viridis", "plasma", "magma", "inferno", "jet", "gray"]
+
+
+def make_bowser_widget(
+    dataset_name: str | None = None,
+    bowser_url: str = "http://localhost:8000",
+    **server_kwargs,
+) -> widgets.VBox:
+    """Create a Jupyter widget with dataset, colormap, rescale and opacity controls."""
+    os.environ["TQDM_DISABLE"] = "1"
+    # Ensure a server is available (this part is unchanged)
+    server = None
+    try:
+        requests.get(f"{bowser_url}/mode", timeout=2)
+    except requests.exceptions.RequestException:
+        logger.info("Starting Bowser server...")
+        server = BowserServer(**server_kwargs)
+        server.start()
+        bowser_url = server.url
+
+    try:
+        mode = requests.get(f"{bowser_url}/mode").json()["mode"]
+        datasets = requests.get(f"{bowser_url}/datasets").json()
+        if not datasets:
+            raise RuntimeError("Bowser returned no datasets.")
+        if dataset_name is None:
+            dataset_name = list(datasets.keys())[0]
+        if dataset_name not in datasets:
+            raise ValueError(f"Dataset '{dataset_name}' not found.")
+
+        # --- controls (unchanged) ---
+        dataset_dd = widgets.Dropdown(
+            options=list(datasets.keys()), value=dataset_name, description="Layer:"
+        )
+        cmap_dd = widgets.Dropdown(
+            options=CMAPS, value=DEFAULT_CMAP, description="Colormap:"
+        )
+        vmin_ft = widgets.FloatText(value=DEFAULT_VMIN, step=0.01, description="vmin:")
+        vmax_ft = widgets.FloatText(value=DEFAULT_VMAX, step=0.01, description="vmax:")
+        opacity_sl = widgets.FloatSlider(
+            value=1.0, min=0.0, max=1.0, step=0.01, description="Opacity:"
+        )
+        idx_sl = widgets.IntSlider(description="Index:", continuous_update=False)
+        left_controls = widgets.VBox(
+            [dataset_dd, vmin_ft, vmax_ft, cmap_dd, opacity_sl, idx_sl]
+        )
+
+        title = widgets.HTML(value="")
+        m = Map(center=[0, 0], zoom=2, basemap=basemaps.Esri.WorldImagery)
+        m.add_control(ScaleControl(position="bottomleft"))
+        m.add_control(LayersControl(position="topright"))
+        cur_layer: TileLayer | None = None
+        ## Cache for reference point time series data
+        ref_values_cache: dict[str, dict] = {}
+        # --- Markers: use Marker + DivIcon for consistent draggable behavior ---
+        marker_html = (
+            "<div style="
+            "width:14px;height:14px;border-radius:50%;"
+            "background:{color};border:2px solid white;"
+            'box-shadow:0 0 2px rgba(0,0,0,.6)"></div>'
+        )
+        ts_icon = DivIcon(
+            html=marker_html.format(color="royalblue"),
+            icon_size=[14, 14],
+            icon_anchor=[7, 7],
+        )
+        ref_icon = DivIcon(
+            html=marker_html.format(color="black"),
+            icon_size=[14, 14],
+            icon_anchor=[7, 7],
+        )
+        ts_marker = Marker(
+            location=m.center, draggable=True, name="Time Series Point", icon=ts_icon
+        )
+        ref_marker = Marker(
+            location=m.center, draggable=True, name="Reference Point", icon=ref_icon
+        )
+        m.add_layer(ts_marker)
+
+        ## bqplot figure (unchanged from previous version)
+        plot_output = widgets.Output()
+        fig_title = "Time Series (click map to select point)"
+        x_sc, y_sc = DateScale(), LinearScale()
+        line = Lines(x=[], y=[], scales={"x": x_sc, "y": y_sc}, colors=["steelblue"])
+        current_time_marker = Scatter(
+            x=[],
+            y=[],
+            scales={"x": x_sc, "y": y_sc},
+            colors=["red"],
+            default_size=100,  # Makes the marker dot bigger
+        )
+        x_ax = Axis(scale=x_sc, label="Date")
+        y_ax = Axis(scale=y_sc, orientation="vertical", label="Value")
+        fig = Figure(
+            marks=[line, current_time_marker], axes=[x_ax, y_ax], title=fig_title
+        )
+
+        def fit_to_layer(_=None):
+            # (Function unchanged)
+            info = datasets[dataset_dd.value]
+            b = info.get("latlon_bounds")
+            if b:
+                m.fit_bounds([[b[1], b[0]], [b[3], b[2]]])
+                center = [(b[1] + b[3]) / 2, (b[0] + b[2]) / 2]
+                ts_marker.location = ref_marker.location = center
+
+        def set_dataset_controls(name: str):
+            # (Function mostly unchanged, just added plot clearing)
+            info = datasets[name]
+            idx_sl.min, idx_sl.max = 0, max(0, len(info["x_values"]) - 1)
+            idx_sl.value = min(idx_sl.value, idx_sl.max)
+            title.value = f"<h2>{info['x_values'][idx_sl.value]}</h2>"
+            if info.get("uses_spatial_ref"):
+                if ref_marker not in m.layers:
+                    m.add_layer(ref_marker)
+            else:
+                if ref_marker in m.layers:
+                    m.remove_layer(ref_marker)
+            plot_output.clear_output()
+
+        def build_params(name: str, idx: int) -> tuple[str, dict]:
+            info = datasets[name]
+            params = {
+                "rescale": f"{vmin_ft.value},{vmax_ft.value}",
+                "colormap_name": cmap_dd.value,
+            }
+            ## ADDED: Inject algorithm_params for shift when reference is used
+            if info.get("algorithm") == "shift" and name in ref_values_cache:
+                ref_ts = ref_values_cache[name]
+                if idx < len(ref_ts):
+                    shift_val = ref_ts[idx]
+                    if shift_val is not None and pd.notna(shift_val):
+                        params["algorithm_params"] = f'{{"shift": {shift_val}}}'
+
+            if mode == "md":
+                params.update({"variable": name, "time_idx": idx})
+                endpoint = "md/WebMercatorQuad/tilejson.json"
+            else:
+                params.update({"url": info["file_list"][idx]})
+                endpoint = "cog/WebMercatorQuad/tilejson.json"
+            return endpoint, params
+
+        def refresh_tile(*_):
+            nonlocal cur_layer
+            name, idx = dataset_dd.value, idx_sl.value
+            title.value = f"<h2>{datasets[name]['x_values'][idx]}</h2>"
+            endpoint, params = build_params(name, idx)
+            r = requests.get(f"{bowser_url}/{endpoint}", params=params)
+            r.raise_for_status()
+            tj = TileJSON(**r.json())
+            new_layer = TileLayer(url=tj.tiles[0], opacity=opacity_sl.value)
+            if cur_layer:
+                m.remove_layer(cur_layer)
+            cur_layer = new_layer
+            m.add_layer(cur_layer)
+
+        ## Function to fetch ref data AND THEN refresh the tile layer
+        # Simple debounce to avoid hammering the server while dragging
+        _ref_debounce_handle: dict[str, threading.Timer | None] = {"pending": None}
+
+        def _do_fetch_ref_and_refresh(*_):
+            name = dataset_dd.value
+            if not datasets[name].get("uses_spatial_ref"):
+                return
+            lat, lon = ref_marker.location
+            params = {"dataset_name": name, "lon": lon, "lat": lat}
+            try:
+                r = requests.get(f"{bowser_url}/point", params=params)
+                r.raise_for_status()
+                ref_values_cache[name] = r.json()
+                logger.info(f"Updated reference values for {name}")
+            except requests.RequestException as e:
+                logger.error(f"Failed to fetch reference values: {e}")
+                ref_values_cache.pop(name, None)
+            refresh_tile()  # Refresh the map with the new shift value
+
+        def fetch_ref_and_refresh(*_):
+            # debounce ~150ms on drag
+            if _ref_debounce_handle["pending"] is not None:
+                _ref_debounce_handle["pending"].cancel()
+            t = threading.Timer(0.15, _do_fetch_ref_and_refresh)
+            _ref_debounce_handle["pending"] = t
+            t.start()
+
+        def update_plot_marker(data, *_):
+            if data and "_" in data[0]["x"]:
+                x_dates = pd.to_datetime([d["x"].split("_")[1] for d in data])
+            else:
+                x_dates = pd.to_datetime([d["x"] for d in data])
+            line.x = x_dates
+
+            line.y = y_values = [d["y"] for d in data]
+            idx = idx_sl.value
+            # Check if the line has data and the index is valid
+            if len(line.x) > idx:
+                current_time_marker.x = [line.x[idx]]
+                current_time_marker.y = [line.y[idx]]
+            else:
+                # Hide the marker if there's no data
+                current_time_marker.x = []
+                current_time_marker.y = []
+            return x_dates, y_values
+
+        def update_chart(*_):
+            name = dataset_dd.value
+            lat, lon = ts_marker.location
+            params = {"dataset_name": name, "lon": lon, "lat": lat}
+            if datasets[name].get("uses_spatial_ref") and ref_marker in m.layers:
+                params["ref_lat"], params["ref_lon"] = ref_marker.location
+            try:
+                r = requests.get(f"{bowser_url}/chart_point", params=params)
+                r.raise_for_status()
+                data = r.json()["datasets"][0]["data"]
+                if not data:
+                    line.x, line.y = [], []
+                    fig.title = f"No data for point ({lat:.4f}, {lon:.4f})"
+                else:
+                    if data and "_" in data[0]["x"]:
+                        x_dates = pd.to_datetime([d["x"].split("_")[1] for d in data])
+                    else:
+                        x_dates = pd.to_datetime([d["x"] for d in data])
+                    ## Make y-axis limits dynamic
+                    x_dates, y_values = update_plot_marker(data)
+                    y_min, y_max = min(y_values), max(y_values)
+                    y_sc.min = min(y_min, vmin_ft.value)
+                    y_sc.max = max(y_max, vmax_ft.value)
+                    fig.title = f"Time Series at ({lat:.4f}, {lon:.4f})"
+                with plot_output:
+                    plot_output.clear_output(wait=True)
+                    display(fig)
+            except (requests.RequestException, IndexError) as e:
+                logger.error(f"Failed to fetch chart data: {e}")
+
+        def on_map_click(**event):
+            if event["type"] == "click":
+                ts_marker.location = event["coordinates"]
+                update_chart()
+
+        ## handler for dataset changes to manage fetching reference data
+        def on_dataset_change(_):
+            name = dataset_dd.value
+            set_dataset_controls(name)
+            if datasets[name].get("uses_spatial_ref"):
+                # immediate (non-debounced) fetch on dataset switch for first frame
+                _do_fetch_ref_and_refresh()
+            else:
+                refresh_tile()
+
+        # wiring
+        dataset_dd.observe(on_dataset_change, names="value")
+        idx_sl.observe(lambda _: (refresh_tile(), update_chart()), names="value")
+        cmap_dd.observe(refresh_tile, names="value")
+        vmin_ft.observe(lambda _: (refresh_tile(), update_chart()), names="value")
+        vmax_ft.observe(lambda _: (refresh_tile(), update_chart()), names="value")
+        opacity_sl.observe(
+            lambda c: setattr(cur_layer, "opacity", c["new"]) if cur_layer else None,
+            names="value",
+        )
+
+        m.on_interaction(on_map_click)
+        # Dragging either marker updates the outputs:
+        ts_marker.observe(update_chart, names="location")  # live chart follow
+        ref_marker.observe(
+            fetch_ref_and_refresh, names="location"
+        )  # re-shift map on drag
+
+        # init
+        fit_to_layer()
+        on_dataset_change(None)  # Initial load
+
+        # layout
+        container = widgets.GridBox(
+            children=[left_controls, m],
+            layout=widgets.Layout(
+                width="100%",
+                height="55vh",
+                grid_template_columns="25em 1fr",
+                grid_template_areas='"menu map"',
+                align_items="stretch",
+            ),
+        )
+
+        # In the figure definition, set a proportional height
+        fig = Figure(
+            marks=[line, current_time_marker],
+            axes=[x_ax, y_ax],
+            title=fig_title,
+            layout={"height": "35vh", "width": "95%"},
+        )
+        ui = widgets.VBox([title, container, plot_output])
+        return ui
+
+    except Exception as e:
+        if server:
+            server.stop()
+        raise e

--- a/build/lib/bowser/cli.py
+++ b/build/lib/bowser/cli.py
@@ -254,35 +254,10 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
     from .titiler import Algorithm, RasterGroup, _find_files
 
     def _glob(g):
-        import rasterio
-
         try:
-            files = _find_files(g.replace("'", "").replace('"', ""))
-        except (RuntimeError, Exception):
+            return _find_files(g.replace("'", "").replace('"', ""))
+        except RuntimeError:
             return []
-        readable = []
-        for f in files:
-            if not Path(f).exists():
-                continue
-            try:
-                with rasterio.open(f):
-                    pass
-                readable.append(f)
-            except KeyError:
-                # rasterio doesn't recognise the GDAL dtype (e.g. Float16 = type 15)
-                # but the file is still valid — include it
-                readable.append(f)
-            except Exception:
-                pass
-        return readable
-
-    def _glob_first(*patterns):
-        """Return result of first pattern that finds any files."""
-        for p in patterns:
-            result = _glob(p)
-            if result:
-                return result
-        return []
 
     wd = dolphin_work_dir.rstrip("/")
 
@@ -295,7 +270,7 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
         },
         {
             "name": "velocity",
-            "file_list": _glob(f"{wd}/timeseries/velocity.tif"),
+            "file_list": [f"{wd}/timeseries/velocity.tif"],
             "uses_spatial_ref": True,
             "algorithm": Algorithm.SHIFT.value,
         },
@@ -305,7 +280,7 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
         },
         {
             "name": "Filtered velocity",
-            "file_list": _glob(f"{wd}/filtered_timeseries*/velocity.tif"),
+            "file_list": [f"{wd}/filtered_timeseries*/velocity.tif"],
         },
         {
             "name": "unwrapped",
@@ -323,10 +298,6 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
             "file_list": _glob(f"{wd}/timeseries/nonzero_conncomp_count_*.tif"),
         },
         {
-            "name": "Multi-looked coherence",
-            "file_list": _glob(f"{wd}/interferograms/multilooked_coh*.tif"),
-        },
-        {
             "name": "Re-wrapped phase",
             "file_list": _glob(f"{wd}/unwrapped/2*[0-9].unw.tif"),
             "algorithm": Algorithm.REWRAP.value,
@@ -341,10 +312,7 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
         },
         {
             "name": "Temporal coherence",
-            "file_list": _glob_first(
-                f"{wd}/interferograms/temporal_coherence_[0-9]*.tif",
-                f"{wd}/interferograms/temporal_coherence*.tif",
-            ),
+            "file_list": _glob(f"{wd}/interferograms/temporal_coherence_[0-9]*.tif"),
         },
         {
             "name": "Average temporal coherence",
@@ -352,10 +320,7 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
         },
         {
             "name": "Phase cosine similarity",
-            "file_list": _glob_first(
-                f"{wd}/interferograms/similarity_[0-9]*.tif",
-                f"{wd}/interferograms/similarity*.tif",
-            ),
+            "file_list": _glob(f"{wd}/interferograms/similarity_[0-9]*.tif"),
         },
         {
             "name": "Phase cosine similarity (full)",
@@ -400,16 +365,6 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
                 "algorithm": Algorithm.PHASE.value,
             }
         )
-    amplitude_files = _glob(f"{wd}/amplitude_db/2*_amp_db.tif")
-    print(amplitude_files)
-    if amplitude_files:
-        dolphin_outputs.append(
-            {
-                "name": "Amplitude",
-                "file_list": amplitude_files,
-                "algorithm": Algorithm.AMPLITUDE.value,
-            }
-        )
     if timeseries_mask is not None:
         # Timeseries
         dolphin_outputs[0]["mask_file_list"] = timeseries_mask
@@ -417,8 +372,6 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
         dolphin_outputs[1]["mask_file_list"] = timeseries_mask
     raster_groups = []
     for group in dolphin_outputs:
-        if not group.get("file_list"):
-            continue
         try:
             rg = RasterGroup(**group)
         except Exception as e:
@@ -571,142 +524,6 @@ def setup_aligned_disp_s1(disp_s1_dir: str, output: str):
         raster_groups.append(rg)
 
     _dump_raster_groups(raster_groups, output=output)
-
-
-@cli_app.command()
-@click.argument(
-    "slc_files",
-    nargs=-1,
-    required=True,
-)
-@click.option(
-    "-o",
-    "--output-dir",
-    required=True,
-    type=click.Path(writable=True),
-    help="Directory where amplitude dB COG files will be written.",
-)
-@click.option(
-    "--overwrite",
-    is_flag=True,
-    default=False,
-    help="Overwrite existing output files.",
-)
-@click.option(
-    "-m",
-    "--mask",
-    "mask_path",
-    type=click.Path(exists=True, dir_okay=False),
-    default=None,
-    help="Mask GeoTIFF (e.g. combined_mask.tif). Pixels where mask == 0 are set to NaN.",
-)
-@click.option(
-    "-j",
-    "--workers",
-    default=4,
-    show_default=True,
-    help="Number of files to process in parallel.",
-)
-def prepare_amplitude(slc_files, output_dir, overwrite, mask_path, workers):
-    """Convert complex SLC GeoTIFFs to amplitude-in-dB COG files.
-
-    Computes 20·log10(|z|) for each complex pixel and writes a
-    Cloud-Optimised GeoTIFF (float32, DEFLATE, tiled 512×512).
-
-    SLC_FILES: one or more paths to complex GeoTIFF files (e.g. linked_phase/*.slc.tif).
-    Pixels where |z|==0 or outside the mask are written as nodata (NaN).
-    """
-    import numpy as np
-    import rasterio
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    out_dir = Path(output_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    cog_profile = {
-        "driver": "GTiff",
-        "dtype": "float32",
-        "count": 1,
-        "tiled": True,
-        "blockxsize": 512,
-        "blockysize": 512,
-        "compress": "deflate",
-        "predictor": 2,
-        "nodata": float("nan"),
-        "BIGTIFF": "IF_SAFER",
-    }
-
-    # Load mask fully into memory once — avoids repeated disk reads per file/window.
-    mask_arr: "np.ndarray | None" = None
-    if mask_path:
-        with rasterio.open(mask_path) as m:
-            mask_arr = m.read(1)  # shape (H, W), dtype uint8/bool
-        click.echo(f"  mask loaded: {Path(mask_path).name} {mask_arr.shape}")
-
-    def _process_one(slc_path: str) -> str:
-        src_path = Path(slc_path)
-        name = src_path.stem.split(".")[0]
-        out_path = out_dir / f"{name}_amp_db.tif"
-
-        if out_path.exists() and not overwrite:
-            return f"skip  {out_path.name}"
-
-        tmp_path = out_path.with_suffix(".tmp.tif")
-        with rasterio.open(src_path) as src:
-            profile = cog_profile.copy()
-            profile.update(
-                width=src.width,
-                height=src.height,
-                crs=src.crs,
-                transform=src.transform,
-            )
-            with rasterio.open(tmp_path, "w", **profile) as dst:
-                for _, window in src.block_windows(1):
-                    data = src.read(1, window=window)
-                    amp = np.abs(data).astype(np.float32)
-                    with np.errstate(divide="ignore", invalid="ignore"):
-                        db = np.where(amp > 0, 20.0 * np.log10(amp), np.nan)
-                    if mask_arr is not None:
-                        r, c = window.row_off, window.col_off
-                        h, w = window.height, window.width
-                        db = np.where(mask_arr[r:r + h, c:c + w] != 0, db, np.nan)
-                    dst.write(db.astype(np.float32), 1, window=window)
-
-        _make_cog(tmp_path, out_path)
-        tmp_path.unlink(missing_ok=True)
-        return f"done  {out_path.name}"
-
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = {pool.submit(_process_one, p): p for p in slc_files}
-        for fut in as_completed(futures):
-            try:
-                click.echo(f"  {fut.result()}")
-            except Exception as exc:
-                click.echo(f"  ERROR {Path(futures[fut]).name}: {exc}")
-
-
-def _make_cog(src_path: Path, dst_path: Path) -> None:
-    """Add overviews to src_path and copy to dst_path as a COG."""
-    import rasterio
-    from rasterio.enums import Resampling
-    from rasterio.shutil import copy as rio_copy
-
-    overview_levels = [2, 4, 8, 16, 32]
-    with rasterio.open(src_path, "r+") as ds:
-        ds.build_overviews(overview_levels, Resampling.average)
-        ds.update_tags(ns="rio_overview", resampling="average")
-
-    copy_profile = {
-        "driver": "GTiff",
-        "tiled": True,
-        "blockxsize": 512,
-        "blockysize": 512,
-        "compress": "deflate",
-        "predictor": 2,
-        "copy_src_overviews": True,
-        "BIGTIFF": "IF_SAFER",
-    }
-    rio_copy(str(src_path), str(dst_path), **copy_profile)
 
 
 @cli_app.command()

--- a/build/lib/bowser/config.py
+++ b/build/lib/bowser/config.py
@@ -1,0 +1,37 @@
+# import secrets
+from typing import Union
+
+from pydantic import AnyHttpUrl, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Settings for FastAPI app."""
+
+    # Can be overridden by environment variable:
+    BOWSER_DATASET_CONFIG_FILE: str = "bowser_rasters.json"
+    BOWSER_STACK_DATA_FILE: str = ""
+    LOG_LEVEL: str = "WARNING"
+
+    # SECRET_KEY: str = secrets.token_urlsafe(32)
+    # SERVER_NAME: str
+    # SERVER_HOST: AnyHttpUrl
+    # BACKEND_CORS_ORIGINS is a JSON-formatted list of origins
+    # e.g: '["http://localhost", "http://localhost:4200", "http://localhost:3000", \
+    # "http://localhost:8080", "http://local.dockertoolbox.tiangolo.com"]'
+    BACKEND_CORS_ORIGINS: list[AnyHttpUrl] = []
+    DOMAIN: str = "localhost"
+
+    @classmethod
+    @field_validator("BACKEND_CORS_ORIGINS", mode="before")
+    def _assemble_cors_origins(cls, v: Union[str, list[str]]) -> Union[list[str], str]:
+        if isinstance(v, str) and not v.startswith("["):
+            return [i.strip() for i in v.split(",")]
+        elif isinstance(v, (str, list)):
+            return v
+        raise ValueError(v)
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+
+settings = Settings()

--- a/build/lib/bowser/dist/index.css
+++ b/build/lib/bowser/dist/index.css
@@ -659,7 +659,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 		print-color-adjust: exact;
 		}
 	}
-/* ── Design tokens ─────────────────────────────────────────── */
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -668,25 +667,31 @@ svg.leaflet-image-layer.leaflet-interactive path {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  --color-dark: rgb(0, 0, 8);
+  --background-light: #e0dbdb;
+  --border-dark: #2e1111;
+  --border-mid: #464141;
+  --link-color: #646cff;
+  --link-hover-color: #53f2ed;
 
-  /* Sidebar palette */
-  --sb-bg:        #13151f;
-  --sb-surface:   #1c1f2e;
-  --sb-surface2:  #242840;
-  --sb-border:    #2c2f4a;
-  --sb-text:      #dde0f0;
-  --sb-muted:     #7880a8;
-  --sb-accent:    #4d9de0;
-  --sb-accent2:   #6aaee8;
-  --sb-green:     #3ec97a;
-  --sb-red:       #e05d6a;
-
-  color: var(--sb-text);
-  background-color: var(--sb-bg);
+  color: var(--color-dark);
+  background-color: var(--background-light);
 }
 
-a { font-weight: 500; color: var(--sb-accent); text-decoration: none; }
-a:hover { color: var(--sb-accent2); }
+a {
+  font-weight: 500;
+  color: var(--link-color);
+  text-decoration: inherit;
+}
+
+a:hover {
+  color: var(--link-hover-color);
+}
+
+h1 {
+  font-size: 2.2em;
+  line-height: 1.1;
+}
 
 body {
   margin: 0;
@@ -701,308 +706,59 @@ body {
   width: 100vw;
 }
 
-/* ── Layout ─────────────────────────────────────────────────── */
 .app-container {
   display: grid;
   grid-template-areas: "menu map";
-  grid-template-columns: 22em auto;
+  grid-template-columns: 20em auto;
   height: 100vh;
   width: 100vw;
 }
 
-/* ── Sidebar ────────────────────────────────────────────────── */
+
 #menu {
   grid-area: menu;
-  background: var(--sb-bg);
-  border-right: 1px solid var(--sb-border);
+  border: 1px solid var(--border-dark);
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--sb-border) transparent;
+  margin: 1em;
 }
 
-.sidebar-section {
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--sb-border);
+
+.menu-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
 }
 
-.sidebar-section-label {
-  font-size: 0.68em;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--sb-muted);
-  margin-bottom: 2px;
-}
 
-.sidebar-section-label i {
-  margin-right: 5px;
-  opacity: 0.8;
-}
-
-/* ── Form controls ──────────────────────────────────────────── */
-.sidebar-select {
+#menu-content .menu-group>div,
+#menu-content .select-container {
+  /* This ensures that the divs inside the menu group take full width */
   width: 100%;
-  background: var(--sb-surface2);
-  color: var(--sb-text);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 0.85em;
-  cursor: pointer;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%237880a8' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-  padding-right: 28px;
-  transition: border-color 0.15s;
+  /* Space out between menu items a little */
+  margin-bottom: 1em;
 }
 
-.sidebar-select:hover,
-.sidebar-select:focus {
-  border-color: var(--sb-accent);
-  outline: none;
-}
-
-.sidebar-input {
+#menu-content select,
+#menu-content input[type="range"],
+#menu-content input[type="text"] {
   width: 100%;
+  /* This makes sure that all form elements take up the full width available */
   box-sizing: border-box;
-  background: var(--sb-surface2);
-  color: var(--sb-text);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-  padding: 5px 8px;
-  font-size: 0.85em;
+  /* This ensures padding and borders are included in the width */
   text-align: center;
-  transition: border-color 0.15s;
 }
 
-.sidebar-input:focus {
-  outline: none;
-  border-color: var(--sb-accent);
-}
-
-/* Range slider */
-.sidebar-range {
-  width: 100%;
-  accent-color: var(--sb-accent);
-  cursor: pointer;
-  height: 4px;
-  border-radius: 2px;
-}
-
-.slider-group {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.slider-label {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.8em;
-  color: var(--sb-muted);
-}
-
-.slider-value {
-  color: var(--sb-text);
-  font-variant-numeric: tabular-nums;
-  font-size: 0.9em;
+#layer-slider-value {
+  /* Allow text to wrap */
+  /* Break long words if necessary */
   word-break: break-all;
-  max-width: 60%;
-  text-align: right;
+  background: rgb(250, 250, 250);
 }
 
-/* Min/Max row */
-.minmax-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
-}
-
-.minmax-field {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.minmax-label {
-  font-size: 0.72em;
-  color: var(--sb-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-/* Colormap row with invert button */
-.colormap-row {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.colormap-row .sidebar-select {
-  flex: 1;
-}
-
-.invert-btn {
-  flex-shrink: 0;
-  width: 30px;
-  height: 30px;
-  background: var(--sb-surface2);
-  color: var(--sb-muted);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-  font-size: 1em;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.invert-btn:hover {
-  border-color: var(--sb-accent);
-  color: var(--sb-accent);
-}
-
-.invert-btn.active {
-  background: var(--sb-accent);
-  color: white;
-  border-color: var(--sb-accent);
-}
-
-/* Colorbar */
-.colorbar-img {
-  width: 100%;
-  height: auto;
-  border-radius: 4px;
-  display: block;
-}
-
-/* ── Histogram ──────────────────────────────────────────────── */
-.histogram-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.histogram-chart-area {
-  height: 64px;
-  background: var(--sb-surface);
-  border-radius: 6px;
-  overflow: hidden;
-  padding: 2px;
-}
-
-.histogram-range {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.72em;
-  color: var(--sb-muted);
-  padding: 0 2px;
-}
-
-.histogram-buttons {
-  display: flex;
-  gap: 6px;
-}
-
-.hist-btn {
-  flex: 1;
-  background: var(--sb-surface2);
-  color: var(--sb-accent);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-  padding: 5px 6px;
-  font-size: 0.78em;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-
-.hist-btn:hover {
-  background: var(--sb-accent);
-  color: white;
-  border-color: var(--sb-accent);
-}
-
-.histogram-loading {
-  height: 20px;
-  font-size: 0.8em;
-  color: var(--sb-muted);
-  text-align: center;
-}
-
-/* ── Masking section ────────────────────────────────────────── */
-.custom-mask-row {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.custom-mask-controls {
-  display: flex;
-  gap: 6px;
-}
-
-/* ── Toggle pill ────────────────────────────────────────────── */
-.toggle-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.toggle-pill {
-  background: var(--sb-surface2);
-  color: var(--sb-muted);
-  border: 1px solid var(--sb-border);
-  border-radius: 12px;
-  padding: 3px 12px;
-  font-size: 0.75em;
-  font-weight: 700;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-  letter-spacing: 0.05em;
-}
-
-.toggle-pill.active {
-  background: var(--sb-accent);
-  color: white;
-  border-color: var(--sb-accent);
-}
-
-/* ── Sidebar footer ─────────────────────────────────────────── */
-.sidebar-footer {
-  padding: 14px 16px;
-  margin-top: auto;
-  border-top: 1px solid var(--sb-border);
-}
-
-.chart-toggle-btn {
-  width: 100%;
-  background: var(--sb-accent);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  padding: 9px 14px;
-  font-size: 0.88em;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-}
-
-.chart-toggle-btn:hover {
-  background: var(--sb-accent2);
-}
-
-/* ── Map ────────────────────────────────────────────────────── */
+/* ********** */
+/* Map styles */
 .map-container {
   grid-area: map;
   position: relative;
@@ -1015,69 +771,50 @@ body {
   height: 100%;
 }
 
-img.huechange { filter: hue-rotate(120deg); }
+/* https://stackoverflow.com/questions/23567203/leaflet-changing-marker-color */
+img.huechange {
+  filter: hue-rotate(120deg);
+}
 
-/* ── Time Series Chart ──────────────────────────────────────── */
+/* chart styles */
 #chart-container {
-  width: 38vw;
-  max-width: 560px;
-  min-width: 320px;
-  height: 420px;
+  width: 35vw;
+  max-width: 500px;
+  height: 400px;
+  /* Make the chart fixed to the bottom right corner of the screen */
   position: fixed;
   bottom: 20px;
   right: 20px;
-  padding: 14px;
-  background: rgba(19, 21, 31, 0.95);
-  backdrop-filter: blur(8px);
+  /* But also give it some padding */
+  padding: 1rem;
+  /* Make the chart have a white background */
+  background-color: white;
+  /* Have it on top of the leaflet map but below point manager */
   z-index: 3000;
-  border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-  border: 1px solid var(--sb-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
-  color: var(--sb-text);
 }
 
 .chart-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 10px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--sb-border);
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #eee;
 }
 
 .chart-header h4 {
   margin: 0;
-  font-size: 0.95em;
+  font-size: 1.1em;
   font-weight: 600;
-  color: var(--sb-text);
-  letter-spacing: 0.02em;
 }
 
 .chart-controls {
   display: flex;
-  gap: 6px;
-}
-
-.chart-btn {
-  background: var(--sb-surface2);
-  color: var(--sb-accent);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-  padding: 4px 10px;
-  font-size: 0.78em;
-  cursor: pointer;
-  transition: background 0.15s;
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.chart-btn:hover {
-  background: var(--sb-accent);
-  color: white;
-  border-color: var(--sb-accent);
+  gap: 8px;
 }
 
 .chart-content {
@@ -1092,31 +829,28 @@ img.huechange { filter: hue-rotate(120deg); }
   justify-content: center;
   align-items: center;
   height: 300px;
-  color: var(--sb-muted);
+  color: #666;
   text-align: center;
-  gap: 6px;
 }
 
 .chart-help {
-  margin-top: 6px;
-  padding-top: 6px;
-  border-top: 1px solid var(--sb-border);
-  color: var(--sb-muted);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #eee;
+  color: #666;
   text-align: center;
-  font-size: 0.75em;
 }
 
-/* ── Mouse position control ─────────────────────────────────── */
 .leaflet-control-mouseposition {
-  background-color: rgba(19, 21, 31, 0.8);
-  box-shadow: 0 0 5px rgba(0,0,0,0.4);
-  padding: 2px 6px;
-  color: var(--sb-text);
-  font: 11px/1.5 "Inter", "Helvetica Neue", Arial, sans-serif;
-  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 0 5px #bbb;
+  padding: 0 5px;
+  margin: 0;
+  color: #333;
+  font: 11px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
 }
 
-/* ── Point Manager Panel ────────────────────────────────────── */
+/* Point Manager Panel Styles */
 .point-manager-toggle {
   position: fixed;
   top: 20px;
@@ -1130,15 +864,14 @@ img.huechange { filter: hue-rotate(120deg); }
   right: 20px;
   width: 300px;
   max-height: 60vh;
-  background: rgba(255, 255, 255, 0.97);
-  border: 1px solid var(--sb-border);
-  border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  background-color: white;
+  border: 1px solid var(--border-dark);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   z-index: 4000;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  color: var(--sb-text);
 }
 
 .point-manager-header {
@@ -1146,71 +879,72 @@ img.huechange { filter: hue-rotate(120deg); }
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  background: var(--sb-surface);
-  border-bottom: 1px solid var(--sb-border);
+  background-color: #f5f5f5;
+  border-bottom: 1px solid var(--border-mid);
 }
 
 .point-manager-header h3 {
   margin: 0;
-  font-size: 0.9em;
+  font-size: 1em;
   font-weight: 600;
 }
 
 .point-manager-controls {
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--sb-border);
+  padding: 12px 16px;
+  border-bottom: 1px solid #eee;
   display: flex;
-  gap: 6px;
+  gap: 8px;
 }
 
 .point-list {
   flex: 1;
   overflow-y: auto;
   max-height: 400px;
-  scrollbar-width: thin;
-  scrollbar-color: var(--sb-border) transparent;
 }
 
 .no-points {
   padding: 20px;
   text-align: center;
-  color: var(--sb-muted);
+  color: #666;
 }
 
 .point-item {
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--sb-border);
+  padding: 12px 16px;
+  border-bottom: 1px solid #eee;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background-color 0.2s;
 }
 
-.point-item:hover { background: var(--sb-surface); }
+.point-item:hover {
+  background-color: #f8f9fa;
+}
+
 .point-item.selected {
-  background: rgba(77, 157, 224, 0.12);
-  border-left: 3px solid var(--sb-accent);
+  background-color: #e3f2fd;
+  border-left: 4px solid #2196f3;
 }
 
 .point-item-header {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 
 .point-color-indicator {
-  width: 11px;
-  height: 11px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  border: 2px solid rgba(255,255,255,0.3);
+  border: 2px solid white;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
   flex-shrink: 0;
 }
 
 .point-name-input {
   border: none;
   background: transparent;
-  color: var(--sb-text);
   font-weight: 500;
-  font-size: 0.88em;
+  font-size: 0.9em;
   padding: 2px 4px;
   border-radius: 3px;
   flex: 1;
@@ -1218,18 +952,22 @@ img.huechange { filter: hue-rotate(120deg); }
 
 .point-name-input:focus {
   outline: none;
-  background: var(--sb-surface2);
-  border: 1px solid var(--sb-border);
+  background-color: white;
+  border: 1px solid #ccc;
+}
+
+.point-item-info {
+  margin-bottom: 8px;
 }
 
 .point-coordinates {
-  color: var(--sb-muted);
-  font-size: 0.78em;
+  color: #666;
+  font-size: 0.8em;
 }
 
 .point-trend-info {
-  color: var(--sb-accent);
-  font-size: 0.78em;
+  color: #2196f3;
+  font-size: 0.8em;
   font-weight: 500;
 }
 
@@ -1237,119 +975,44 @@ img.huechange { filter: hue-rotate(120deg); }
   display: flex;
   gap: 4px;
   justify-content: flex-end;
-  margin-top: 4px;
 }
 
 .point-item-controls button {
-  padding: 3px 8px;
-  font-size: 0.76em;
-  background: var(--sb-surface2);
-  color: var(--sb-muted);
-  border: 1px solid var(--sb-border);
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.point-item-controls button:hover {
-  background: var(--sb-surface);
-  color: var(--sb-text);
+  padding: 4px 8px;
+  font-size: 0.8em;
+  min-width: auto;
 }
 
 .point-manager-help {
-  padding: 10px 14px;
-  background: var(--sb-surface);
-  border-top: 1px solid var(--sb-border);
-  color: var(--sb-muted);
-  font-size: 0.76em;
-  line-height: 1.5;
+  padding: 12px 16px;
+  background-color: #f8f9fa;
+  border-top: 1px solid #eee;
+  color: #666;
+  font-size: 0.8em;
+  line-height: 1.4;
 }
 
-/* ── Custom marker ──────────────────────────────────────────── */
+/* Custom colored marker styles */
 .custom-colored-marker {
   background: transparent !important;
   border: none !important;
 }
 
-/* ── Utility ────────────────────────────────────────────────── */
-.button-warning { background: var(--sb-green); color: #fff; border: none; border-radius: 5px; }
-.button-error   { background: var(--sb-red);   color: #fff; border: none; border-radius: 5px; }
-
-/* Override Pure CSS defaults for dark theme */
-.pure-button {
-  background: var(--sb-surface2);
-  color: var(--sb-accent);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-}
-
-.pure-button:hover {
-  background: var(--sb-accent);
+/* Button utility classes */
+.button-warning {
+  background-color: #ff9800;
   color: white;
 }
 
-.pure-button-primary {
-  background: var(--sb-accent);
+.button-warning:hover {
+  background-color: #f57c00;
+}
+
+.button-error {
+  background-color: #f44336;
   color: white;
-  border-color: var(--sb-accent);
 }
 
-.pure-button-primary:hover {
-  background: var(--sb-accent2);
-}
-
-/* ── Map toolbar ────────────────────────────────────────────── */
-.map-toolbar {
-  position: absolute;
-  top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 2000;
-  display: flex;
-  gap: 6px;
-  background: rgba(19, 21, 31, 0.9);
-  border: 1px solid var(--sb-border);
-  border-radius: 8px;
-  padding: 6px 8px;
-  backdrop-filter: blur(6px);
-}
-
-.map-tool-btn {
-  background: var(--sb-surface2);
-  color: var(--sb-muted);
-  border: 1px solid var(--sb-border);
-  border-radius: 6px;
-  width: 32px;
-  height: 32px;
-  font-size: 0.9em;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s, color 0.15s;
-}
-
-.map-tool-btn:hover,
-.map-tool-btn.active {
-  background: var(--sb-accent);
-  color: white;
-  border-color: var(--sb-accent);
-}
-
-/* ── Profile panel ──────────────────────────────────────────── */
-.profile-panel {
-  position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 500px;
-  max-width: 90vw;
-  background: rgba(19, 21, 31, 0.95);
-  border: 1px solid var(--sb-border);
-  border-radius: 12px;
-  padding: 12px 14px;
-  z-index: 3500;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
-  backdrop-filter: blur(8px);
-  color: var(--sb-text);
+.button-error:hover {
+  background-color: #d32f2f;
 }

--- a/build/lib/bowser/dist/index.html
+++ b/build/lib/bowser/dist/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <!-- pure css -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css"
+    integrity="sha384-X38yfunGUhNzHpBaEBsWLO+A0HDYOQi8ufWDkZ0k9e0eXz/tH3II7uKZ9msv++Ls" crossorigin="anonymous">
+  <!-- font awesome-->
+  <script src="https://kit.fontawesome.com/acadc5aab9.js" crossorigin="anonymous"></script>
+
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+
+  <title>Bowser</title>
+  <script type="module" crossorigin src="./index.js"></script>
+  <link rel="stylesheet" crossorigin href="./index.css">
+</head>
+
+<body>
+  <div id="root"></div>
+</body>
+
+</html>

--- a/build/lib/bowser/dist/index.js
+++ b/build/lib/bowser/dist/index.js
@@ -7042,21 +7042,7 @@ const initialState = {
   opacity: 1,
   showChart: false,
   selectedPointId: null,
-  showTrends: false,
-  showResiduals: false,
-  coherenceThreshold: 0,
-  phaseSimilarityThreshold: 0,
-  customMaskPath: null,
-  bufferEnabled: false,
-  bufferRadius: 500,
-  bufferSamples: 10,
-  invResidThreshold: 0,
-  pickingEnabled: true,
-  refEnabled: true,
-  showProfile: false,
-  refBufferEnabled: false,
-  refBufferRadius: 500,
-  showRefChart: false
+  showTrends: false
 };
 function appReducer(state, action) {
   switch (action.type) {
@@ -7178,34 +7164,6 @@ function appReducer(state, action) {
       return { ...state, vmax: action.payload };
     case "SET_OPACITY":
       return { ...state, opacity: action.payload };
-    case "TOGGLE_RESIDUALS":
-      return { ...state, showResiduals: !state.showResiduals };
-    case "SET_COHERENCE_THRESHOLD":
-      return { ...state, coherenceThreshold: action.payload };
-    case "SET_PHASE_SIMILARITY_THRESHOLD":
-      return { ...state, phaseSimilarityThreshold: action.payload };
-    case "SET_CUSTOM_MASK_PATH":
-      return { ...state, customMaskPath: action.payload };
-    case "TOGGLE_BUFFER":
-      return { ...state, bufferEnabled: !state.bufferEnabled };
-    case "SET_BUFFER_RADIUS":
-      return { ...state, bufferRadius: action.payload };
-    case "SET_BUFFER_SAMPLES":
-      return { ...state, bufferSamples: action.payload };
-    case "SET_INV_RESID_THRESHOLD":
-      return { ...state, invResidThreshold: action.payload };
-    case "TOGGLE_PICKING":
-      return { ...state, pickingEnabled: !state.pickingEnabled };
-    case "TOGGLE_REF_ENABLED":
-      return { ...state, refEnabled: !state.refEnabled };
-    case "TOGGLE_PROFILE":
-      return { ...state, showProfile: !state.showProfile };
-    case "TOGGLE_REF_BUFFER":
-      return { ...state, refBufferEnabled: !state.refBufferEnabled };
-    case "SET_REF_BUFFER_RADIUS":
-      return { ...state, refBufferRadius: action.payload };
-    case "TOGGLE_REF_CHART":
-      return { ...state, showRefChart: !state.showRefChart };
     case "TOGGLE_CHART":
       return { ...state, showChart: !state.showChart };
     default:
@@ -7267,17 +7225,13 @@ function useApi() {
       return void 0;
     }
   }, []);
-  const fetchMultiPointTimeSeries = reactExports.useCallback(async (points, datasetName, refLon, refLat, calculateTrends = false, coherenceMin = 0, phaseSimilarityMin = 0, invResidMax = 0, refBufferM = 0) => {
+  const fetchMultiPointTimeSeries = reactExports.useCallback(async (points, datasetName, refLon, refLat, calculateTrends = false) => {
     const payload = {
       points,
       dataset_name: datasetName,
       ref_lon: refLon,
       ref_lat: refLat,
-      calculate_trends: calculateTrends,
-      coherence_min: coherenceMin,
-      phase_similarity_min: phaseSimilarityMin,
-      inv_resid_max: invResidMax,
-      ref_buffer_m: refBufferM
+      calculate_trends: calculateTrends
     };
     try {
       const response = await fetch("/multi_point", {
@@ -7320,32 +7274,6 @@ function useApi() {
       return void 0;
     }
   }, []);
-  const fetchBufferTimeSeries = reactExports.useCallback(async (lon, lat, datasetName, bufferM, nSamples, refLon, refLat, coherenceMin = 0, phaseSimilarityMin = 0, invResidMax = 0, refBufferM = 0) => {
-    try {
-      const response = await fetch("/buffer_timeseries", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          lon,
-          lat,
-          dataset_name: datasetName,
-          buffer_m: bufferM,
-          n_samples: nSamples,
-          ref_lon: refLon ?? null,
-          ref_lat: refLat ?? null,
-          coherence_min: coherenceMin,
-          phase_similarity_min: phaseSimilarityMin,
-          inv_resid_max: invResidMax,
-          ref_buffer_m: refBufferM
-        })
-      });
-      if (!response.ok) return void 0;
-      return await response.json();
-    } catch (error) {
-      console.error("Error fetching buffer time series:", error);
-      return void 0;
-    }
-  }, []);
   return {
     fetchDatasets,
     fetchDataMode,
@@ -7353,8 +7281,7 @@ function useApi() {
     fetchChartTimeSeries,
     fetchMultiPointTimeSeries,
     fetchTrendAnalysis,
-    fetchTimeBounds,
-    fetchBufferTimeSeries
+    fetchTimeBounds
   };
 }
 function useAttribution(map2, attribution) {
@@ -17235,25 +17162,49 @@ L$1.control.mousePosition = function(options) {
   return new MousePositionControl(options);
 };
 L$1.control.mousePosition;
-function MeasureTool({ active, onDeactivate }) {
+delete L$1.Icon.Default.prototype._getIconUrl;
+L$1.Icon.Default.mergeOptions({
+  iconRetinaUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png",
+  iconUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png",
+  shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png"
+});
+const fontAwesomeIcon = L$1.divIcon({
+  html: '<i class="fa-solid fa-location-dot fa-3x"></i>',
+  iconSize: [20, 20],
+  className: "myDivIcon"
+});
+function MapEvents() {
+  const { dispatch } = useAppContext();
+  useMapEvents({
+    click: (e) => {
+      dispatch({
+        type: "ADD_TIME_SERIES_POINT",
+        payload: {
+          position: [e.latlng.lat, e.latlng.lng],
+          name: `Point ${Date.now().toString().slice(-4)}`
+          // Short unique name
+        }
+      });
+    }
+  });
+  return null;
+}
+function MousePosition() {
   const map2 = useMap();
-  const pointsRef = reactExports.useRef([]);
-  const linesRef = reactExports.useRef([]);
-  const markersRef = reactExports.useRef([]);
-  const labelRef = reactExports.useRef(null);
-  const fmtDist = (m2) => m2 >= 1e3 ? `${(m2 / 1e3).toFixed(2)} km` : `${m2.toFixed(0)} m`;
-  const clearAll = () => {
-    linesRef.current.forEach((l2) => l2.remove());
-    markersRef.current.forEach((m2) => m2.remove());
-    if (labelRef.current) labelRef.current.remove();
-    pointsRef.current = [];
-    linesRef.current = [];
-    markersRef.current = [];
-    labelRef.current = null;
-  };
   reactExports.useEffect(() => {
-    if (!active) {
-      clearAll();
+    const mousePositionControl = new MousePositionControl();
+    mousePositionControl.addTo(map2);
+    return () => {
+      mousePositionControl.remove();
+    };
+  }, [map2]);
+  return null;
+}
+function RasterTileLayer() {
+  const { state } = useAppContext();
+  const [tileUrl, setTileUrl] = reactExports.useState(null);
+  reactExports.useEffect(() => {
+    if (!state.currentDataset || !state.datasetInfo[state.currentDataset]) {
       return;
     }
     const controller = new AbortController();
@@ -17495,7 +17446,7 @@ function ControlPanel() {
     localStorage.setItem(`${datasetName}-colormap_name`, state.colormap);
     localStorage.setItem(`${datasetName}-vmin`, safeNumToString(state.vmin));
     localStorage.setItem(`${datasetName}-vmax`, safeNumToString(state.vmax));
-  }, [state.colormap, state.vmin, state.vmax]);
+  }, [state.currentDataset, state.colormap, state.vmin, state.vmax]);
   reactExports.useEffect(() => {
     const datasetName = state.currentDataset;
     if (!datasetName) return;
@@ -21743,481 +21694,6 @@ class DatasetController {
 __publicField(DatasetController, "defaults", {});
 __publicField(DatasetController, "datasetElementType", null);
 __publicField(DatasetController, "dataElementType", null);
-function getAllScaleValues(scale, type) {
-  if (!scale._cache.$bar) {
-    const visibleMetas = scale.getMatchingVisibleMetas(type);
-    let values = [];
-    for (let i = 0, ilen = visibleMetas.length; i < ilen; i++) {
-      values = values.concat(visibleMetas[i].controller.getAllParsedValues(scale));
-    }
-    scale._cache.$bar = _arrayUnique(values.sort((a, b) => a - b));
-  }
-  return scale._cache.$bar;
-}
-function computeMinSampleSize(meta) {
-  const scale = meta.iScale;
-  const values = getAllScaleValues(scale, meta.type);
-  let min = scale._length;
-  let i, ilen, curr, prev;
-  const updateMinAndPrev = () => {
-    if (curr === 32767 || curr === -32768) {
-      return;
-    }
-    if (defined(prev)) {
-      min = Math.min(min, Math.abs(curr - prev) || min);
-    }
-    prev = curr;
-  };
-  for (i = 0, ilen = values.length; i < ilen; ++i) {
-    curr = scale.getPixelForValue(values[i]);
-    updateMinAndPrev();
-  }
-  prev = void 0;
-  for (i = 0, ilen = scale.ticks.length; i < ilen; ++i) {
-    curr = scale.getPixelForTick(i);
-    updateMinAndPrev();
-  }
-  return min;
-}
-function computeFitCategoryTraits(index, ruler, options, stackCount) {
-  const thickness = options.barThickness;
-  let size, ratio;
-  if (isNullOrUndef(thickness)) {
-    size = ruler.min * options.categoryPercentage;
-    ratio = options.barPercentage;
-  } else {
-    size = thickness * stackCount;
-    ratio = 1;
-  }
-  return {
-    chunk: size / stackCount,
-    ratio,
-    start: ruler.pixels[index] - size / 2
-  };
-}
-function computeFlexCategoryTraits(index, ruler, options, stackCount) {
-  const pixels = ruler.pixels;
-  const curr = pixels[index];
-  let prev = index > 0 ? pixels[index - 1] : null;
-  let next = index < pixels.length - 1 ? pixels[index + 1] : null;
-  const percent = options.categoryPercentage;
-  if (prev === null) {
-    prev = curr - (next === null ? ruler.end - ruler.start : next - curr);
-  }
-  if (next === null) {
-    next = curr + curr - prev;
-  }
-  const start = curr - (curr - Math.min(prev, next)) / 2 * percent;
-  const size = Math.abs(next - prev) / 2 * percent;
-  return {
-    chunk: size / stackCount,
-    ratio: options.barPercentage,
-    start
-  };
-}
-function parseFloatBar(entry, item, vScale, i) {
-  const startValue = vScale.parse(entry[0], i);
-  const endValue = vScale.parse(entry[1], i);
-  const min = Math.min(startValue, endValue);
-  const max = Math.max(startValue, endValue);
-  let barStart = min;
-  let barEnd = max;
-  if (Math.abs(min) > Math.abs(max)) {
-    barStart = max;
-    barEnd = min;
-  }
-  item[vScale.axis] = barEnd;
-  item._custom = {
-    barStart,
-    barEnd,
-    start: startValue,
-    end: endValue,
-    min,
-    max
-  };
-}
-function parseValue(entry, item, vScale, i) {
-  if (isArray(entry)) {
-    parseFloatBar(entry, item, vScale, i);
-  } else {
-    item[vScale.axis] = vScale.parse(entry, i);
-  }
-  return item;
-}
-function parseArrayOrPrimitive(meta, data, start, count) {
-  const iScale = meta.iScale;
-  const vScale = meta.vScale;
-  const labels = iScale.getLabels();
-  const singleScale = iScale === vScale;
-  const parsed = [];
-  let i, ilen, item, entry;
-  for (i = start, ilen = start + count; i < ilen; ++i) {
-    entry = data[i];
-    item = {};
-    item[iScale.axis] = singleScale || iScale.parse(labels[i], i);
-    parsed.push(parseValue(entry, item, vScale, i));
-  }
-  return parsed;
-}
-function isFloatBar(custom) {
-  return custom && custom.barStart !== void 0 && custom.barEnd !== void 0;
-}
-function barSign(size, vScale, actualBase) {
-  if (size !== 0) {
-    return sign(size);
-  }
-  return (vScale.isHorizontal() ? 1 : -1) * (vScale.min >= actualBase ? 1 : -1);
-}
-function borderProps(properties) {
-  let reverse, start, end, top, bottom;
-  if (properties.horizontal) {
-    reverse = properties.base > properties.x;
-    start = "left";
-    end = "right";
-  } else {
-    reverse = properties.base < properties.y;
-    start = "bottom";
-    end = "top";
-  }
-  if (reverse) {
-    top = "end";
-    bottom = "start";
-  } else {
-    top = "start";
-    bottom = "end";
-  }
-  return {
-    start,
-    end,
-    reverse,
-    top,
-    bottom
-  };
-}
-function setBorderSkipped(properties, options, stack, index) {
-  let edge = options.borderSkipped;
-  const res = {};
-  if (!edge) {
-    properties.borderSkipped = res;
-    return;
-  }
-  if (edge === true) {
-    properties.borderSkipped = {
-      top: true,
-      right: true,
-      bottom: true,
-      left: true
-    };
-    return;
-  }
-  const { start, end, reverse, top, bottom } = borderProps(properties);
-  if (edge === "middle" && stack) {
-    properties.enableBorderRadius = true;
-    if ((stack._top || 0) === index) {
-      edge = top;
-    } else if ((stack._bottom || 0) === index) {
-      edge = bottom;
-    } else {
-      res[parseEdge(bottom, start, end, reverse)] = true;
-      edge = top;
-    }
-  }
-  res[parseEdge(edge, start, end, reverse)] = true;
-  properties.borderSkipped = res;
-}
-function parseEdge(edge, a, b, reverse) {
-  if (reverse) {
-    edge = swap(edge, a, b);
-    edge = startEnd(edge, b, a);
-  } else {
-    edge = startEnd(edge, a, b);
-  }
-  return edge;
-}
-function swap(orig, v1, v2) {
-  return orig === v1 ? v2 : orig === v2 ? v1 : orig;
-}
-function startEnd(v2, start, end) {
-  return v2 === "start" ? start : v2 === "end" ? end : v2;
-}
-function setInflateAmount(properties, { inflateAmount }, ratio) {
-  properties.inflateAmount = inflateAmount === "auto" ? ratio === 1 ? 0.33 : 0 : inflateAmount;
-}
-class BarController extends DatasetController {
-  parsePrimitiveData(meta, data, start, count) {
-    return parseArrayOrPrimitive(meta, data, start, count);
-  }
-  parseArrayData(meta, data, start, count) {
-    return parseArrayOrPrimitive(meta, data, start, count);
-  }
-  parseObjectData(meta, data, start, count) {
-    const { iScale, vScale } = meta;
-    const { xAxisKey = "x", yAxisKey = "y" } = this._parsing;
-    const iAxisKey = iScale.axis === "x" ? xAxisKey : yAxisKey;
-    const vAxisKey = vScale.axis === "x" ? xAxisKey : yAxisKey;
-    const parsed = [];
-    let i, ilen, item, obj;
-    for (i = start, ilen = start + count; i < ilen; ++i) {
-      obj = data[i];
-      item = {};
-      item[iScale.axis] = iScale.parse(resolveObjectKey(obj, iAxisKey), i);
-      parsed.push(parseValue(resolveObjectKey(obj, vAxisKey), item, vScale, i));
-    }
-    return parsed;
-  }
-  updateRangeFromParsed(range, scale, parsed, stack) {
-    super.updateRangeFromParsed(range, scale, parsed, stack);
-    const custom = parsed._custom;
-    if (custom && scale === this._cachedMeta.vScale) {
-      range.min = Math.min(range.min, custom.min);
-      range.max = Math.max(range.max, custom.max);
-    }
-  }
-  getMaxOverflow() {
-    return 0;
-  }
-  getLabelAndValue(index) {
-    const meta = this._cachedMeta;
-    const { iScale, vScale } = meta;
-    const parsed = this.getParsed(index);
-    const custom = parsed._custom;
-    const value = isFloatBar(custom) ? "[" + custom.start + ", " + custom.end + "]" : "" + vScale.getLabelForValue(parsed[vScale.axis]);
-    return {
-      label: "" + iScale.getLabelForValue(parsed[iScale.axis]),
-      value
-    };
-  }
-  initialize() {
-    this.enableOptionSharing = true;
-    super.initialize();
-    const meta = this._cachedMeta;
-    meta.stack = this.getDataset().stack;
-  }
-  update(mode) {
-    const meta = this._cachedMeta;
-    this.updateElements(meta.data, 0, meta.data.length, mode);
-  }
-  updateElements(bars, start, count, mode) {
-    const reset = mode === "reset";
-    const { index, _cachedMeta: { vScale } } = this;
-    const base = vScale.getBasePixel();
-    const horizontal = vScale.isHorizontal();
-    const ruler = this._getRuler();
-    const { sharedOptions, includeOptions } = this._getSharedOptions(start, mode);
-    for (let i = start; i < start + count; i++) {
-      const parsed = this.getParsed(i);
-      const vpixels = reset || isNullOrUndef(parsed[vScale.axis]) ? {
-        base,
-        head: base
-      } : this._calculateBarValuePixels(i);
-      const ipixels = this._calculateBarIndexPixels(i, ruler);
-      const stack = (parsed._stacks || {})[vScale.axis];
-      const properties = {
-        horizontal,
-        base: vpixels.base,
-        enableBorderRadius: !stack || isFloatBar(parsed._custom) || index === stack._top || index === stack._bottom,
-        x: horizontal ? vpixels.head : ipixels.center,
-        y: horizontal ? ipixels.center : vpixels.head,
-        height: horizontal ? ipixels.size : Math.abs(vpixels.size),
-        width: horizontal ? Math.abs(vpixels.size) : ipixels.size
-      };
-      if (includeOptions) {
-        properties.options = sharedOptions || this.resolveDataElementOptions(i, bars[i].active ? "active" : mode);
-      }
-      const options = properties.options || bars[i].options;
-      setBorderSkipped(properties, options, stack, index);
-      setInflateAmount(properties, options, ruler.ratio);
-      this.updateElement(bars[i], i, properties, mode);
-    }
-  }
-  _getStacks(last, dataIndex) {
-    const { iScale } = this._cachedMeta;
-    const metasets = iScale.getMatchingVisibleMetas(this._type).filter((meta) => meta.controller.options.grouped);
-    const stacked = iScale.options.stacked;
-    const stacks = [];
-    const currentParsed = this._cachedMeta.controller.getParsed(dataIndex);
-    const iScaleValue = currentParsed && currentParsed[iScale.axis];
-    const skipNull = (meta) => {
-      const parsed = meta._parsed.find((item) => item[iScale.axis] === iScaleValue);
-      const val = parsed && parsed[meta.vScale.axis];
-      if (isNullOrUndef(val) || isNaN(val)) {
-        return true;
-      }
-    };
-    for (const meta of metasets) {
-      if (dataIndex !== void 0 && skipNull(meta)) {
-        continue;
-      }
-      if (stacked === false || stacks.indexOf(meta.stack) === -1 || stacked === void 0 && meta.stack === void 0) {
-        stacks.push(meta.stack);
-      }
-      if (meta.index === last) {
-        break;
-      }
-    }
-    if (!stacks.length) {
-      stacks.push(void 0);
-    }
-    return stacks;
-  }
-  _getStackCount(index) {
-    return this._getStacks(void 0, index).length;
-  }
-  _getStackIndex(datasetIndex, name, dataIndex) {
-    const stacks = this._getStacks(datasetIndex, dataIndex);
-    const index = name !== void 0 ? stacks.indexOf(name) : -1;
-    return index === -1 ? stacks.length - 1 : index;
-  }
-  _getRuler() {
-    const opts = this.options;
-    const meta = this._cachedMeta;
-    const iScale = meta.iScale;
-    const pixels = [];
-    let i, ilen;
-    for (i = 0, ilen = meta.data.length; i < ilen; ++i) {
-      pixels.push(iScale.getPixelForValue(this.getParsed(i)[iScale.axis], i));
-    }
-    const barThickness = opts.barThickness;
-    const min = barThickness || computeMinSampleSize(meta);
-    return {
-      min,
-      pixels,
-      start: iScale._startPixel,
-      end: iScale._endPixel,
-      stackCount: this._getStackCount(),
-      scale: iScale,
-      grouped: opts.grouped,
-      ratio: barThickness ? 1 : opts.categoryPercentage * opts.barPercentage
-    };
-  }
-  _calculateBarValuePixels(index) {
-    const { _cachedMeta: { vScale, _stacked, index: datasetIndex }, options: { base: baseValue, minBarLength } } = this;
-    const actualBase = baseValue || 0;
-    const parsed = this.getParsed(index);
-    const custom = parsed._custom;
-    const floating = isFloatBar(custom);
-    let value = parsed[vScale.axis];
-    let start = 0;
-    let length = _stacked ? this.applyStack(vScale, parsed, _stacked) : value;
-    let head, size;
-    if (length !== value) {
-      start = length - value;
-      length = value;
-    }
-    if (floating) {
-      value = custom.barStart;
-      length = custom.barEnd - custom.barStart;
-      if (value !== 0 && sign(value) !== sign(custom.barEnd)) {
-        start = 0;
-      }
-      start += value;
-    }
-    const startValue = !isNullOrUndef(baseValue) && !floating ? baseValue : start;
-    let base = vScale.getPixelForValue(startValue);
-    if (this.chart.getDataVisibility(index)) {
-      head = vScale.getPixelForValue(start + length);
-    } else {
-      head = base;
-    }
-    size = head - base;
-    if (Math.abs(size) < minBarLength) {
-      size = barSign(size, vScale, actualBase) * minBarLength;
-      if (value === actualBase) {
-        base -= size / 2;
-      }
-      const startPixel = vScale.getPixelForDecimal(0);
-      const endPixel = vScale.getPixelForDecimal(1);
-      const min = Math.min(startPixel, endPixel);
-      const max = Math.max(startPixel, endPixel);
-      base = Math.max(Math.min(base, max), min);
-      head = base + size;
-      if (_stacked && !floating) {
-        parsed._stacks[vScale.axis]._visualValues[datasetIndex] = vScale.getValueForPixel(head) - vScale.getValueForPixel(base);
-      }
-    }
-    if (base === vScale.getPixelForValue(actualBase)) {
-      const halfGrid = sign(size) * vScale.getLineWidthForValue(actualBase) / 2;
-      base += halfGrid;
-      size -= halfGrid;
-    }
-    return {
-      size,
-      base,
-      head,
-      center: head + size / 2
-    };
-  }
-  _calculateBarIndexPixels(index, ruler) {
-    const scale = ruler.scale;
-    const options = this.options;
-    const skipNull = options.skipNull;
-    const maxBarThickness = valueOrDefault(options.maxBarThickness, Infinity);
-    let center, size;
-    if (ruler.grouped) {
-      const stackCount = skipNull ? this._getStackCount(index) : ruler.stackCount;
-      const range = options.barThickness === "flex" ? computeFlexCategoryTraits(index, ruler, options, stackCount) : computeFitCategoryTraits(index, ruler, options, stackCount);
-      const stackIndex = this._getStackIndex(this.index, this._cachedMeta.stack, skipNull ? index : void 0);
-      center = range.start + range.chunk * stackIndex + range.chunk / 2;
-      size = Math.min(maxBarThickness, range.chunk * range.ratio);
-    } else {
-      center = scale.getPixelForValue(this.getParsed(index)[scale.axis], index);
-      size = Math.min(maxBarThickness, ruler.min * ruler.ratio);
-    }
-    return {
-      base: center - size / 2,
-      head: center + size / 2,
-      center,
-      size
-    };
-  }
-  draw() {
-    const meta = this._cachedMeta;
-    const vScale = meta.vScale;
-    const rects = meta.data;
-    const ilen = rects.length;
-    let i = 0;
-    for (; i < ilen; ++i) {
-      if (this.getParsed(i)[vScale.axis] !== null && !rects[i].hidden) {
-        rects[i].draw(this._ctx);
-      }
-    }
-  }
-}
-__publicField(BarController, "id", "bar");
-__publicField(BarController, "defaults", {
-  datasetElementType: false,
-  dataElementType: "bar",
-  categoryPercentage: 0.8,
-  barPercentage: 0.9,
-  grouped: true,
-  animations: {
-    numbers: {
-      type: "number",
-      properties: [
-        "x",
-        "y",
-        "base",
-        "width",
-        "height"
-      ]
-    }
-  }
-});
-__publicField(BarController, "overrides", {
-  scales: {
-    _index_: {
-      type: "category",
-      offset: true,
-      grid: {
-        offset: true
-      }
-    },
-    _value_: {
-      type: "linear",
-      beginAtZero: true
-    }
-  }
-});
 class LineController extends DatasetController {
   initialize() {
     this.enableOptionSharing = true;
@@ -22477,13 +21953,13 @@ function getNearestCartesianItems(chart, position, axis, intersect, useFinalPosi
   const distanceMetric = getDistanceMetricForAxis(axis);
   let minDistance = Number.POSITIVE_INFINITY;
   function evaluationFunc(element, datasetIndex, index) {
-    const inRange2 = element.inRange(position.x, position.y, useFinalPosition);
-    if (intersect && !inRange2) {
+    const inRange = element.inRange(position.x, position.y, useFinalPosition);
+    if (intersect && !inRange) {
       return;
     }
     const center = element.getCenterPoint(useFinalPosition);
     const pointInArea = !!includeInvisible || chart.isPointInArea(center);
-    if (!pointInArea && !inRange2) {
+    if (!pointInArea && !inRange) {
       return;
     }
     const distance = distanceMetric(position, center);
@@ -23380,11 +22856,11 @@ function sample(arr, numItems) {
 }
 function getPixelForGridLine(scale, index, offsetGridLines) {
   const length = scale.ticks.length;
-  const validIndex2 = Math.min(index, length - 1);
+  const validIndex = Math.min(index, length - 1);
   const start = scale._startPixel;
   const end = scale._endPixel;
   const epsilon = 1e-6;
-  let lineValue = scale.getPixelForTick(validIndex2);
+  let lineValue = scale.getPixelForTick(validIndex);
   let offset;
   if (offsetGridLines) {
     if (length === 1) {
@@ -23392,9 +22868,9 @@ function getPixelForGridLine(scale, index, offsetGridLines) {
     } else if (index === 0) {
       offset = (scale.getPixelForTick(1) - lineValue) / 2;
     } else {
-      offset = (lineValue - scale.getPixelForTick(validIndex2 - 1)) / 2;
+      offset = (lineValue - scale.getPixelForTick(validIndex - 1)) / 2;
     }
-    lineValue += validIndex2 < index ? offset : -offset;
+    lineValue += validIndex < index ? offset : -offset;
     if (lineValue < start - epsilon || lineValue > end + epsilon) {
       return;
     }
@@ -26524,188 +26000,6 @@ __publicField(PointElement, "defaultRoutes", {
   backgroundColor: "backgroundColor",
   borderColor: "borderColor"
 });
-function getBarBounds(bar, useFinalPosition) {
-  const { x: x2, y: y2, base, width, height } = bar.getProps([
-    "x",
-    "y",
-    "base",
-    "width",
-    "height"
-  ], useFinalPosition);
-  let left, right, top, bottom, half;
-  if (bar.horizontal) {
-    half = height / 2;
-    left = Math.min(x2, base);
-    right = Math.max(x2, base);
-    top = y2 - half;
-    bottom = y2 + half;
-  } else {
-    half = width / 2;
-    left = x2 - half;
-    right = x2 + half;
-    top = Math.min(y2, base);
-    bottom = Math.max(y2, base);
-  }
-  return {
-    left,
-    top,
-    right,
-    bottom
-  };
-}
-function skipOrLimit(skip2, value, min, max) {
-  return skip2 ? 0 : _limitValue(value, min, max);
-}
-function parseBorderWidth(bar, maxW, maxH) {
-  const value = bar.options.borderWidth;
-  const skip2 = bar.borderSkipped;
-  const o = toTRBL(value);
-  return {
-    t: skipOrLimit(skip2.top, o.top, 0, maxH),
-    r: skipOrLimit(skip2.right, o.right, 0, maxW),
-    b: skipOrLimit(skip2.bottom, o.bottom, 0, maxH),
-    l: skipOrLimit(skip2.left, o.left, 0, maxW)
-  };
-}
-function parseBorderRadius(bar, maxW, maxH) {
-  const { enableBorderRadius } = bar.getProps([
-    "enableBorderRadius"
-  ]);
-  const value = bar.options.borderRadius;
-  const o = toTRBLCorners(value);
-  const maxR = Math.min(maxW, maxH);
-  const skip2 = bar.borderSkipped;
-  const enableBorder = enableBorderRadius || isObject(value);
-  return {
-    topLeft: skipOrLimit(!enableBorder || skip2.top || skip2.left, o.topLeft, 0, maxR),
-    topRight: skipOrLimit(!enableBorder || skip2.top || skip2.right, o.topRight, 0, maxR),
-    bottomLeft: skipOrLimit(!enableBorder || skip2.bottom || skip2.left, o.bottomLeft, 0, maxR),
-    bottomRight: skipOrLimit(!enableBorder || skip2.bottom || skip2.right, o.bottomRight, 0, maxR)
-  };
-}
-function boundingRects(bar) {
-  const bounds = getBarBounds(bar);
-  const width = bounds.right - bounds.left;
-  const height = bounds.bottom - bounds.top;
-  const border = parseBorderWidth(bar, width / 2, height / 2);
-  const radius = parseBorderRadius(bar, width / 2, height / 2);
-  return {
-    outer: {
-      x: bounds.left,
-      y: bounds.top,
-      w: width,
-      h: height,
-      radius
-    },
-    inner: {
-      x: bounds.left + border.l,
-      y: bounds.top + border.t,
-      w: width - border.l - border.r,
-      h: height - border.t - border.b,
-      radius: {
-        topLeft: Math.max(0, radius.topLeft - Math.max(border.t, border.l)),
-        topRight: Math.max(0, radius.topRight - Math.max(border.t, border.r)),
-        bottomLeft: Math.max(0, radius.bottomLeft - Math.max(border.b, border.l)),
-        bottomRight: Math.max(0, radius.bottomRight - Math.max(border.b, border.r))
-      }
-    }
-  };
-}
-function inRange(bar, x2, y2, useFinalPosition) {
-  const skipX = x2 === null;
-  const skipY = y2 === null;
-  const skipBoth = skipX && skipY;
-  const bounds = bar && !skipBoth && getBarBounds(bar, useFinalPosition);
-  return bounds && (skipX || _isBetween(x2, bounds.left, bounds.right)) && (skipY || _isBetween(y2, bounds.top, bounds.bottom));
-}
-function hasRadius(radius) {
-  return radius.topLeft || radius.topRight || radius.bottomLeft || radius.bottomRight;
-}
-function addNormalRectPath(ctx, rect) {
-  ctx.rect(rect.x, rect.y, rect.w, rect.h);
-}
-function inflateRect(rect, amount, refRect = {}) {
-  const x2 = rect.x !== refRect.x ? -amount : 0;
-  const y2 = rect.y !== refRect.y ? -amount : 0;
-  const w2 = (rect.x + rect.w !== refRect.x + refRect.w ? amount : 0) - x2;
-  const h = (rect.y + rect.h !== refRect.y + refRect.h ? amount : 0) - y2;
-  return {
-    x: rect.x + x2,
-    y: rect.y + y2,
-    w: rect.w + w2,
-    h: rect.h + h,
-    radius: rect.radius
-  };
-}
-class BarElement extends Element$1 {
-  constructor(cfg) {
-    super();
-    this.options = void 0;
-    this.horizontal = void 0;
-    this.base = void 0;
-    this.width = void 0;
-    this.height = void 0;
-    this.inflateAmount = void 0;
-    if (cfg) {
-      Object.assign(this, cfg);
-    }
-  }
-  draw(ctx) {
-    const { inflateAmount, options: { borderColor, backgroundColor } } = this;
-    const { inner, outer } = boundingRects(this);
-    const addRectPath = hasRadius(outer.radius) ? addRoundedRectPath : addNormalRectPath;
-    ctx.save();
-    if (outer.w !== inner.w || outer.h !== inner.h) {
-      ctx.beginPath();
-      addRectPath(ctx, inflateRect(outer, inflateAmount, inner));
-      ctx.clip();
-      addRectPath(ctx, inflateRect(inner, -inflateAmount, outer));
-      ctx.fillStyle = borderColor;
-      ctx.fill("evenodd");
-    }
-    ctx.beginPath();
-    addRectPath(ctx, inflateRect(inner, inflateAmount));
-    ctx.fillStyle = backgroundColor;
-    ctx.fill();
-    ctx.restore();
-  }
-  inRange(mouseX, mouseY, useFinalPosition) {
-    return inRange(this, mouseX, mouseY, useFinalPosition);
-  }
-  inXRange(mouseX, useFinalPosition) {
-    return inRange(this, mouseX, null, useFinalPosition);
-  }
-  inYRange(mouseY, useFinalPosition) {
-    return inRange(this, null, mouseY, useFinalPosition);
-  }
-  getCenterPoint(useFinalPosition) {
-    const { x: x2, y: y2, base, horizontal } = this.getProps([
-      "x",
-      "y",
-      "base",
-      "horizontal"
-    ], useFinalPosition);
-    return {
-      x: horizontal ? (x2 + base) / 2 : x2,
-      y: horizontal ? y2 : (y2 + base) / 2
-    };
-  }
-  getRange(axis) {
-    return axis === "x" ? this.width / 2 : this.height / 2;
-  }
-}
-__publicField(BarElement, "id", "bar");
-__publicField(BarElement, "defaults", {
-  borderSkipped: "start",
-  borderWidth: 0,
-  borderRadius: 0,
-  inflateAmount: "auto",
-  pointStyle: void 0
-});
-__publicField(BarElement, "defaultRoutes", {
-  backgroundColor: "backgroundColor",
-  borderColor: "borderColor"
-});
 const getBoxSize = (labelOpts, fontSize) => {
   let { boxHeight = fontSize, boxWidth = fontSize } = labelOpts;
   if (labelOpts.usePointStyle) {
@@ -28374,127 +27668,6 @@ var plugin_tooltip = {
     "interaction"
   ]
 };
-const addIfString = (labels, raw, index, addedLabels) => {
-  if (typeof raw === "string") {
-    index = labels.push(raw) - 1;
-    addedLabels.unshift({
-      index,
-      label: raw
-    });
-  } else if (isNaN(raw)) {
-    index = null;
-  }
-  return index;
-};
-function findOrAddLabel(labels, raw, index, addedLabels) {
-  const first = labels.indexOf(raw);
-  if (first === -1) {
-    return addIfString(labels, raw, index, addedLabels);
-  }
-  const last = labels.lastIndexOf(raw);
-  return first !== last ? index : first;
-}
-const validIndex = (index, max) => index === null ? null : _limitValue(Math.round(index), 0, max);
-function _getLabelForValue(value) {
-  const labels = this.getLabels();
-  if (value >= 0 && value < labels.length) {
-    return labels[value];
-  }
-  return value;
-}
-class CategoryScale extends Scale {
-  constructor(cfg) {
-    super(cfg);
-    this._startValue = void 0;
-    this._valueRange = 0;
-    this._addedLabels = [];
-  }
-  init(scaleOptions) {
-    const added = this._addedLabels;
-    if (added.length) {
-      const labels = this.getLabels();
-      for (const { index, label } of added) {
-        if (labels[index] === label) {
-          labels.splice(index, 1);
-        }
-      }
-      this._addedLabels = [];
-    }
-    super.init(scaleOptions);
-  }
-  parse(raw, index) {
-    if (isNullOrUndef(raw)) {
-      return null;
-    }
-    const labels = this.getLabels();
-    index = isFinite(index) && labels[index] === raw ? index : findOrAddLabel(labels, raw, valueOrDefault(index, raw), this._addedLabels);
-    return validIndex(index, labels.length - 1);
-  }
-  determineDataLimits() {
-    const { minDefined, maxDefined } = this.getUserBounds();
-    let { min, max } = this.getMinMax(true);
-    if (this.options.bounds === "ticks") {
-      if (!minDefined) {
-        min = 0;
-      }
-      if (!maxDefined) {
-        max = this.getLabels().length - 1;
-      }
-    }
-    this.min = min;
-    this.max = max;
-  }
-  buildTicks() {
-    const min = this.min;
-    const max = this.max;
-    const offset = this.options.offset;
-    const ticks = [];
-    let labels = this.getLabels();
-    labels = min === 0 && max === labels.length - 1 ? labels : labels.slice(min, max + 1);
-    this._valueRange = Math.max(labels.length - (offset ? 0 : 1), 1);
-    this._startValue = this.min - (offset ? 0.5 : 0);
-    for (let value = min; value <= max; value++) {
-      ticks.push({
-        value
-      });
-    }
-    return ticks;
-  }
-  getLabelForValue(value) {
-    return _getLabelForValue.call(this, value);
-  }
-  configure() {
-    super.configure();
-    if (!this.isHorizontal()) {
-      this._reversePixels = !this._reversePixels;
-    }
-  }
-  getPixelForValue(value) {
-    if (typeof value !== "number") {
-      value = this.parse(value);
-    }
-    return value === null ? NaN : this.getPixelForDecimal((value - this._startValue) / this._valueRange);
-  }
-  getPixelForTick(index) {
-    const ticks = this.ticks;
-    if (index < 0 || index > ticks.length - 1) {
-      return null;
-    }
-    return this.getPixelForValue(ticks[index].value);
-  }
-  getValueForPixel(pixel) {
-    return Math.round(this._startValue + this.getDecimalForPixel(pixel) * this._valueRange);
-  }
-  getBasePixel() {
-    return this.bottom;
-  }
-}
-__publicField(CategoryScale, "id", "category");
-__publicField(CategoryScale, "defaults", {
-  ticks: {
-    callback: _getLabelForValue
-  }
-});
 function generateTicks$1(generationOptions, dataRange) {
   const ticks = [];
   const MIN_SPACING = 1e-14;
@@ -29408,1244 +28581,6 @@ function createTypedChart(type, registerables) {
   }));
 }
 const Line = /* @__PURE__ */ createTypedChart("line", LineController);
-const Bar = /* @__PURE__ */ createTypedChart("bar", BarController);
-const VERTEX_ICON = L$1.divIcon({
-  className: "",
-  html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
-  iconSize: [0, 0]
-});
-function ProfileTool({ active, onDeactivate: _onDeactivate }) {
-  const map2 = useMap();
-  const { state } = useAppContext();
-  const polyRef = reactExports.useRef(null);
-  const previewRef = reactExports.useRef(null);
-  const markersRef = reactExports.useRef([]);
-  const ptsRef = reactExports.useRef([]);
-  const modeRef = reactExports.useRef("idle");
-  const [profileData, setProfileData] = reactExports.useState(null);
-  const [loading, setLoading] = reactExports.useState(false);
-  const fetchFn = reactExports.useCallback(async (pts) => {
-    if (pts.length < 2 || !state.currentDataset) return;
-    setLoading(true);
-    try {
-      const res = await fetch("/profile", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          coords: pts.map((p2) => [p2.lng, p2.lat]),
-          dataset_name: state.currentDataset,
-          time_index: state.currentTimeIndex,
-          n_samples: 200
-        })
-      });
-      if (res.ok) setProfileData(await res.json());
-    } finally {
-      setLoading(false);
-    }
-  }, [state.currentDataset, state.currentTimeIndex]);
-  const fetchRef = reactExports.useRef(fetchFn);
-  reactExports.useEffect(() => {
-    fetchRef.current = fetchFn;
-  }, [fetchFn]);
-  const updatePoly = (pts) => {
-    if (polyRef.current) {
-      polyRef.current.setLatLngs(pts);
-    } else {
-      polyRef.current = L$1.polyline(pts, { color: "#f0a500", weight: 2.5 }).addTo(map2);
-    }
-  };
-  const rebuildMarkers = (pts) => {
-    markersRef.current.forEach((m2) => m2.remove());
-    markersRef.current = pts.map((pt, idx) => {
-      const m2 = L$1.marker(pt, { icon: VERTEX_ICON, draggable: true }).addTo(map2);
-      m2.on("drag", () => {
-        ptsRef.current[idx] = m2.getLatLng();
-        updatePoly(ptsRef.current);
-      });
-      m2.on("dragend", () => {
-        ptsRef.current[idx] = m2.getLatLng();
-        fetchRef.current(ptsRef.current);
-      });
-      return m2;
-    });
-  };
-  const clearAll = reactExports.useCallback(() => {
-    var _a2, _b2;
-    (_a2 = polyRef.current) == null ? void 0 : _a2.remove();
-    polyRef.current = null;
-    (_b2 = previewRef.current) == null ? void 0 : _b2.remove();
-    previewRef.current = null;
-    markersRef.current.forEach((m2) => m2.remove());
-    markersRef.current = [];
-    ptsRef.current = [];
-    modeRef.current = "idle";
-    setProfileData(null);
-  }, []);
-  reactExports.useEffect(() => {
-    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current);
-    }
-  }, [state.currentTimeIndex, active]);
-  reactExports.useEffect(() => {
-    if (!active) {
-      clearAll();
-      map2.getContainer().style.cursor = "";
-      return;
-    }
-    map2.getContainer().style.cursor = "crosshair";
-    const onClick = (e) => {
-      if (modeRef.current === "ready") {
-        clearAll();
-        modeRef.current = "drawing";
-        map2.getContainer().style.cursor = "crosshair";
-      }
-      modeRef.current = "drawing";
-      ptsRef.current = [...ptsRef.current, e.latlng];
-      updatePoly(ptsRef.current);
-    };
-    const onMouseMove = (e) => {
-      if (modeRef.current !== "drawing" || ptsRef.current.length === 0) return;
-      const preview = [...ptsRef.current, e.latlng];
-      if (previewRef.current) {
-        previewRef.current.setLatLngs(preview);
-      } else {
-        previewRef.current = L$1.polyline(preview, {
-          color: "#f0a500",
-          weight: 2,
-          dashArray: "6 4"
-        }).addTo(map2);
-      }
-    };
-    const onDblClick = (e) => {
-      var _a2;
-      L$1.DomEvent.stop(e);
-      if (modeRef.current !== "drawing" || ptsRef.current.length < 2) return;
-      (_a2 = previewRef.current) == null ? void 0 : _a2.remove();
-      previewRef.current = null;
-      updatePoly(ptsRef.current);
-      modeRef.current = "ready";
-      map2.getContainer().style.cursor = "default";
-      rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current);
-    };
-    map2.on("click", onClick);
-    map2.on("mousemove", onMouseMove);
-    map2.on("dblclick", onDblClick);
-    map2.doubleClickZoom.disable();
-    return () => {
-      map2.off("click", onClick);
-      map2.off("mousemove", onMouseMove);
-      map2.off("dblclick", onDblClick);
-      map2.doubleClickZoom.enable();
-      map2.getContainer().style.cursor = "";
-    };
-  }, [active, map2, clearAll]);
-  if (loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "profile-panel", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Extracting profile…" }) }) });
-  }
-  if (!profileData || profileData.length === 0 || !state.showProfile) return null;
-  const chartData = {
-    labels: profileData.map((p2) => p2.dist.toFixed(0)),
-    datasets: [{
-      label: state.currentDataset,
-      data: profileData.map((p2) => p2.value),
-      borderColor: "#4d9de0",
-      backgroundColor: "rgba(77,157,224,0.15)",
-      borderWidth: 1.5,
-      pointRadius: 0,
-      fill: true,
-      tension: 0.2
-    }]
-  };
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 0 },
-    plugins: { legend: { display: false } },
-    scales: {
-      x: {
-        title: { display: true, text: "Distance (m)", color: "#aaa" },
-        ticks: { color: "#aaa", maxTicksLimit: 8 },
-        grid: { color: "rgba(255,255,255,0.1)" }
-      },
-      y: {
-        title: { display: true, text: state.currentDataset, color: "#aaa" },
-        ticks: { color: "#aaa" },
-        grid: { color: "rgba(255,255,255,0.1)" }
-      }
-    }
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-panel", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
-        "Profile — ",
-        state.currentDataset
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: clearAll, title: "Clear profile", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" }) })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { height: 180, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) })
-  ] });
-}
-function RefPointChart() {
-  var _a2;
-  const { state } = useAppContext();
-  const { fetchBufferTimeSeries } = useApi();
-  const [bufferData, setBufferData] = reactExports.useState(null);
-  const [loading, setLoading] = reactExports.useState(false);
-  const abortRef = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    var _a3;
-    if (!state.refBufferEnabled || !state.showRefChart || !state.currentDataset) {
-      setBufferData(null);
-      return;
-    }
-    (_a3 = abortRef.current) == null ? void 0 : _a3.abort();
-    const ctrl = new AbortController();
-    abortRef.current = ctrl;
-    const [lat, lng] = state.refMarkerPosition;
-    setLoading(true);
-    fetchBufferTimeSeries(lng, lat, state.currentDataset, state.refBufferRadius, 20).then((data) => {
-      if (!ctrl.signal.aborted && data) setBufferData(data);
-    }).finally(() => {
-      if (!ctrl.signal.aborted) setLoading(false);
-    });
-    return () => ctrl.abort();
-  }, [
-    state.refBufferEnabled,
-    state.showRefChart,
-    state.currentDataset,
-    state.refMarkerPosition,
-    state.refBufferRadius
-  ]);
-  if (!state.refBufferEnabled || !state.showRefChart) return null;
-  if (loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "profile-panel", style: { left: "50%", transform: "translateX(-50%)", bottom: 0, right: "auto", width: 500 }, children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading reference buffer…" }) }) });
-  }
-  if (!bufferData || bufferData.labels.length === 0) return null;
-  const { median, samples } = bufferData;
-  const rawLabels = (((_a2 = state.datasetInfo[state.currentDataset]) == null ? void 0 : _a2.x_values) ?? bufferData.labels).map(String);
-  const n2 = rawLabels.length;
-  const toDisplay = (l2) => {
-    const parts = l2.split("_");
-    if (parts.length === 2 && /^\d{8}$/.test(parts[1])) {
-      const d = parts[1];
-      return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
-    }
-    return l2.slice(0, 10);
-  };
-  const displayLabels = rawLabels.map(toDisplay);
-  const mean = Array(n2).fill(0);
-  const std = Array(n2).fill(0);
-  if (samples.length > 0) {
-    for (let t2 = 0; t2 < n2; t2++) {
-      const vals = samples.map((s) => s[t2]).filter((v2) => isFinite(v2));
-      if (vals.length === 0) {
-        mean[t2] = NaN;
-        std[t2] = NaN;
-        continue;
-      }
-      const m2 = vals.reduce((a, b) => a + b, 0) / vals.length;
-      mean[t2] = m2;
-      std[t2] = Math.sqrt(vals.reduce((a, b) => a + (b - m2) ** 2, 0) / vals.length);
-    }
-  }
-  const meanPlusStd = mean.map((m2, i) => isFinite(m2) ? m2 + std[i] : NaN);
-  const meanMinusStd = mean.map((m2, i) => isFinite(m2) ? m2 - std[i] : NaN);
-  const sampleDatasets = samples.slice(0, 8).map((s, i) => ({
-    label: `sample ${i + 1}`,
-    data: s,
-    borderColor: "rgba(150,180,220,0.18)",
-    backgroundColor: "transparent",
-    borderWidth: 1,
-    pointRadius: 0,
-    tension: 0.15
-  }));
-  const chartData = {
-    labels: displayLabels,
-    datasets: [
-      // +1σ bound — fills toward -1σ (dataset index 1)
-      {
-        label: "+1σ",
-        data: meanPlusStd,
-        borderColor: "rgba(77,157,224,0.4)",
-        backgroundColor: "rgba(77,157,224,0.12)",
-        borderWidth: 1,
-        borderDash: [3, 3],
-        pointRadius: 0,
-        fill: { target: 1, above: "rgba(77,157,224,0.12)" },
-        tension: 0.2
-      },
-      // -1σ bound
-      {
-        label: "-1σ",
-        data: meanMinusStd,
-        borderColor: "rgba(77,157,224,0.4)",
-        backgroundColor: "transparent",
-        borderWidth: 1,
-        borderDash: [3, 3],
-        pointRadius: 0,
-        fill: false,
-        tension: 0.2
-      },
-      // Mean
-      {
-        label: "Mean",
-        data: mean,
-        borderColor: "#4d9de0",
-        backgroundColor: "transparent",
-        borderWidth: 2,
-        pointRadius: 0,
-        tension: 0.2
-      },
-      // Median
-      {
-        label: "Median",
-        data: median,
-        borderColor: "#3ec97a",
-        backgroundColor: "transparent",
-        borderWidth: 2,
-        borderDash: [6, 4],
-        pointRadius: 0,
-        fill: false,
-        tension: 0.2
-      },
-      // Individual samples (faint, behind main lines)
-      ...sampleDatasets
-    ]
-  };
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 0 },
-    plugins: {
-      legend: {
-        display: true,
-        labels: {
-          color: "#aaa",
-          filter: (item) => ["Mean", "Median", "+1σ"].includes(item.text),
-          boxWidth: 20,
-          font: { size: 11 }
-        }
-      },
-      tooltip: { mode: "index", intersect: false }
-    },
-    scales: {
-      x: {
-        ticks: { color: "#aaa", maxTicksLimit: 8, maxRotation: 45 },
-        grid: { color: "rgba(255,255,255,0.08)" }
-      },
-      y: {
-        title: { display: true, text: state.currentDataset, color: "#aaa" },
-        ticks: { color: "#aaa" },
-        grid: { color: "rgba(255,255,255,0.08)" }
-      }
-    }
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-panel", style: { right: 16, left: "auto", width: 520 }, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-header", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
-      "Ref Buffer — ",
-      bufferData.n_pixels,
-      " px, r=",
-      state.refBufferRadius,
-      " m"
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { height: 200, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) })
-  ] });
-}
-delete L$1.Icon.Default.prototype._getIconUrl;
-L$1.Icon.Default.mergeOptions({
-  iconRetinaUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png",
-  iconUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png",
-  shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png"
-});
-const fontAwesomeIcon = L$1.divIcon({
-  html: '<i class="fa-solid fa-location-dot fa-3x" style="color:#111; text-shadow: 0 0 4px white, 0 0 4px white;"></i>',
-  iconSize: [20, 20],
-  className: "myDivIcon"
-});
-function MapEvents() {
-  const { state, dispatch } = useAppContext();
-  useMapEvents({
-    click: (e) => {
-      if (!state.pickingEnabled) return;
-      dispatch({
-        type: "ADD_TIME_SERIES_POINT",
-        payload: {
-          position: [e.latlng.lat, e.latlng.lng],
-          name: `Point ${Date.now().toString().slice(-4)}`
-        }
-      });
-    }
-  });
-  return null;
-}
-function MousePosition() {
-  const map2 = useMap();
-  reactExports.useEffect(() => {
-    const mousePositionControl = new MousePositionControl();
-    mousePositionControl.addTo(map2);
-    return () => {
-      mousePositionControl.remove();
-    };
-  }, [map2]);
-  return null;
-}
-function ScaleBar() {
-  const map2 = useMap();
-  reactExports.useEffect(() => {
-    const scale = L$1.control.scale({ position: "bottomleft", imperial: true, metric: true, maxWidth: 150 });
-    scale.addTo(map2);
-    return () => {
-      scale.remove();
-    };
-  }, [map2]);
-  return null;
-}
-function RasterTileLayer() {
-  const { state } = useAppContext();
-  const [tileUrl, setTileUrl] = reactExports.useState(null);
-  reactExports.useEffect(() => {
-    if (!state.currentDataset || !state.datasetInfo[state.currentDataset]) {
-      return;
-    }
-    const controller = new AbortController();
-    const signal = controller.signal;
-    const updateTileLayer2 = async () => {
-      const currentDatasetInfo = state.datasetInfo[state.currentDataset];
-      const colormap = state.colormap;
-      const vmin = state.vmin;
-      const vmax = state.vmax;
-      const maxIdx = currentDatasetInfo.x_values.length - 1;
-      const timeIdx = Math.max(0, Math.min(state.currentTimeIndex, maxIdx));
-      const params = {
-        variable: state.currentDataset,
-        time_idx: timeIdx.toString(),
-        rescale: `${vmin},${vmax}`,
-        colormap_name: colormap
-      };
-      if (currentDatasetInfo.algorithm) {
-        params.algorithm = currentDatasetInfo.algorithm;
-      }
-      if (state.refEnabled && state.refValues[state.currentDataset] && currentDatasetInfo.algorithm === "shift") {
-        const shift = state.refValues[state.currentDataset][timeIdx];
-        if (shift !== void 0) {
-          params.algorithm_params = JSON.stringify({ shift });
-        }
-      }
-      if (state.dataMode === "cog") {
-        const url = currentDatasetInfo.file_list[timeIdx];
-        const maskUrl = currentDatasetInfo.mask_file_list[timeIdx];
-        const maskMinValue = currentDatasetInfo.mask_min_value;
-        params.url = url;
-        if (maskUrl) params.mask = encodeURIComponent(maskUrl);
-        if (maskMinValue !== void 0) params.mask_min_value = maskMinValue.toString();
-        if (state.customMaskPath) params.custom_mask = state.customMaskPath;
-        if (state.coherenceThreshold > 0) params.coherence_min = state.coherenceThreshold.toString();
-        if (state.phaseSimilarityThreshold > 0) params.phase_similarity_min = state.phaseSimilarityThreshold.toString();
-      }
-      if (state.dataMode === "md") {
-        if (state.coherenceThreshold > 0) params.coherence_min = state.coherenceThreshold.toString();
-        if (state.phaseSimilarityThreshold > 0) params.phase_similarity_min = state.phaseSimilarityThreshold.toString();
-        if (state.invResidThreshold > 0) params.inv_resid_max = state.invResidThreshold.toString();
-        if (state.customMaskPath) params.custom_mask_path = state.customMaskPath;
-      }
-      const urlParams = new URLSearchParams(params).toString();
-      const endpoint = state.dataMode === "md" ? `/md/WebMercatorQuad/tilejson.json?${urlParams}` : `/cog/WebMercatorQuad/tilejson.json?${urlParams}`;
-      try {
-        const response = await fetch(endpoint, { signal });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const tileInfo = await response.json();
-        if (!signal.aborted) setTileUrl(tileInfo.tiles[0]);
-      } catch (err) {
-        if (err.name !== "AbortError") {
-          console.error("Error fetching tile info:", err);
-        }
-      }
-    };
-    updateTileLayer2();
-    return () => controller.abort();
-  }, [
-    state.currentDataset,
-    state.currentTimeIndex,
-    state.datasetInfo,
-    state.dataMode,
-    state.refValues,
-    state.refMarkerPosition,
-    state.refEnabled,
-    state.colormap,
-    state.vmin,
-    state.vmax,
-    state.coherenceThreshold,
-    state.phaseSimilarityThreshold,
-    state.invResidThreshold,
-    state.customMaskPath
-  ]);
-  if (!tileUrl) return null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(
-    TileLayer,
-    {
-      url: tileUrl,
-      opacity: state.opacity,
-      maxZoom: 19
-    },
-    tileUrl
-  );
-}
-function MarkerEventHandlers() {
-  const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
-  const map2 = useMap();
-  const handleMarkerClick = (position, pointName) => {
-    const [lat, lng] = position;
-    const content = pointName ? `${pointName} (lon, lat):
-(${lng.toFixed(6)}, ${lat.toFixed(6)})` : `Reference (lon, lat):
-(${lng.toFixed(6)}, ${lat.toFixed(6)})`;
-    L$1.popup().setLatLng([lat, lng]).setContent(content).openOn(map2);
-  };
-  const handleTsMarkerDragEnd = (pointId) => (e) => {
-    const marker = e.target;
-    const position = marker.getLatLng();
-    dispatch({
-      type: "UPDATE_TIME_SERIES_POINT",
-      payload: {
-        id: pointId,
-        updates: { position: [position.lat, position.lng] }
-      }
-    });
-  };
-  const handleRefMarkerDragEnd = async (e) => {
-    const marker = e.target;
-    const position = marker.getLatLng();
-    const lat = position.lat;
-    const lng = position.lng;
-    dispatch({ type: "SET_REF_MARKER_POSITION", payload: [lat, lng] });
-    const ds = state.currentDataset;
-    const info = ds ? state.datasetInfo[ds] : null;
-    if (ds && (info == null ? void 0 : info.algorithm) === "shift") {
-      try {
-        const values = await fetchPointTimeSeries(lng, lat, ds);
-        if (values) {
-          dispatch({
-            type: "SET_REF_VALUES",
-            payload: { dataset: ds, values }
-          });
-        }
-      } catch (err) {
-        console.error("Error updating reference values after drag:", err);
-      }
-    }
-  };
-  const handleTsMarkerDoubleClick = (pointId) => () => {
-    dispatch({ type: "REMOVE_TIME_SERIES_POINT", payload: pointId });
-  };
-  const createColoredIcon = (color2, isSelected = false) => {
-    const iconSize = isSelected ? 25 : 20;
-    return L$1.divIcon({
-      html: `<div style="
-        width: ${iconSize}px;
-        height: ${iconSize}px;
-        background-color: ${color2};
-        border: ${isSelected ? "3px solid white" : "2px solid white"};
-        border-radius: 50%;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-      "></div>`,
-      iconSize: [iconSize, iconSize],
-      className: "custom-colored-marker"
-    });
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-    state.timeSeriesPoints.filter((p2) => p2.visible).map((point) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-      Marker,
-      {
-        position: point.position,
-        icon: createColoredIcon(point.color, state.selectedPointId === point.id),
-        draggable: true,
-        title: `${point.name} - Double-click to remove`,
-        eventHandlers: {
-          click: () => {
-            handleMarkerClick(point.position, point.name);
-            dispatch({ type: "SET_SELECTED_POINT", payload: point.id });
-          },
-          dragend: handleTsMarkerDragEnd(point.id),
-          dblclick: handleTsMarkerDoubleClick(point.id)
-        }
-      },
-      point.id
-    )),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      Marker,
-      {
-        position: state.refMarkerPosition,
-        icon: fontAwesomeIcon,
-        draggable: true,
-        title: "Reference Location",
-        eventHandlers: {
-          click: () => handleMarkerClick(state.refMarkerPosition),
-          dragend: handleRefMarkerDragEnd
-        }
-      }
-    )
-  ] });
-}
-function MapContainer() {
-  const { state } = useAppContext();
-  const getInitialCenter = () => {
-    if (state.currentDataset && state.datasetInfo[state.currentDataset]) {
-      const bounds = state.datasetInfo[state.currentDataset].latlon_bounds;
-      const centerLat = (bounds[1] + bounds[3]) / 2;
-      const centerLng = (bounds[0] + bounds[2]) / 2;
-      return [centerLat, centerLng];
-    }
-    const datasets = Object.values(state.datasetInfo);
-    if (datasets.length > 0) {
-      const bounds = datasets[0].latlon_bounds;
-      const centerLat = (bounds[1] + bounds[3]) / 2;
-      const centerLng = (bounds[0] + bounds[2]) / 2;
-      return [centerLat, centerLng];
-    }
-    return [0, 0];
-  };
-  const selectedBasemap = baseMaps[state.selectedBasemap] || baseMaps.esriSatellite;
-  const center = getInitialCenter();
-  const hasDatasets = Object.keys(state.datasetInfo).length > 0;
-  const [measureActive, setMeasureActive] = reactExports.useState(false);
-  const [profileActive, setProfileActive] = reactExports.useState(false);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-container", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-toolbar", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          className: `map-tool-btn${measureActive ? " active" : ""}`,
-          title: "Measure distance (click points, double-click to finish)",
-          onClick: () => {
-            setMeasureActive((v2) => !v2);
-            setProfileActive(false);
-          },
-          children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-ruler" })
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          className: `map-tool-btn${profileActive ? " active" : ""}`,
-          title: "Draw profile line (click start, click end, double-click to extract)",
-          onClick: () => {
-            setProfileActive((v2) => !v2);
-            setMeasureActive(false);
-          },
-          children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-chart-area" })
-        }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      MapContainer$1,
-      {
-        center,
-        zoom: 9,
-        style: { height: "100%", width: "100%" },
-        doubleClickZoom: false,
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            TileLayer,
-            {
-              url: selectedBasemap.url,
-              attribution: selectedBasemap.attribution,
-              maxZoom: 19
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(RasterTileLayer, {}),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(MarkerEventHandlers, {}),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(MapEvents, {}),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(MousePosition, {}),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(ScaleBar, {}),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(MeasureTool, { active: measureActive, onDeactivate: () => setMeasureActive(false) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileTool, { active: profileActive, onDeactivate: () => setProfileActive(false) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(RefPointChart, {})
-        ]
-      },
-      hasDatasets ? "with-data" : "no-data"
-    )
-  ] });
-}
-Chart$1.register(CategoryScale, LinearScale, BarElement, plugin_tooltip);
-function Histogram() {
-  const { state, dispatch } = useAppContext();
-  const [histData, setHistData] = reactExports.useState(null);
-  const [loading, setLoading] = reactExports.useState(false);
-  const fetchHistogram = reactExports.useCallback(async () => {
-    if (!state.currentDataset) return;
-    setLoading(true);
-    try {
-      const params = new URLSearchParams({ time_index: String(state.currentTimeIndex) });
-      const res = await fetch(`/histogram/${encodeURIComponent(state.currentDataset)}?${params}`);
-      if (res.ok) {
-        const data = await res.json();
-        setHistData(data);
-      }
-    } catch (e) {
-      console.error("Error fetching histogram:", e);
-    } finally {
-      setLoading(false);
-    }
-  }, [state.currentDataset, state.currentTimeIndex]);
-  reactExports.useEffect(() => {
-    fetchHistogram();
-  }, [fetchHistogram]);
-  const handleAutoScale = () => {
-    if (!histData) return;
-    dispatch({ type: "SET_VMIN", payload: parseFloat(histData.p2.toFixed(4)) });
-    dispatch({ type: "SET_VMAX", payload: parseFloat(histData.p98.toFixed(4)) });
-  };
-  const handleFullScale = () => {
-    if (!histData) return;
-    dispatch({ type: "SET_VMIN", payload: parseFloat(histData.min.toFixed(4)) });
-    dispatch({ type: "SET_VMAX", payload: parseFloat(histData.max.toFixed(4)) });
-  };
-  const handleSigmaScale = () => {
-    if (!histData || histData.p16 == null || histData.p84 == null) return;
-    dispatch({ type: "SET_VMIN", payload: parseFloat(histData.p16.toFixed(4)) });
-    dispatch({ type: "SET_VMAX", payload: parseFloat(histData.p84.toFixed(4)) });
-  };
-  const handleTwoSigmaScale = () => {
-    if (!histData || histData.p23 == null || histData.p977 == null) return;
-    dispatch({ type: "SET_VMIN", payload: parseFloat(histData.p23.toFixed(4)) });
-    dispatch({ type: "SET_VMAX", payload: parseFloat(histData.p977.toFixed(4)) });
-  };
-  if (!state.currentDataset || loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "histogram-loading", children: loading ? "Computing…" : "" });
-  }
-  if (!histData || histData.bins.length < 2) return null;
-  const labels = histData.bins.slice(0, -1).map(
-    (b, i) => ((b + histData.bins[i + 1]) / 2).toFixed(4)
-  );
-  const bgColors = histData.bins.slice(0, -1).map((b, i) => {
-    const center = (b + histData.bins[i + 1]) / 2;
-    return center >= state.vmin && center <= state.vmax ? "rgba(77,157,224,0.85)" : "rgba(120,120,160,0.30)";
-  });
-  const chartData = {
-    labels,
-    datasets: [{ data: histData.counts, backgroundColor: bgColors, borderWidth: 0, borderRadius: 2 }]
-  };
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 0 },
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        callbacks: {
-          title: (ctx) => `Value: ${ctx[0].label}`,
-          label: (ctx) => `Count: ${ctx.raw}`
-        }
-      }
-    },
-    scales: { x: { display: false }, y: { display: false } }
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "histogram-wrapper", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "histogram-chart-area", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Bar, { data: chartData, options }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "histogram-range", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hist-val", children: histData.min.toFixed(3) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hist-val", children: histData.max.toFixed(3) })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "histogram-buttons", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleAutoScale, title: "2nd–98th percentile", children: "2–98%" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleSigmaScale, title: "±1σ (16–84%)", children: "±1σ" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleTwoSigmaScale, title: "±2σ (2.3–97.7%)", children: "±2σ" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleFullScale, title: "Full range", children: "Full" })
-    ] })
-  ] });
-}
-const colormapOptions = [
-  { value: "rdbu", label: "Blue–Red" },
-  { value: "twilight", label: "Twilight (cyclic)" },
-  { value: "cfastie", label: "CFastie" },
-  { value: "rplumbo", label: "RPlumbo" },
-  { value: "schwarzwald", label: "Schwarzwald" },
-  { value: "viridis", label: "Viridis" },
-  { value: "bugn", label: "Blue–Green" },
-  { value: "ylgn", label: "Yellow–Green" },
-  { value: "magma", label: "Magma" },
-  { value: "gist_earth", label: "Earth" },
-  { value: "ocean", label: "Ocean" },
-  { value: "terrain", label: "Terrain" },
-  { value: "gray", label: "Grays" },
-  { value: "jet", label: "Jet" }
-];
-function ControlPanel() {
-  const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
-  const [draftVmin, setDraftVmin] = reactExports.useState(String(state.vmin));
-  const [draftVmax, setDraftVmax] = reactExports.useState(String(state.vmax));
-  reactExports.useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
-  reactExports.useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
-  reactExports.useEffect(() => {
-    const ds = state.currentDataset;
-    if (!ds) return;
-    const safeStr = (x2) => Object.is(x2, -0) ? "-0" : String(x2);
-    localStorage.setItem(`${ds}-colormap_name`, state.colormap);
-    localStorage.setItem(`${ds}-vmin`, safeStr(state.vmin));
-    localStorage.setItem(`${ds}-vmax`, safeStr(state.vmax));
-  }, [state.currentDataset, state.colormap, state.vmin, state.vmax]);
-  reactExports.useEffect(() => {
-    const ds = state.currentDataset;
-    if (!ds) return;
-    const info = state.datasetInfo[ds];
-    const isPhase = (info == null ? void 0 : info.algorithm) === "phase" || (info == null ? void 0 : info.algorithm) === "rewrap";
-    const colormap = localStorage.getItem(`${ds}-colormap_name`);
-    const vminStr = localStorage.getItem(`${ds}-vmin`);
-    const vmaxStr = localStorage.getItem(`${ds}-vmax`);
-    if (colormap) dispatch({ type: "SET_COLORMAP", payload: colormap });
-    if (vminStr !== null) {
-      const v2 = Number(vminStr);
-      if (!Number.isNaN(v2)) dispatch({ type: "SET_VMIN", payload: v2 });
-    } else if (isPhase) {
-      dispatch({ type: "SET_VMIN", payload: -Math.PI });
-    }
-    if (vmaxStr !== null) {
-      const v2 = Number(vmaxStr);
-      if (!Number.isNaN(v2)) dispatch({ type: "SET_VMAX", payload: v2 });
-    } else if (isPhase) {
-      dispatch({ type: "SET_VMAX", payload: Math.PI });
-    }
-  }, [state.currentDataset, dispatch]);
-  const handleDatasetChange = (ds) => {
-    dispatch({ type: "SET_CURRENT_DATASET", payload: ds });
-    const info = state.datasetInfo[ds];
-    if ((info == null ? void 0 : info.uses_spatial_ref) && !state.refValues[ds]) setRefValues(ds);
-  };
-  const commitVmin = reactExports.useCallback(() => {
-    const v2 = Number(draftVmin);
-    if (!Number.isNaN(v2)) dispatch({ type: "SET_VMIN", payload: v2 });
-  }, [draftVmin, dispatch]);
-  const commitVmax = reactExports.useCallback(() => {
-    const v2 = Number(draftVmax);
-    if (!Number.isNaN(v2)) dispatch({ type: "SET_VMAX", payload: v2 });
-  }, [draftVmax, dispatch]);
-  const setRefValues = async (ds) => {
-    const [lat, lng] = state.refMarkerPosition;
-    try {
-      const values = await fetchPointTimeSeries(lng, lat, ds);
-      if (values) dispatch({ type: "SET_REF_VALUES", payload: { dataset: ds, values } });
-    } catch (error) {
-      console.error("Error setting reference values:", error);
-    }
-  };
-  const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
-  const currentTimeValue = currentDatasetInfo ? currentDatasetInfo.x_values[state.currentTimeIndex] : "";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "menu", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-layer-group" }),
-        " Layers"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "select",
-        {
-          className: "sidebar-select",
-          value: state.currentDataset,
-          onChange: (e) => handleDatasetChange(e.target.value),
-          children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
-        }
-      ),
-      currentDatasetInfo && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Time step" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: currentTimeValue })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: currentDatasetInfo.x_values.length - 1,
-            step: "1",
-            value: state.currentTimeIndex,
-            onChange: (e) => dispatch({ type: "SET_TIME_INDEX", payload: parseInt(e.target.value) })
-          }
-        )
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-palette" }),
-        " Colormap"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "colormap-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "select",
-          {
-            className: "sidebar-select",
-            value: state.colormap.endsWith("_r") ? state.colormap.slice(0, -2) : state.colormap,
-            onChange: (e) => {
-              const base = e.target.value;
-              const inverted = state.colormap.endsWith("_r");
-              dispatch({ type: "SET_COLORMAP", payload: inverted ? `${base}_r` : base });
-            },
-            children: colormapOptions.map((opt) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: opt.value, children: opt.label }, opt.value))
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            className: `invert-btn${state.colormap.endsWith("_r") ? " active" : ""}`,
-            title: "Invert colormap",
-            onClick: () => {
-              const cm = state.colormap;
-              dispatch({ type: "SET_COLORMAP", payload: cm.endsWith("_r") ? cm.slice(0, -2) : `${cm}_r` });
-            },
-            children: "⇅"
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "img",
-        {
-          src: `/colorbar/${state.colormap}`,
-          className: "colorbar-img",
-          alt: "Colormap"
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "Min" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              className: "sidebar-input",
-              type: "text",
-              inputMode: "decimal",
-              value: draftVmin,
-              onChange: (e) => setDraftVmin(e.target.value),
-              onBlur: commitVmin,
-              onKeyDown: (e) => e.key === "Enter" && commitVmin()
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "Max" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              className: "sidebar-input",
-              type: "text",
-              inputMode: "decimal",
-              value: draftVmax,
-              onChange: (e) => setDraftVmax(e.target.value),
-              onBlur: commitVmax,
-              onKeyDown: (e) => e.key === "Enter" && commitVmax()
-            }
-          )
-        ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Opacity" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
-            Math.round(state.opacity * 100),
-            "%"
-          ] })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.opacity,
-            onChange: (e) => dispatch({ type: "SET_OPACITY", payload: parseFloat(e.target.value) })
-          }
-        )
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-map" }),
-        " Basemap"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "select",
-        {
-          className: "sidebar-select",
-          value: state.selectedBasemap,
-          onChange: (e) => dispatch({ type: "SET_BASEMAP", payload: e.target.value }),
-          children: Object.keys(baseMaps).map((key) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: key, children: key }, key))
-        }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-chart-bar" }),
-        " Value Distribution"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(Histogram, {})
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-mask" }),
-        " Masking"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Temporal coherence ≥" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.coherenceThreshold === 0 ? "off" : state.coherenceThreshold.toFixed(2) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.coherenceThreshold,
-            onChange: (e) => dispatch({ type: "SET_COHERENCE_THRESHOLD", payload: parseFloat(e.target.value) })
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Phase similarity ≥" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.phaseSimilarityThreshold === 0 ? "off" : state.phaseSimilarityThreshold.toFixed(2) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.phaseSimilarityThreshold,
-            onChange: (e) => dispatch({ type: "SET_PHASE_SIMILARITY_THRESHOLD", payload: parseFloat(e.target.value) })
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Inversion residuals ≤" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.invResidThreshold === 0 ? "off" : state.invResidThreshold.toFixed(2) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.invResidThreshold,
-            onChange: (e) => dispatch({ type: "SET_INV_RESID_THRESHOLD", payload: parseFloat(e.target.value) })
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", style: { marginBottom: 4 }, children: "Custom mask (GeoTIFF)" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-controls", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "hist-btn", style: { cursor: "pointer", textAlign: "center" }, children: [
-            "Upload",
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "input",
-              {
-                type: "file",
-                accept: ".tif,.tiff",
-                style: { display: "none" },
-                onChange: async (e) => {
-                  var _a2;
-                  const f2 = (_a2 = e.target.files) == null ? void 0 : _a2[0];
-                  if (!f2) return;
-                  const form = new FormData();
-                  form.append("file", f2);
-                  const res = await fetch("/upload_mask", { method: "POST", body: form });
-                  if (res.ok) {
-                    const data = await res.json();
-                    dispatch({ type: "SET_CUSTOM_MASK_PATH", payload: data.path });
-                  }
-                }
-              }
-            )
-          ] }),
-          state.customMaskPath && /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              className: "hist-btn",
-              style: { color: "var(--sb-red)" },
-              onClick: () => dispatch({ type: "SET_CUSTOM_MASK_PATH", payload: null }),
-              children: "Clear"
-            }
-          )
-        ] }),
-        state.customMaskPath && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { fontSize: "0.72em", color: "var(--sb-muted)", wordBreak: "break-all", marginTop: 2 }, children: state.customMaskPath.split("/").pop() })
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-circle-dot" }),
-        " Point Buffer Sampling"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "Enable buffer mode" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            className: `toggle-pill${state.bufferEnabled ? " active" : ""}`,
-            onClick: () => dispatch({ type: "TOGGLE_BUFFER" }),
-            children: state.bufferEnabled ? "ON" : "OFF"
-          }
-        )
-      ] }),
-      state.bufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Radius" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
-              state.bufferRadius,
-              " m"
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              type: "range",
-              className: "sidebar-range",
-              min: "50",
-              max: "5000",
-              step: "50",
-              value: state.bufferRadius,
-              onChange: (e) => dispatch({ type: "SET_BUFFER_RADIUS", payload: parseInt(e.target.value) })
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Samples shown" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.bufferSamples })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              type: "range",
-              className: "sidebar-range",
-              min: "0",
-              max: "50",
-              step: "1",
-              value: state.bufferSamples,
-              onChange: (e) => dispatch({ type: "SET_BUFFER_SAMPLES", payload: parseInt(e.target.value) })
-            }
-          )
-        ] })
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-crosshairs" }),
-        " Reference Buffer"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "Sample around ref marker" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            className: `toggle-pill${state.refBufferEnabled ? " active" : ""}`,
-            onClick: () => dispatch({ type: "TOGGLE_REF_BUFFER" }),
-            children: state.refBufferEnabled ? "ON" : "OFF"
-          }
-        )
-      ] }),
-      state.refBufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Radius" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
-            state.refBufferRadius,
-            " m"
-          ] })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "50",
-            max: "5000",
-            step: "50",
-            value: state.refBufferRadius,
-            onChange: (e) => dispatch({ type: "SET_REF_BUFFER_RADIUS", payload: parseInt(e.target.value) })
-          }
-        )
-      ] }) })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-footer", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: `toggle-pill${state.pickingEnabled ? " active" : ""}`,
-          style: { width: "100%", marginBottom: 6, justifyContent: "center" },
-          onClick: () => dispatch({ type: "TOGGLE_PICKING" }),
-          title: "Toggle map-click point picking",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-map-pin", style: { marginRight: 6 } }),
-            "Point Picking: ",
-            state.pickingEnabled ? "ON" : "OFF"
-          ]
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: `toggle-pill${state.refEnabled ? " active" : ""}`,
-          style: { width: "100%", marginBottom: 6, justifyContent: "center" },
-          onClick: () => dispatch({ type: "TOGGLE_REF_ENABLED" }),
-          title: "Toggle spatial re-referencing",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-crosshairs", style: { marginRight: 6 } }),
-            "Re-referencing: ",
-            state.refEnabled ? "ON" : "OFF"
-          ]
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: "chart-toggle-btn",
-          onClick: () => dispatch({ type: "TOGGLE_CHART" }),
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showChart ? "fa-chart-line" : "fa-wave-square"}` }),
-            state.showChart ? "Hide" : "Show",
-            " Time Series"
-          ]
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: "chart-toggle-btn",
-          style: { marginTop: 4 },
-          onClick: () => dispatch({ type: "TOGGLE_PROFILE" }),
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-chart-area" }),
-            state.showProfile ? "Hide" : "Show",
-            " Profile"
-          ]
-        }
-      ),
-      state.refBufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: "chart-toggle-btn",
-          style: { marginTop: 4 },
-          onClick: () => dispatch({ type: "TOGGLE_REF_CHART" }),
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-crosshairs" }),
-            state.showRefChart ? "Hide" : "Show",
-            " Ref Buffer Chart"
-          ]
-        }
-      )
-    ] })
-  ] });
-}
 const millisecondsInWeek = 6048e5;
 const millisecondsInDay = 864e5;
 const millisecondsInMinute = 6e4;
@@ -34342,18 +32277,10 @@ adapters._date.override({
   }
 });
 Chart$1.register(TimeScale, LinearScale, PointElement, LineElement, plugin_title, plugin_tooltip, plugin_legend);
-function toIsoDate(xVal) {
-  const dateStr = xVal.includes("_") ? xVal.split("_").pop() : xVal;
-  if (/^\d{8}$/.test(dateStr)) {
-    return `${dateStr.slice(0, 4)}-${dateStr.slice(4, 6)}-${dateStr.slice(6, 8)}`;
-  }
-  return xVal;
-}
 function TimeSeriesChart() {
   const { state, dispatch } = useAppContext();
-  const { fetchMultiPointTimeSeries, fetchBufferTimeSeries } = useApi();
+  const { fetchMultiPointTimeSeries } = useApi();
   const [chartData, setChartData] = reactExports.useState(null);
-  const [bufferData, setBufferData] = reactExports.useState({});
   const [isLoading, setIsLoading] = reactExports.useState(false);
   const updateChart = reactExports.useCallback(async () => {
     if (!state.showChart || !state.currentDataset || state.timeSeriesPoints.length === 0) {
@@ -34377,7 +32304,7 @@ function TimeSeriesChart() {
         name: point.name
       }));
       let refLon, refLat;
-      if ((currentDatasetInfo == null ? void 0 : currentDatasetInfo.uses_spatial_ref) && state.refEnabled) {
+      if (currentDatasetInfo == null ? void 0 : currentDatasetInfo.uses_spatial_ref) {
         [refLat, refLon] = state.refMarkerPosition;
       }
       const tsData = await fetchMultiPointTimeSeries(
@@ -34385,11 +32312,7 @@ function TimeSeriesChart() {
         state.currentDataset,
         refLon,
         refLat,
-        state.showTrends,
-        state.coherenceThreshold,
-        state.phaseSimilarityThreshold,
-        state.invResidThreshold,
-        state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
+        state.showTrends
       );
       if (tsData) {
         setChartData(tsData);
@@ -34424,76 +32347,21 @@ function TimeSeriesChart() {
     state.showChart,
     state.currentDataset,
     JSON.stringify(state.timeSeriesPoints.map((p2) => ({ id: p2.id, position: p2.position, visible: p2.visible }))),
+    // Only track relevant point changes
     state.refMarkerPosition,
-    state.refEnabled,
     state.datasetInfo,
     state.showTrends,
-    state.coherenceThreshold,
-    state.phaseSimilarityThreshold,
-    state.invResidThreshold,
     fetchMultiPointTimeSeries
   ]);
   reactExports.useEffect(() => {
     updateChart();
-  }, [updateChart]);
-  reactExports.useEffect(() => {
-    if (!state.bufferEnabled || !state.showChart || !state.currentDataset) {
-      setBufferData({});
-      return;
-    }
-    const visiblePoints = state.timeSeriesPoints.filter((p2) => p2.visible);
-    if (visiblePoints.length === 0) {
-      setBufferData({});
-      return;
-    }
-    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
-    let refLon, refLat;
-    if ((currentDatasetInfo == null ? void 0 : currentDatasetInfo.uses_spatial_ref) && state.refEnabled) {
-      [refLat, refLon] = state.refMarkerPosition;
-    }
-    Promise.all(
-      visiblePoints.map(async (p2) => {
-        const result = await fetchBufferTimeSeries(
-          p2.position[1],
-          p2.position[0],
-          state.currentDataset,
-          state.bufferRadius,
-          state.bufferSamples,
-          refLon,
-          refLat,
-          state.coherenceThreshold,
-          state.phaseSimilarityThreshold,
-          state.invResidThreshold,
-          state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
-        );
-        return { id: p2.id, result };
-      })
-    ).then((results) => {
-      const newData = {};
-      results.forEach(({ id: id2, result }) => {
-        if (result) newData[id2] = result;
-      });
-      setBufferData(newData);
-    });
   }, [
-    state.bufferEnabled,
-    state.showChart,
-    state.currentDataset,
-    state.bufferRadius,
-    state.bufferSamples,
-    state.refEnabled,
-    state.refBufferEnabled,
-    state.refBufferRadius,
-    state.coherenceThreshold,
-    state.phaseSimilarityThreshold,
-    state.invResidThreshold,
-    JSON.stringify(state.timeSeriesPoints.map((p2) => ({ id: p2.id, position: p2.position, visible: p2.visible }))),
-    state.refMarkerPosition,
-    fetchBufferTimeSeries
+    updateChart
   ]);
   const handleChartClick = reactExports.useCallback((_event, elements) => {
     if (elements.length === 0 || !chartData) return;
-    const dataIndex = elements[0].index;
+    const element = elements[0];
+    const dataIndex = element.index;
     if (dataIndex !== void 0 && dataIndex < chartData.labels.length) {
       dispatch({ type: "SET_TIME_INDEX", payload: dataIndex });
     }
@@ -34526,7 +32394,8 @@ function TimeSeriesChart() {
         }
       });
     }
-    const csvContent = [headers, ...rows, ...trendRows].map((r2) => r2.join(",")).join("\n");
+    const allRows = [headers, ...rows, ...trendRows];
+    const csvContent = allRows.map((row) => row.join(",")).join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const link = document.createElement("a");
     const url = URL.createObjectURL(blob);
@@ -34541,31 +32410,30 @@ function TimeSeriesChart() {
   const chartOptions = {
     responsive: true,
     maintainAspectRatio: false,
-    animation: { duration: 300 },
-    interaction: { mode: "index", intersect: false },
+    animation: {
+      duration: 300
+    },
+    interaction: {
+      mode: "index",
+      intersect: false
+    },
     plugins: {
       legend: {
         display: true,
         position: "top",
         labels: {
           usePointStyle: true,
-          padding: 16,
-          color: "#ffffff",
-          generateLabels: (chart) => {
+          padding: 20,
+          generateLabels: (_chart) => {
             if (!(chartData == null ? void 0 : chartData.datasets)) return [];
-            return chart.data.datasets.map((ds, index) => ({ ds, index })).filter(
-              ({ ds }) => !ds.label.endsWith(" trend") && !ds.label.endsWith(" residual") && !ds.label.includes(" sample ") && !ds.label.endsWith(" median")
-            ).map(({ ds, index }) => {
-              var _a2, _b2;
-              return {
-                text: ds.label + (ds.label && ((_b2 = (_a2 = chartData.datasets.find((d) => d.label === ds.label)) == null ? void 0 : _a2.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 ? ` (${chartData.datasets.find((d) => d.label === ds.label).trend.mmPerYear.toFixed(1)} mm/yr)` : ""),
-                pointStyle: "circle",
-                fillStyle: ds.borderColor,
-                strokeStyle: ds.borderColor,
-                lineWidth: 2,
-                datasetIndex: index
-              };
-            });
+            return chartData.datasets.map((dataset, index) => ({
+              text: `${dataset.label}${dataset.trend && dataset.trend.mmPerYear !== void 0 ? ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)` : ""}`,
+              pointStyle: "circle",
+              fillStyle: dataset.borderColor,
+              strokeStyle: dataset.borderColor,
+              lineWidth: 2,
+              datasetIndex: index
+            }));
           }
         }
       },
@@ -34573,14 +32441,14 @@ function TimeSeriesChart() {
         callbacks: {
           title: (context) => {
             var _a2;
-            return `${((_a2 = context[0]) == null ? void 0 : _a2.label) || ""}`;
+            return `Time: ${((_a2 = context[0]) == null ? void 0 : _a2.label) || ""}`;
           },
           label: (context) => {
-            var _a2, _b2;
+            var _a2;
             const dataset = (_a2 = chartData == null ? void 0 : chartData.datasets) == null ? void 0 : _a2[context.datasetIndex];
             if (!dataset) return "";
-            let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
-            if (((_b2 = dataset.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 && state.showTrends) {
+            let label = `${dataset.label}: ${context.parsed.y.toFixed(3)}`;
+            if (dataset.trend && dataset.trend.mmPerYear !== void 0 && state.showTrends) {
               label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
             }
             return label;
@@ -34591,131 +32459,65 @@ function TimeSeriesChart() {
     scales: {
       x: {
         type: "time",
-        time: { displayFormats: { month: "MMM yyyy", day: "MMM d", year: "yyyy" } },
-        title: { display: true, text: "Date" },
-        grid: { color: "rgba(255,255,255,0.1)" },
-        ticks: { color: "#aaa" }
+        time: {
+          displayFormats: {
+            month: "MMM yyyy",
+            year: "yyyy"
+          }
+        },
+        title: {
+          display: true,
+          text: "Time"
+        }
       },
       y: {
-        title: { display: true, text: "Displacement (m)" },
+        title: {
+          display: true,
+          text: "Displacement (m)"
+        },
         suggestedMin: state.vmin,
-        suggestedMax: state.vmax,
-        grid: { color: "rgba(255,255,255,0.1)" },
-        ticks: { color: "#aaa" }
+        suggestedMax: state.vmax
       }
     },
     onClick: handleChartClick
   };
-  if (!state.showChart) return null;
+  if (!state.showChart) {
+    return null;
+  }
   if (state.timeSeriesPoints.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-placeholder", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No points selected." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No time series points selected." }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("small", { children: "Click on the map to add points." }) })
     ] }) });
   }
   if (isLoading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading…" }) }) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading time series data..." }) }) });
   }
   if (!chartData || !chartData.datasets || chartData.datasets.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No data for selected points." }) }) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No data available for selected points." }) }) });
   }
-  const isoLabels = chartData.labels.map(toIsoDate);
-  const day0 = isoLabels.length > 0 ? new Date(isoLabels[0]).getTime() / 864e5 : 0;
-  const isoToDay = (iso) => new Date(iso).getTime() / 864e5 - day0;
-  const datasetList = [];
-  chartData.datasets.forEach((dataset) => {
-    const isoData = dataset.data.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y }));
-    datasetList.push({
+  const formattedChartData = {
+    labels: chartData.labels,
+    datasets: chartData.datasets.map((dataset) => ({
       label: dataset.label,
-      data: isoData,
+      data: dataset.data,
       borderColor: dataset.borderColor,
       backgroundColor: dataset.backgroundColor,
       borderWidth: 2,
-      pointRadius: 4,
-      pointHoverRadius: 6,
+      pointRadius: 3,
+      pointHoverRadius: 5,
       tension: 0.1,
       fill: false
-    });
-    if (state.showTrends && dataset.trend && isoData.length > 1) {
-      const { slope, intercept } = dataset.trend;
-      const trendData = isoData.map((pt) => ({
-        x: pt.x,
-        y: slope * isoToDay(pt.x) + intercept
-      }));
-      datasetList.push({
-        label: `${dataset.label} trend`,
-        data: trendData,
-        borderColor: dataset.borderColor,
-        backgroundColor: "transparent",
-        borderWidth: 1.5,
-        borderDash: [6, 4],
-        pointRadius: 0,
-        pointHoverRadius: 0,
-        tension: 0,
-        fill: false
-      });
-      if (state.showResiduals) {
-        const residualData = isoData.map((pt) => ({
-          x: pt.x,
-          y: pt.y - (slope * isoToDay(pt.x) + intercept)
-        }));
-        datasetList.push({
-          label: `${dataset.label} residual`,
-          data: residualData,
-          borderColor: dataset.borderColor,
-          backgroundColor: dataset.backgroundColor,
-          borderWidth: 1,
-          borderDash: [2, 3],
-          pointRadius: 2,
-          pointHoverRadius: 4,
-          tension: 0,
-          fill: false,
-          borderDashOffset: 0
-        });
-      }
-    }
-  });
-  if (state.bufferEnabled) {
-    chartData.datasets.forEach((dataset) => {
-      const buf = bufferData[dataset.pointId];
-      if (!buf) return;
-      const color2 = dataset.borderColor;
-      buf.samples.forEach((sample2, i) => {
-        datasetList.push({
-          label: `${dataset.label} sample ${i}`,
-          data: sample2.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })),
-          borderColor: color2 + "28",
-          backgroundColor: "transparent",
-          borderWidth: 1,
-          pointRadius: 0,
-          pointHoverRadius: 0,
-          tension: 0.1,
-          fill: false
-        });
-      });
-      datasetList.push({
-        label: `${dataset.label} median`,
-        data: buf.median.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })),
-        borderColor: color2,
-        backgroundColor: "transparent",
-        borderWidth: 3,
-        borderDash: [4, 3],
-        pointRadius: 0,
-        pointHoverRadius: 0,
-        tension: 0.1,
-        fill: false
-      });
-    });
-  }
-  const formattedChartData = { labels: isoLabels, datasets: datasetList };
+    }))
+  };
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "chart-container", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { children: "Time Series" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { children: "Time Series Analysis" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-controls", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",
           {
-            className: "chart-btn",
+            className: "pure-button",
             onClick: () => dispatch({ type: "TOGGLE_TRENDS" }),
             title: "Toggle trend analysis",
             children: [
@@ -34725,34 +32527,22 @@ function TimeSeriesChart() {
             ]
           }
         ),
-        state.showTrends && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",
           {
-            className: "chart-btn",
-            onClick: () => dispatch({ type: "TOGGLE_RESIDUALS" }),
-            title: "Show residuals (data minus trend)",
+            className: "pure-button",
+            onClick: handleExportToCSV,
+            title: "Export data to CSV",
             children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showResiduals ? "fa-wave-square" : "fa-chart-scatter"}` }),
-              state.showResiduals ? "Hide" : "Show",
-              " Residuals"
+              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-download" }),
+              "Export CSV"
             ]
           }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", onClick: handleExportToCSV, title: "Export data to CSV", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-download" }),
-          " CSV"
-        ] })
+        )
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-content", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: formattedChartData, options: chartOptions }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-help", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("small", { children: [
-      "Click chart points to sync map time",
-      state.bufferEnabled && Object.keys(bufferData).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-        " · Buffer: ",
-        Object.values(bufferData).map((b) => b.n_pixels).join(", "),
-        " px"
-      ] })
-    ] }) })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-help", children: /* @__PURE__ */ jsxRuntimeExports.jsx("small", { children: "Click on chart points to sync map time • Trends show mm/year rates" }) })
   ] });
 }
 function PointManagerPanel() {

--- a/build/lib/bowser/main.py
+++ b/build/lib/bowser/main.py
@@ -10,7 +10,7 @@ import matplotlib
 import numpy as np
 import rasterio
 import xarray as xr
-from fastapi import Body, FastAPI, HTTPException, Query, Response, UploadFile
+from fastapi import Body, FastAPI, HTTPException, Query, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pyproj import CRS, Transformer
 from rio_tiler.io.xarray import XarrayReader
@@ -136,10 +136,6 @@ def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
                 and "short_wave" not in str(var_name).lower()
                 and not skip_spatial_reference
             )
-            available_mask_vars = [
-                v for v in ["temporal_coherence", "phase_similarity", "recommended_mask"]
-                if v in ds.data_vars
-            ]
             dataset_info[var_name] = {
                 "name": var_name,
                 "file_list": [
@@ -153,7 +149,6 @@ def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
                 "bounds": list(bounds),
                 "latlon_bounds": list(latlon_bounds),
                 "x_values": time_values,
-                "available_mask_vars": available_mask_vars,
             }
 
     return dataset_info
@@ -211,89 +206,15 @@ async def get_variables():
     return {"variables": variables}
 
 
-def _apply_layer_masks_md(
-    da: "xr.DataArray",
-    layer_masks: list[dict],
-    time_idx: int | None = None,
-) -> "xr.DataArray":
-    """Apply a list of layer mask dicts to a DataArray (MD mode).
-
-    Each dict has keys: dataset (str), threshold (float), mode ('min'|'max').
-    'min' keeps pixels >= threshold; 'max' keeps pixels <= threshold.
-    """
-    for m in layer_masks:
-        var = m.get("dataset")
-        threshold = float(m.get("threshold", 0.5))
-        mode = m.get("mode", "min")
-        if not var or var not in XARRAY_DATASET.data_vars:
-            continue
-        mask_da = XARRAY_DATASET[var]
-        if time_idx is not None and "time" in mask_da.dims:
-            mask_da = mask_da.isel(time=time_idx)
-        if mode == "max":
-            da = da.where(mask_da <= threshold)
-        else:
-            da = da.where(mask_da >= threshold)
-    return da
-
-
-async def _get_ref_median(
-    dataset_name: str,
-    lon: float,
-    lat: float,
-    buffer_m: float = 0.0,
-    layer_masks: list[dict] | None = None,
-) -> np.ndarray:
-    """Return reference time series: buffer median when buffer_m > 0 (MD mode), else single pixel."""
-    layer_masks = layer_masks or []
-    if buffer_m <= 0 or DATA_MODE != "md":
-        return await _get_point_values(dataset_name, lon, lat, layer_masks)
-
-    if dataset_name not in XARRAY_DATASET.data_vars:
-        raise HTTPException(status_code=404, detail=f"Variable {dataset_name} not found")
-
-    from pyproj import Transformer as _T  # noqa: PLC0415
-
-    da = XARRAY_DATASET[dataset_name]
-    da = _apply_layer_masks_md(da, layer_masks)
-
-    tr = _T.from_crs(4326, XARRAY_DATASET.rio.crs, always_xy=True)
-    cx, cy = tr.transform(lon, lat)
-    res_x = float(abs(da.x[1] - da.x[0])) if da.x.size > 1 else 1.0
-    res_y = float(abs(da.y[1] - da.y[0])) if da.y.size > 1 else 1.0
-
-    x_slice = da.x.sel(x=slice(cx - buffer_m - res_x, cx + buffer_m + res_x))
-    y_slice = da.y.sel(y=slice(cy + buffer_m + res_y, cy - buffer_m - res_y))
-    if x_slice.size == 0 or y_slice.size == 0:
-        return await _get_point_values(dataset_name, lon, lat, layer_masks)
-
-    window = da.sel(x=x_slice, y=y_slice)
-    xx, yy = np.meshgrid(x_slice.values, y_slice.values)
-    in_circle = np.sqrt((xx - cx) ** 2 + (yy - cy) ** 2) <= buffer_m
-
-    arr = window.values  # (time, ny, nx)
-    arr_masked = np.where(in_circle[np.newaxis, :, :], arr, np.nan)
-    flat = arr_masked.reshape(arr.shape[0], -1)  # (time, n_pixels)
-
-    return np.nanmedian(flat, axis=1)  # (time,)
-
-
-async def _get_point_values(
-    dataset_name: str,
-    lon: float,
-    lat: float,
-    layer_masks: list[dict] | None = None,
-) -> np.ndarray:
-    """Get point values for a dataset at lon/lat, with optional MD-mode masking."""
+async def _get_point_values(dataset_name: str, lon: float, lat: float) -> np.ndarray:
+    """Get point values for a dataset at lon/lat."""
     if DATA_MODE == "md":
         if dataset_name not in XARRAY_DATASET.data_vars:
             raise HTTPException(
                 status_code=404, detail=f"Variable {dataset_name} not found"
             )
-        da = XARRAY_DATASET[dataset_name]
-        da = _apply_layer_masks_md(da, layer_masks or [])
         x, y = transformer_from_lonlat.transform(lon, lat)
-        point_data = da.sel(x=x, y=y, method="nearest")
+        point_data = XARRAY_DATASET[dataset_name].sel(x=x, y=y, method="nearest")
         return np.atleast_1d(point_data.values)
     else:  # cog mode
         if dataset_name not in RASTER_GROUPS:
@@ -387,8 +308,6 @@ async def multi_point(
     calculate_trends: bool = Body(
         False, description="Whether to calculate trend analysis"
     ),
-    layer_masks: list[dict] = Body([], description="List of {dataset, threshold, mode} mask dicts"),
-    ref_buffer_m: float = Body(0.0, description="Buffer radius (m) for median re-referencing; 0 = single pixel"),
 ):
     """Fetch time series data for multiple points efficiently."""
     # Get time values based on data mode
@@ -407,12 +326,10 @@ async def multi_point(
         rg = RASTER_GROUPS[dataset_name]
         x_values = rg.x_values
 
-    # Get reference values if provided (use buffer median when ref_buffer_m > 0)
+    # Get reference values if provided
     ref_values = None
     if ref_lon is not None and ref_lat is not None:
-        ref_values = await _get_ref_median(
-            dataset_name, ref_lon, ref_lat, ref_buffer_m, layer_masks,
-        )
+        ref_values = await _get_point_values(dataset_name, ref_lon, ref_lat)
 
     # Process each point
     results = []
@@ -428,9 +345,7 @@ async def multi_point(
 
         try:
             # Get values at the point
-            values = await _get_point_values(
-                dataset_name, float(lon), float(lat), layer_masks
-            )
+            values = await _get_point_values(dataset_name, float(lon), float(lat))
 
             # Apply reference subtraction if provided
             if ref_values is not None:
@@ -566,255 +481,6 @@ async def get_colorbar(cmap_name: str):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get(
-    "/histogram/{dataset_name}",
-    response_class=JSONResponse,
-    responses={200: {"description": "Return histogram data for one time slice"}},
-)
-async def get_histogram(
-    dataset_name: str,
-    time_index: Annotated[int, Query(ge=0)] = 0,
-    nbins: Annotated[int, Query(ge=4, le=256)] = 100,
-):
-    """Compute a histogram of valid pixel values for one time step of a dataset."""
-    if DATA_MODE == "md":
-        if dataset_name not in XARRAY_DATASET.data_vars:
-            raise HTTPException(status_code=404, detail=f"Variable {dataset_name} not found")
-        da = XARRAY_DATASET[dataset_name]
-        time_index = min(time_index, da.shape[0] - 1)
-        arr = da.isel(time=time_index).values.ravel().astype(float)
-    else:
-        if dataset_name not in RASTER_GROUPS:
-            raise HTTPException(status_code=404, detail=f"Dataset {dataset_name} not found")
-        rg = RASTER_GROUPS[dataset_name]
-        time_index = min(time_index, len(rg.file_list) - 1)
-        with rasterio.open(rg.file_list[time_index]) as src:
-            arr = src.read(1).ravel().astype(float)
-            nodata = src.nodata
-        if nodata is not None:
-            arr = arr[arr != nodata]
-
-    valid = arr[np.isfinite(arr) & (arr != 0)]
-    if valid.size == 0:
-        raise HTTPException(status_code=204, detail="No valid data")
-
-    counts, bin_edges = np.histogram(valid, bins=nbins)
-    return JSONResponse({
-        "bins": bin_edges.tolist(),
-        "counts": counts.tolist(),
-        "min": float(valid.min()),
-        "max": float(valid.max()),
-        "p2": float(np.percentile(valid, 2)),
-        "p98": float(np.percentile(valid, 98)),
-        "p16": float(np.percentile(valid, 16)),
-        "p84": float(np.percentile(valid, 84)),
-        "p23": float(np.percentile(valid, 2.275)),
-        "p977": float(np.percentile(valid, 97.725)),
-    })
-
-
-@app.post(
-    "/buffer_timeseries",
-    response_class=JSONResponse,
-    responses={200: {"description": "Return median + sampled pixel time series within a buffer"}},
-)
-async def buffer_timeseries(
-    lon: float = Body(..., description="Center longitude"),
-    lat: float = Body(..., description="Center latitude"),
-    dataset_name: str = Body(..., description="Dataset name"),
-    buffer_m: float = Body(500.0, description="Buffer radius in metres"),
-    n_samples: int = Body(10, description="Number of random pixel samples to return"),
-    ref_lon: Optional[float] = Body(None),
-    ref_lat: Optional[float] = Body(None),
-    layer_masks: list[dict] = Body([], description="List of {dataset, threshold, mode} mask dicts"),
-    ref_buffer_m: float = Body(0.0, description="Buffer radius (m) for median re-referencing; 0 = single pixel"),
-):
-    """Collect all pixels within a circular buffer, return median + random samples."""
-    if DATA_MODE == "md":
-        if dataset_name not in XARRAY_DATASET.data_vars:
-            raise HTTPException(status_code=404, detail=f"Variable {dataset_name} not found")
-        da = XARRAY_DATASET[dataset_name]
-        da = _apply_layer_masks_md(da, layer_masks)
-        x_values: list = da.time.dt.strftime("%Y-%m-%d").values.tolist()
-
-        # Project centre to dataset CRS
-        from pyproj import Transformer as _T  # noqa: PLC0415
-        tr = _T.from_crs(4326, XARRAY_DATASET.rio.crs, always_xy=True)
-        cx, cy = tr.transform(lon, lat)
-
-        res_x = float(abs(da.x[1] - da.x[0])) if da.x.size > 1 else 1.0
-        res_y = float(abs(da.y[1] - da.y[0])) if da.y.size > 1 else 1.0
-
-        # Select spatial window
-        x_slice = da.x.sel(x=slice(cx - buffer_m - res_x, cx + buffer_m + res_x))
-        y_slice = da.y.sel(y=slice(cy + buffer_m + res_y, cy - buffer_m - res_y))
-        if x_slice.size == 0 or y_slice.size == 0:
-            raise HTTPException(status_code=404, detail="Buffer outside dataset extent")
-
-        window = da.sel(x=x_slice, y=y_slice)
-        # Circular mask
-        xx, yy = np.meshgrid(x_slice.values, y_slice.values)
-        dist = np.sqrt((xx - cx) ** 2 + (yy - cy) ** 2)
-        in_circle = dist <= buffer_m  # (ny, nx)
-
-        # Stack time series for valid pixels: shape (time, n_valid)
-        arr = window.values  # (time, ny, nx)
-        mask2d = in_circle[np.newaxis, :, :]
-        arr_masked = np.where(mask2d, arr, np.nan)  # (time, ny, nx)
-        flat = arr_masked.reshape(arr.shape[0], -1)  # (time, n_pixels)
-
-        # Reference subtraction (use buffer median when ref_buffer_m > 0)
-        if ref_lon is not None and ref_lat is not None:
-            ref_vals = await _get_ref_median(
-                dataset_name, ref_lon, ref_lat, ref_buffer_m, layer_masks,
-            )
-            flat = flat - ref_vals[:, np.newaxis]
-
-    else:
-        if dataset_name not in RASTER_GROUPS:
-            raise HTTPException(status_code=404, detail=f"Dataset {dataset_name} not found")
-        rg = RASTER_GROUPS[dataset_name]
-        x_values = rg.x_values
-
-        reader0 = rg._reader.readers[0]
-        tr_from = reader0._transformer_from_lonlat
-        cx, cy = tr_from.transform(lon, lat)
-        tf = reader0.transform
-        res_x = abs(tf.a)
-        res_y = abs(tf.e)
-
-        # Pixel radius
-        pr_x = int(np.ceil(buffer_m / res_x))
-        pr_y = int(np.ceil(buffer_m / res_y))
-        row_c, col_c = reader0._lonlat_to_rowcol(lon, lat)
-        r0, r1 = max(0, row_c - pr_y), min(reader0.shape[0], row_c + pr_y + 1)
-        c0, c1 = max(0, col_c - pr_x), min(reader0.shape[1], col_c + pr_x + 1)
-
-        rows, cols = np.meshgrid(np.arange(r0, r1), np.arange(c0, c1), indexing='ij')
-        xs = tf.c + (cols + 0.5) * tf.a
-        ys = tf.f + (rows + 0.5) * tf.e
-        dist = np.sqrt((xs - cx) ** 2 + (ys - cy) ** 2)
-        in_circle = (dist <= buffer_m).ravel()
-
-        # Read full stack for window — shape (T, ny, nx) via slicing
-        T = len(rg.file_list)
-        ny, nx = r1 - r0, c1 - c0
-        flat_full = np.full((T, ny * nx), np.nan)
-        for t_idx in range(T):
-            with rasterio.open(rg.file_list[t_idx]) as src:
-                nodata = src.nodata
-                patch = src.read(1, window=rasterio.windows.Window(c0, r0, nx, ny)).astype(float)
-                if nodata is not None:
-                    patch[patch == nodata] = np.nan
-                flat_full[t_idx] = patch.ravel()
-        flat = flat_full[:, in_circle]
-
-        if ref_lon is not None and ref_lat is not None:
-            ref_vals = await _get_point_values(dataset_name, ref_lon, ref_lat)
-            flat = flat - ref_vals[:, np.newaxis]
-
-    # Drop columns (pixels) that are all NaN
-    valid_cols = ~np.all(np.isnan(flat), axis=0)
-    flat = flat[:, valid_cols]
-    if flat.shape[1] == 0:
-        raise HTTPException(status_code=404, detail="No valid pixels in buffer")
-
-    median_ts = np.nanmedian(flat, axis=1).tolist()
-
-    # Random sample (up to n_samples)
-    rng = np.random.default_rng(42)
-    n_actual = min(n_samples, flat.shape[1])
-    sample_idx = rng.choice(flat.shape[1], size=n_actual, replace=False)
-    samples = flat[:, sample_idx].T.tolist()  # list of n_actual time series
-
-    return JSONResponse({
-        "labels": x_values,
-        "median": [{"x": x, "y": float(v)} for x, v in zip(x_values, median_ts) if not np.isnan(v)],
-        "samples": [
-            [{"x": x, "y": float(v)} for x, v in zip(x_values, ts) if not np.isnan(v)]
-            for ts in samples
-        ],
-        "n_pixels": int(flat.shape[1]),
-    })
-
-
-@app.post(
-    "/profile",
-    response_class=JSONResponse,
-    responses={200: {"description": "Return values along a line profile"}},
-)
-async def extract_profile(
-    coords: list[list[float]] = Body(..., description="List of [lon, lat] pairs"),
-    dataset_name: str = Body(..., description="Dataset name"),
-    time_index: int = Body(0, description="Time index"),
-    n_samples: int = Body(200, description="Number of samples along line"),
-):
-    """Sample raster values along a polyline and return distance + value pairs."""
-    from pyproj import Geod  # noqa: PLC0415
-
-    if len(coords) < 2:
-        raise HTTPException(status_code=422, detail="Need at least 2 coordinate pairs")
-    time_index = max(0, time_index)
-    lons = [c[0] for c in coords]
-    lats = [c[1] for c in coords]
-    geod = Geod(ellps="WGS84")
-
-    # Cumulative geodesic distances along segments
-    seg_dists: list[float] = [0.0]
-    for i in range(1, len(lons)):
-        _, _, d = geod.inv(lons[i - 1], lats[i - 1], lons[i], lats[i])
-        seg_dists.append(seg_dists[-1] + float(d))
-    total_dist = seg_dists[-1]
-    if total_dist == 0:
-        raise HTTPException(status_code=422, detail="Zero-length line")
-
-    sample_dists = np.linspace(0, total_dist, n_samples)
-    results: list[dict] = []
-    for sd in sample_dists:
-        seg_idx = int(np.clip(np.searchsorted(seg_dists, sd, side="right") - 1, 0, len(lons) - 2))
-        frac = (sd - seg_dists[seg_idx]) / max(seg_dists[seg_idx + 1] - seg_dists[seg_idx], 1e-9)
-        slon = lons[seg_idx] + frac * (lons[seg_idx + 1] - lons[seg_idx])
-        slat = lats[seg_idx] + frac * (lats[seg_idx + 1] - lats[seg_idx])
-        try:
-            if DATA_MODE == "md":
-                if dataset_name not in XARRAY_DATASET.data_vars:
-                    continue
-                da = XARRAY_DATASET[dataset_name]
-                if "time" in da.dims and time_index < da.shape[0]:
-                    da = da.isel(time=time_index)
-                x_c, y_c = transformer_from_lonlat.transform(slon, slat)
-                val = float(da.sel(x=x_c, y=y_c, method="nearest").values)
-            else:
-                if dataset_name not in RASTER_GROUPS:
-                    continue
-                rg = RASTER_GROUPS[dataset_name]
-                t = min(time_index, len(rg.file_list) - 1)
-                val = float(np.atleast_1d(rg._reader.readers[t].read_lonlat(slon, slat))[0])
-            if np.isfinite(val):
-                results.append({"dist": float(sd), "value": val})
-        except Exception:
-            continue
-    return JSONResponse(results)
-
-
-# Upload directory for custom masks
-_UPLOAD_DIR = Path(os.environ.get("BOWSER_UPLOAD_DIR", "/tmp/bowser_masks"))
-_UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-
-
-@app.post(
-    "/upload_mask",
-    response_class=JSONResponse,
-    responses={200: {"description": "Upload a GeoTIFF mask file and return its server path"}},
-)
-async def upload_mask(file: UploadFile):
-    """Accept a GeoTIFF mask upload and store it for use in masking."""
-    import uuid  # noqa: PLC0415
-    dest = _UPLOAD_DIR / f"mask_{uuid.uuid4().hex}.tif"
-    dest.write_bytes(await file.read())
-    return JSONResponse({"path": str(dest)})
-
-
 # Set up CORS
 app.add_middleware(
     CORSMiddleware,
@@ -846,61 +512,16 @@ PostProcessParams: Callable = algorithms.dependency
 # Set up routing based on data mode
 # if DATA_MODE == "cog":
 # COG mode: use RasterGroup approach
-# Ordered lists of RasterGroup names to search for each mask type in COG mode.
-_COG_COHERENCE_NAMES  = ["Temporal coherence", "Average temporal coherence", "(Pseudo) correlation"]
-_COG_SIMILARITY_NAMES = ["Phase cosine similarity", "Phase cosine similarity (full)"]
-
-
-def _cog_mask_file(group_names: list[str], time_idx: int) -> str | None:
-    """Return the file path for the first matching RasterGroup at time_idx."""
-    for name in group_names:
-        if name in RASTER_GROUPS:
-            fl = RASTER_GROUPS[name].file_list
-            if fl:
-                return fl[min(time_idx, len(fl) - 1)]
-    return None
-
-
 def InputDependency(
     url: Annotated[str, Query(description="Dataset URL")],
     mask: Annotated[str | None, Query(description="Mask URL")] = None,
     mask_min_value: Annotated[float, Query(description="Mask Minimum Value")] = 0.1,
-    custom_mask: Annotated[str | None, Query(description="Custom mask GeoTIFF path")] = None,
-    layer_masks: Annotated[str | None, Query(description="JSON list of {dataset,threshold,mode} mask dicts")] = None,
-    time_idx: Annotated[int, Query(description="Time index for resolving mask files")] = 0,
 ) -> dict:
     """Create dataset path from args."""
-    extra_masks: list[tuple[str, float]] = []
-    if custom_mask and Path(custom_mask).exists():
-        extra_masks.append((custom_mask, 0.5))
-
-    if layer_masks:
-        try:
-            masks = json.loads(layer_masks)
-            for m in masks:
-                dataset = m.get("dataset")
-                threshold = float(m.get("threshold", 0.5))
-                mode = m.get("mode", "min")
-                if not dataset or dataset not in RASTER_GROUPS:
-                    continue
-                fl = RASTER_GROUPS[dataset].file_list
-                if not fl:
-                    continue
-                f = fl[min(time_idx, len(fl) - 1)]
-                # For 'max' mode (keep <= threshold), we invert: mask out pixels > threshold
-                # CustomReader extra_masks keeps pixels where value > min_value, so for 'max'
-                # we can't natively invert — pass None to skip (tile-level COG 'max' not supported)
-                if mode == "min":
-                    extra_masks.append((f, threshold))
-                # 'max' mode skipped for COG tiles (no inversion support in CustomReader)
-        except (json.JSONDecodeError, Exception) as e:
-            logger.warning(f"Failed to parse layer_masks: {e}")
-
     return {
         "data": url,
         "mask": mask,
         "mask_min_value": mask_min_value,
-        "extra_masks": extra_masks,
     }
 
 
@@ -922,8 +543,6 @@ def XarrayPathDependency(
     time_idx: Optional[int] = Query(None, description="Time index"),
     mask_variable: Optional[str] = Query(None, description="Mask variable"),
     mask_min_value: float = Query(0.1, description="Mask minimum value"),
-    layer_masks: Optional[str] = Query(None, description="JSON list of {dataset,threshold,mode} mask dicts"),
-    custom_mask_path: Optional[str] = Query(None, description="Path to uploaded custom mask GeoTIFF"),
 ) -> xr.DataArray:
     """Create a DataArray from query parameters."""
     da = XARRAY_DATASET[variable]
@@ -937,33 +556,14 @@ def XarrayPathDependency(
     else:
         mask_da = None
 
-    # Resolve time
-    if time_idx is not None and "time" in da.dims:
-        da = da.sel(time=XARRAY_DATASET.time[time_idx])
+    if time_idx is None or "time" not in da.dims:
         if mask_da is not None:
-            mask_da = mask_da.sel(time=XARRAY_DATASET.time[time_idx])
-
-    # Apply primary mask
+            da = da.where(mask_da > mask_min_value)
+        return da
+    da = da.sel(time=XARRAY_DATASET.time[time_idx])
     if mask_da is not None:
-        da = da.where(mask_da > mask_min_value)
-
-    # Apply layer masks
-    if layer_masks:
-        try:
-            da = _apply_layer_masks_md(da, json.loads(layer_masks), time_idx)
-        except (json.JSONDecodeError, Exception) as e:
-            logger.warning(f"Failed to apply layer_masks: {e}")
-
-    # Custom mask (uploaded GeoTIFF) — reproject to match da
-    if custom_mask_path and Path(custom_mask_path).exists():
-        try:
-            import rioxarray as rxr  # noqa: PLC0415
-            custom_da = rxr.open_rasterio(custom_mask_path, masked=True).squeeze("band", drop=True)
-            custom_da_repr = custom_da.rio.reproject_match(da)
-            da = da.where(custom_da_repr > 0)
-        except Exception as exc:
-            logger.warning(f"Failed to apply custom mask {custom_mask_path}: {exc}")
-
+        mask_da = mask_da.sel(time=XARRAY_DATASET.time[time_idx])
+        return da.where(mask_da > mask_min_value)
     return da
 
 

--- a/build/lib/bowser/readers.py
+++ b/build/lib/bowser/readers.py
@@ -487,16 +487,10 @@ class CustomReader(BaseReader):
     def __attrs_post_init__(self):
         """Define _kwargs, open dataset and get info."""
         self.dataset = self._ctx_stack.enter_context(Reader(self.input["data"]))
-        if self.input.get("mask"):
+        if self.input["mask"]:
             self.mask = self._ctx_stack.enter_context(Reader(self.input["mask"]))
         else:
             self.mask = None
-
-        # Open extra masks (e.g. custom uploaded masks)
-        self._extra_masks: list[tuple[Any, float]] = []
-        for mask_path, mask_min in self.input.get("extra_masks", []):
-            reader = self._ctx_stack.enter_context(Reader(mask_path))
-            self._extra_masks.append((reader, mask_min))
 
         self.bounds = self.dataset.bounds
         self.crs = self.dataset.crs
@@ -548,32 +542,33 @@ class CustomReader(BaseReader):
             **kwargs,
         )
 
-        combined_mask = img.mask == 0  # True = invalid
-
-        # Apply primary mask
+        # https://rasterio.readthedocs.io/en/stable/topics/masks.html#nodata-representations-in-raster-files
         if self.mask is not None:
             mask_layer_img = self.mask.tile(
-                tile_x, tile_y, tile_z, tilesize, indexes=1, **kwargs,
+                tile_x,
+                tile_y,
+                tile_z,
+                tilesize,
+                indexes=1,
+                **kwargs,
             )
-            filled = np.squeeze(mask_layer_img.array.filled(0))
-            combined_mask = np.logical_or.reduce([
-                combined_mask,
-                filled == 0,
-                filled < self.input["mask_min_value"],
-            ])
 
-        # Apply extra masks (custom uploaded masks — binary: > 0 = valid)
-        for extra_reader, extra_min in self._extra_masks:
-            try:
-                extra_img = extra_reader.tile(
-                    tile_x, tile_y, tile_z, tilesize, indexes=1, **kwargs,
-                )
-                extra_filled = np.squeeze(extra_img.array.filled(0))
-                combined_mask = np.logical_or(combined_mask, extra_filled <= extra_min)
-            except Exception:
-                pass  # tile outside bounds — skip
+            # Combine the invalid pixels of `.mask` and `.img`
+            bad_image_pixels = img.mask == 0
+            # img.mask has "valid" = 255, "invalid" = 0
+            # need to convert it to numpy style
+            filled_mask_layer = np.squeeze(mask_layer_img.array.filled(0))
+            bad_mask_pixels = filled_mask_layer == 0
 
-        if np.any(combined_mask != (img.mask == 0)):
+            # Also mask out the pixels which don't pass the threshold
+            pixels_below_threshold = filled_mask_layer < self.input["mask_min_value"]
+            combined_mask = np.logical_or.reduce(
+                [
+                    bad_image_pixels,
+                    bad_mask_pixels,
+                    pixels_below_threshold,
+                ]
+            )
             img = ImageData(
                 np.ma.MaskedArray(img.data, mask=combined_mask),
                 assets=img.assets,

--- a/build/lib/bowser/titiler.py
+++ b/build/lib/bowser/titiler.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+from glob import glob
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import simplejson
+from pydantic import BaseModel, computed_field, field_validator
+from rio_tiler.models import ImageData
+from starlette import responses
+from titiler.core.algorithm import BaseAlgorithm
+
+from .readers import RasterStackReader
+from .utils import list_bucket
+
+# TODO: Prep COGS with
+#  for f in `ls ig*[0-9].tif`; do
+#    gdal_translate DERIVED_SUBDATASET:PHASE:$f phase_${f/.tif/.vrt};
+#  done
+
+
+class Algorithm(str, Enum):
+    """Available algorithms."""
+
+    PHASE = "phase"
+    AMPLITUDE = "amplitude"
+    SHIFT = "shift"
+    REWRAP = "rewrap"
+
+
+class Phase(BaseAlgorithm):
+    """Creation algorithm for the phase of a complex raster."""
+
+    def __call__(self, img: ImageData) -> ImageData:  # noqa: D102
+        return _process_complex(img, np.angle)
+
+
+class Amplitude(BaseAlgorithm):
+    """Custom tile creation algorithm for amplitude of complex data."""
+
+    def __call__(self, img: ImageData) -> ImageData:  # noqa: D102
+        return _process_complex(img, np.abs)
+
+
+class Rewrap(BaseAlgorithm):
+    """Creation algorithm for re-wrapping unwrapped phase to (-pi, pi)."""
+
+    scale_factor: float = 1.0
+
+    def __call__(self, img: ImageData) -> ImageData:  # noqa: D102
+        return ImageData(
+            np.ma.mod(np.pi + (self.scale_factor * img.array), 2 * np.pi) - np.pi,
+            # img. - self.shift,
+            # np.ma.MaskedArray(data, mask=~mask),
+            assets=img.assets,
+            crs=img.crs,
+            bounds=img.bounds,
+        )
+
+
+def _process_complex(
+    img: ImageData, func: Callable[[np.ndarray], np.ndarray]
+) -> ImageData:
+    """Tile algorithm for derived statistics of a complex raster.
+
+    See https://developmentseed.org/titiler/examples/code/tiler_with_custom_algorithm/
+    """
+    data = func(img.data)
+    # Mask at 0  in addition to current mask
+    mask = np.logical_or(np.isnan(data), data == 0)
+
+    # Create output ImageData
+    return ImageData(
+        np.ma.MaskedArray(data, mask=mask),
+        assets=img.assets,
+        crs=img.crs,
+        bounds=img.bounds,
+    )
+
+
+class Shift(BaseAlgorithm):
+    """Apply a simple shift (to subtract a reference point."""
+
+    # Parameters
+    shift: float | None = 0
+    nan_to_zero: bool = True
+
+    def __call__(self, img: ImageData) -> ImageData:  # noqa: D102
+        shift = np.nan_to_num(self.shift or 0) if self.nan_to_zero else self.shift
+        return ImageData(
+            img.array - shift,
+            assets=img.assets,
+            crs=img.crs,
+            bounds=img.bounds,
+        )
+
+
+class RasterGroup(BaseModel):
+    """A group of rasters to view."""
+
+    name: str
+    file_list: list[str | Path]
+    mask_file_list: list[str | Path] = []
+    nodata: float | None = None
+    uses_spatial_ref: bool = False
+    algorithm: str | None = None
+    mask_min_value: float = 0.1
+    file_date_fmt: str | None = "%Y%m%d"
+    _reader: RasterStackReader
+    _disable_tqdm: bool = True
+
+    @field_validator("file_list")
+    @classmethod
+    def _ensure_string(cls, v: Any):
+        return list(map(os.fspath, v))
+
+    def model_post_init(self, __context: Any) -> None:  # noqa: D102
+        super().model_post_init(__context)
+
+        self._reader = RasterStackReader.from_file_list(
+            self.file_list,
+            bands=1,
+            keep_open=False,
+            num_threads=3,
+            nodata=self.nodata,
+            file_date_fmt=self.file_date_fmt,
+            disable_tqdm=self._disable_tqdm,
+        )
+
+    @computed_field
+    def bounds(self) -> tuple[float, float, float, float]:
+        """Project (left, bottom, right, top) bounds in the raster's CRS."""
+        return self._reader.bounds
+
+    @computed_field
+    def latlon_bounds(self) -> tuple[float, float, float, float]:
+        """Geographical (left, bottom, right, top) bounds of the raster group."""
+        return self._reader.latlon_bounds
+
+    # @functools.cached_property
+    @computed_field
+    def x_values(self) -> list[str | int]:
+        """Vales to use for the x axis of a time series plot."""
+        # if len(self.file_list) == 1:
+        dates = self._reader.dates
+        if not dates or any(d is None for d in dates):
+            # otherwise, use indexes
+            x_values = np.arange(len(self.file_list)).tolist()
+        else:
+            x_values = [_format_dates(*k) for k in dates]  # type: ignore[misc]
+
+        return x_values
+
+    @classmethod
+    def from_glob(
+        cls,
+        glob_str: str,
+        *,
+        name: str,
+        algorithm: str | None = None,
+        nodata: float | None = None,
+    ) -> RasterGroup:
+        """Construct a RasterGroup from a glob string.
+
+        Can be either a local path, or an s3 url.
+        """
+        file_list = _find_files(glob_str)
+        if not file_list:
+            raise ValueError("No files found.")
+
+        return cls(
+            name=name,
+            file_list=_find_files(glob_str),
+            algorithm=algorithm,
+            nodata=nodata,
+        )
+
+
+def _find_files(glob_str: str) -> list[str]:
+    if "*" not in glob_str:
+        file_list = [glob_str]
+    elif glob_str.startswith("s3://"):
+        # Need to split the '*' from the rest of the path
+        file_list = list_bucket(full_bucket_glob=glob_str)
+    else:
+        file_list = sorted(glob(glob_str))
+    return file_list
+
+
+def _format_dates(*dates, fmt="%Y%m%d") -> str:
+    return "_".join(f"{d.strftime(fmt)}" for d in dates)
+
+
+# https://github.com/developmentseed/titiler/blob/0fddd7ed268557e82a5e1520cdd7fdf084afa1b8/src/titiler/core/titiler/core/resources/responses.py#L15
+class JSONResponse(responses.JSONResponse):
+    """Custom JSON Response."""
+
+    def render(self, content: Any) -> bytes:
+        """Render JSON.
+
+        Same defaults as starlette.responses.JSONResponse.render but allow NaN
+        to be replaced by null using simplejson
+        """
+        return simplejson.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=None,
+            separators=(",", ":"),
+            ignore_nan=True,
+        ).encode("utf-8")

--- a/build/lib/bowser/utils.py
+++ b/build/lib/bowser/utils.py
@@ -1,0 +1,251 @@
+import json
+import subprocess
+from datetime import datetime
+from functools import cache
+from typing import Sequence, TypeVar
+
+import numpy as np
+from dateutil import parser
+from scipy import stats
+
+
+class CredentialsError(Exception):
+    """Raised when AWS credentials have expired."""
+
+
+DateOrDatetimeT = TypeVar("DateOrDatetimeT", datetime, np.datetime64)
+
+
+def _parse_x_values(x_values: list[str | int]) -> np.ndarray:
+    """Parse x_values to get numeric time values in days.
+
+    Parameters
+    ----------
+    x_values : list[str | int]
+        List of x values which can be:
+        - integers (no time information)
+        - datetime strings in "%Y-%m-%d" format (xarray mode)
+        - datetime strings in "%Y%m%d" or "%Y%m%d_%Y%m%d" format (COG mode)
+
+    Returns
+    -------
+    np.ndarray
+        Numeric time values in days since first time value
+
+    """
+    if not x_values:
+        return np.array([])
+
+    # If x_values are integers, just use them as-is
+    if isinstance(x_values[0], int):
+        return np.array(x_values, dtype=float)
+
+    # Otherwise, parse datetime strings
+    dates = []
+    for x in x_values:
+        if isinstance(x, str) and "_" in x:
+            # Multiple dates in the string (e.g., "20160708_20160801")
+            # Use index 1 (second date) as per requirement
+            parts = x.split("_")
+            date_str = parts[1] if len(parts) > 1 else parts[0]
+        elif isinstance(x, int):
+            date_str = str(x)
+        else:
+            date_str = x
+
+        try:
+            date = parser.parse(date_str)
+            dates.append(date)
+        except ValueError as e:
+            raise ValueError(f"Could not parse date string: {date_str}") from e
+
+    return datetime_to_float(dates)
+
+
+def calculate_trend(
+    values: np.ndarray, x_values: list[str | int | DateOrDatetimeT]
+) -> dict[str, float]:
+    """Calculate linear trend for time series data.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Time series values (e.g., displacement in meters)
+    x_values : list[str | int]
+        Time values as strings (datetime format) or integers
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary with slope (m/day), intercept (m), r_squared, and mm_per_year
+
+    """
+    # Filter out NaN values
+    valid_mask = ~np.isnan(values)
+    if valid_mask.sum() < 2:
+        return {
+            "slope": 0.0,
+            "intercept": 0.0,
+            "r_squared": 0.0,
+            "mm_per_year": 0.0,
+        }
+
+    valid_values = values[valid_mask]
+
+    # Parse x_values to get numeric time values in days
+    time_days = _parse_x_values(x_values)
+    valid_time = time_days[valid_mask]
+
+    # Calculate linear regression using actual time values
+    slope, intercept, r_value, p_value, std_err = stats.linregress(
+        valid_time, valid_values
+    )
+
+    # Convert slope to mm/year
+    # slope is in meters/day, so convert to mm/year
+    mm_per_year = slope * 1000 * 365.25
+
+    return {
+        "slope": float(slope),
+        "intercept": float(intercept),
+        "r_squared": float(r_value**2),
+        "mm_per_year": float(mm_per_year),
+    }
+
+
+def datetime_to_float(dates: Sequence[DateOrDatetimeT]) -> np.ndarray:
+    """Convert a sequence of datetime objects to a float representation.
+
+    Output units are in days since the first item in `dates`.
+
+    Parameters
+    ----------
+    dates : Sequence[DateOrDatetimeT]
+        List of datetime objects to convert to floats
+
+    Returns
+    -------
+    date_arr : np.array 1D
+        The float representation of the datetime objects
+
+    """
+    sec_per_day = 60 * 60 * 24
+    date_arr = np.asarray(dates).astype("datetime64[s]")
+    # Reference the 0 to the first date
+    date_arr = date_arr - date_arr[0]
+    return date_arr.astype(float) / sec_per_day
+
+
+def list_bucket(
+    bucket: str | None = None,
+    prefix: str | None = None,
+    suffix: str | None = None,
+    full_bucket_glob: str | None = None,
+    aws_profile: str | None = None,
+    num_workers: int = 10,
+) -> list[str]:
+    """Use `s5cmd` to quickly list items in a bucket.
+
+    Parameters
+    ----------
+    bucket : str
+        Name of the bucket.
+    prefix : str, optional
+        Prefix to filter by, by default "".
+    suffix : str, optional
+        Suffix to filter by, by default "".
+    full_bucket_glob : str, optional
+        Alternate to prefix/suffix. Full glob to filter by, by default None.
+    aws_profile : str, optional
+        AWS profile to use, by default None.
+    num_workers : int, default = 10
+        Number of workers to use for parallel downloads.
+
+    Returns
+    -------
+    list[str]
+        List of items in the bucket.
+
+    """
+    cmd = ["s5cmd", "--json", "--numworkers", str(num_workers)]
+    if aws_profile:
+        cmd += ["--profile", aws_profile]
+
+    if full_bucket_glob:
+        bucket_str = full_bucket_glob
+    else:
+        bucket_str = f"s3://{bucket}"
+        if prefix:
+            bucket_str += f"/{prefix}"
+        if suffix:
+            bucket_str += f"*{suffix}"
+    cmd += ["ls", bucket_str.strip()]
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=90)
+    except subprocess.CalledProcessError as e:
+        if "ExpiredToken" in e.stderr:
+            raise CredentialsError(
+                "Error downloading files: AWS credentials have expired."
+            ) from e
+        raise RuntimeError(f"Error listing bucket {bucket_str}: {e.stderr}") from e
+
+    out: list[str] = []
+    for line in p.stdout.splitlines():
+        item = json.loads(line)
+        if item["type"] == "directory":
+            continue
+        out.append(item["key"])
+    return out
+
+
+@cache
+def generate_colorbar(cmap_name: str) -> bytes:
+    """Generate a colorbar image using a specified matplotlib colormap.
+
+    Parameters
+    ----------
+    cmap_name : str
+        Name of the colormap to be used.
+
+    Returns
+    -------
+    bytes
+        WEBP image data as bytes
+
+    """
+    from io import BytesIO
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    gradient = np.array([[0, 1]])
+    fig, ax = plt.subplots(figsize=(9, 1.5))
+    ax.imshow(gradient, cmap=cmap_name)
+    ax.set_visible(False)
+
+    # Create colorbar in a tightly fitted axis
+    cax = fig.add_axes([0.05, 0.2, 0.9, 0.6])
+    colorbar = plt.colorbar(
+        ax.imshow(gradient, cmap=cmap_name), cax=cax, orientation="horizontal"
+    )
+    colorbar.set_ticks([])
+
+    # Adjust subplot parameters and apply tight layout
+    plt.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
+    buf = BytesIO()
+    plt.savefig(buf, format="webp", bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+    buf.seek(0)
+    return buf.read()
+
+
+def desensitize_mpl_case():
+    """Make `cmap` case insensitive by registering repeated cmap names."""
+    import matplotlib as mpl
+
+    cmap_names = list(mpl.colormaps)
+    for name in cmap_names:
+        if name.lower() in mpl.colormaps:
+            continue
+        mpl.colormaps.register(mpl.colormaps[name], name=name.lower())

--- a/build/lib/components/App.tsx
+++ b/build/lib/components/App.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import { AppProvider, useAppContext } from '../context/AppContext';
+import { useApi } from '../hooks/useApi';
+import MapContainer from './MapContainer';
+import ControlPanel from './ControlPanel';
+import TimeSeriesChart from './TimeSeriesChart';
+import PointManagerPanel from './PointManagerPanel';
+import '../style.css';
+
+function AppContent() {
+  const { state, dispatch } = useAppContext();
+  const { fetchDatasets, fetchDataMode } = useApi();
+
+  useEffect(() => {
+    const initializeApp = async () => {
+      try {
+        // Fetch data mode first
+        const mode = await fetchDataMode();
+        dispatch({ type: 'SET_DATA_MODE', payload: mode });
+
+        // Then fetch datasets
+        const datasets = await fetchDatasets();
+        dispatch({ type: 'SET_DATASETS', payload: datasets });
+
+        // Set initial dataset and position
+        const firstDataset = Object.keys(datasets)[0];
+        if (firstDataset) {
+          dispatch({ type: 'SET_CURRENT_DATASET', payload: firstDataset });
+
+          // Compute center from bounds
+          const bounds = datasets[firstDataset].latlon_bounds;
+          const centerLat = (bounds[1] + bounds[3]) / 2;
+          const centerLng = (bounds[0] + bounds[2]) / 2;
+
+          // Set reference marker position
+          dispatch({ type: 'SET_REF_MARKER_POSITION', payload: [centerLat, centerLng] });
+        }
+      } catch (error) {
+        console.error('Error initializing app:', error);
+      }
+    };
+
+    initializeApp();
+  }, [fetchDatasets, fetchDataMode, dispatch]);
+
+  return (
+    <div className="app-container">
+      <ControlPanel />
+      <div className="map-container">
+        <MapContainer />
+        <PointManagerPanel />
+        {state.showChart && <TimeSeriesChart />}
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <AppProvider>
+      <AppContent />
+    </AppProvider>
+  );
+}

--- a/build/lib/components/ControlPanel.tsx
+++ b/build/lib/components/ControlPanel.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useAppContext } from '../context/AppContext';
+import { baseMaps } from '../basemap';
+import { useApi } from '../hooks/useApi';
+
+const colormapOptions = [
+  { value: 'rdbu_r', label: 'Blue-Red' },
+  { value: 'twilight', label: 'Twilight (cyclic)' },
+  { value: 'cfastie', label: 'CFastie' },
+  { value: 'rplumbo', label: 'RPlumbo' },
+  { value: 'schwarzwald', label: 'Schwarzwald (elevation)' },
+  { value: 'viridis', label: 'Viridis' },
+  { value: 'bugn', label: 'Blue-Green' },
+  { value: 'ylgn', label: 'Yellow-Green' },
+  { value: 'magma', label: 'Magma' },
+  { value: 'gist_earth', label: 'Earth' },
+  { value: 'ocean', label: 'Ocean' },
+  { value: 'terrain', label: 'Terrain' },
+];
+
+export default function ControlPanel() {
+  const { state, dispatch } = useAppContext();
+  const { fetchPointTimeSeries } = useApi();
+
+  // Local controlled drafts so users can type partial numbers like "-0."
+  const [draftVmin, setDraftVmin] = useState(String(state.vmin));
+  const [draftVmax, setDraftVmax] = useState(String(state.vmax));
+
+  // Keep drafts in sync when state changes from outside (dataset swap, loadPreferences, etc.)
+  useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
+  useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
+
+  // Persist *current* state to localStorage whenever it changes
+  useEffect(() => {
+    const datasetName = state.currentDataset;
+    if (!datasetName) return;
+
+    const safeNumToString = (x: number) => (Object.is(x, -0) ? '-0' : String(x));
+
+    localStorage.setItem(`${datasetName}-colormap_name`, state.colormap);
+    localStorage.setItem(`${datasetName}-vmin`, safeNumToString(state.vmin));
+    localStorage.setItem(`${datasetName}-vmax`, safeNumToString(state.vmax));
+  }, [state.currentDataset, state.colormap, state.vmin, state.vmax]);
+
+  // On first load / dataset change, read preferences and push into state once
+  useEffect(() => {
+    const datasetName = state.currentDataset;
+    if (!datasetName) return;
+
+    const colormap = localStorage.getItem(`${datasetName}-colormap_name`);
+    const vminStr = localStorage.getItem(`${datasetName}-vmin`);
+    const vmaxStr = localStorage.getItem(`${datasetName}-vmax`);
+
+    if (colormap) dispatch({ type: 'SET_COLORMAP', payload: colormap });
+
+    if (vminStr !== null) {
+      const v = Number(vminStr);
+      if (!Number.isNaN(v)) dispatch({ type: 'SET_VMIN', payload: v });
+    }
+    if (vmaxStr !== null) {
+      const v = Number(vmaxStr);
+      if (!Number.isNaN(v)) dispatch({ type: 'SET_VMAX', payload: v });
+    }
+  }, [state.currentDataset, dispatch]);
+
+  const handleDatasetChange = (datasetName: string) => {
+    dispatch({ type: 'SET_CURRENT_DATASET', payload: datasetName });
+
+    const currentDatasetInfo = state.datasetInfo[datasetName];
+    if (currentDatasetInfo?.uses_spatial_ref && !state.refValues[datasetName]) {
+      setRefValues(datasetName);
+    }
+  };
+
+  const handleTimeIndexChange = (newIndex: number) => {
+    dispatch({ type: 'SET_TIME_INDEX', payload: newIndex });
+  };
+
+  const handleColormapChange = (colormap: string) => {
+    dispatch({ type: 'SET_COLORMAP', payload: colormap });
+  };
+
+  const commitVmin = useCallback(() => {
+    const v = Number(draftVmin);
+    if (!Number.isNaN(v)) {
+      dispatch({ type: 'SET_VMIN', payload: v });
+    }
+  }, [draftVmin, dispatch]);
+
+  const commitVmax = useCallback(() => {
+    const v = Number(draftVmax);
+    if (!Number.isNaN(v)) {
+      dispatch({ type: 'SET_VMAX', payload: v });
+    }
+  }, [draftVmax, dispatch]);
+
+  const handleOpacityChange = (opacity: number) => {
+    dispatch({ type: 'SET_OPACITY', payload: opacity });
+  };
+
+  const handleBasemapChange = (basemapKey: string) => {
+    dispatch({ type: 'SET_BASEMAP', payload: basemapKey });
+  };
+
+  const toggleChart = () => {
+    dispatch({ type: 'TOGGLE_CHART' });
+  };
+
+  const setRefValues = async (datasetName: string) => {
+    const [lat, lng] = state.refMarkerPosition;
+    try {
+      const values = await fetchPointTimeSeries(lng, lat, datasetName);
+      if (values) {
+        dispatch({
+          type: 'SET_REF_VALUES',
+          payload: { dataset: datasetName, values }
+        });
+      }
+    } catch (error) {
+      console.error('Error setting reference values:', error);
+    }
+  };
+
+  const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
+  const currentTimeValue = currentDatasetInfo ? currentDatasetInfo.x_values[state.currentTimeIndex] : '';
+
+  return (
+    <div id="menu">
+      <div id="menu-content" className="pure-form">
+        {/* Dataset Selector */}
+        <div className="menu-group">
+          <div>
+            <i className="fa-solid fa-layer-group"></i> Layers
+          </div>
+          <div className="select-container">
+            <select
+              value={state.currentDataset}
+              onChange={(e) => handleDatasetChange(e.target.value)}
+            >
+              {Object.keys(state.datasetInfo).map((datasetName) => (
+                <option key={datasetName} value={datasetName}>
+                  {datasetName}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Time Slider */}
+        {currentDatasetInfo && (
+          <div className="menu-group">
+            <label htmlFor="layer-slider">
+              Viewing Image: <span id="layer-slider-value">{currentTimeValue}</span>
+            </label>
+            <input
+              id="layer-slider"
+              className="input"
+              type="range"
+              min="0"
+              max={currentDatasetInfo.x_values.length - 1}
+              step="1"
+              value={state.currentTimeIndex}
+              onChange={(e) => handleTimeIndexChange(parseInt(e.target.value))}
+            />
+          </div>
+        )}
+
+        {/* Colormap Section */}
+        <div className="menu-group">
+          <div id="colormap-section">
+            <div>
+              <i className="fa-solid fa-palette"></i> Color Map
+            </div>
+            <div className="select-container">
+              <select
+                value={state.colormap}
+                onChange={(e) => handleColormapChange(e.target.value)}
+              >
+                {colormapOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <img
+              id="colormap-img"
+              src={`/colorbar/${state.colormap}`}
+              style={{ maxWidth: '100%', height: 'auto' }}
+              alt="Colormap"
+            />
+          </div>
+
+          {/* Min/Max Controls */}
+          <div id="minmax-data">
+            <div>Rescale color limits</div>
+            <div>
+              <input
+                className="input"
+                type="text"
+                inputMode="decimal"
+                value={draftVmin}
+                onChange={(e) => setDraftVmin(e.target.value)}
+                onBlur={commitVmin}
+                onKeyDown={(e) => e.key === 'Enter' && commitVmin()}
+              />
+            </div>
+            <div>
+              <input
+                className="input"
+                type="text"
+                inputMode="decimal"
+                value={draftVmax}
+                onChange={(e) => setDraftVmax(e.target.value)}
+                onBlur={commitVmax}
+                onKeyDown={(e) => e.key === 'Enter' && commitVmax()}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Opacity Slider */}
+        <div className="menu-group pure-form">
+          <div id="opacity-slider-container">
+            <div>
+              <label htmlFor="opacity-slider">
+                Opacity: <span id="opacity-slider-value">{state.opacity}</span>
+              </label>
+            </div>
+            <input
+              id="opacity-slider"
+              className="input"
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={state.opacity}
+              onChange={(e) => handleOpacityChange(parseFloat(e.target.value))}
+            />
+          </div>
+        </div>
+
+        {/* Basemap Selector */}
+        <div className="select-container">
+          Basemap:
+          <select
+            value={state.selectedBasemap}
+            onChange={(e) => handleBasemapChange(e.target.value)}
+          >
+            {Object.entries(baseMaps).map(([key]) => (
+              <option key={key} value={key}>
+                {key}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Chart Control */}
+      <div className="menu-group">
+        <div id="menu-chart">
+          <button
+            className="pure-button pure-button-primary"
+            onClick={toggleChart}
+          >
+            {state.showChart ? 'Hide time series' : 'Show time series'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/build/lib/components/MapContainer.tsx
+++ b/build/lib/components/MapContainer.tsx
@@ -6,9 +6,6 @@ import { useApi } from '../hooks/useApi';
 import { useAppContext } from '../context/AppContext';
 import { baseMaps } from '../basemap';
 import { MousePositionControl } from '../mouse';
-import MeasureTool from './MeasureTool';
-import ProfileTool from './ProfileTool';
-import RefPointChart from './RefPointChart';
 
 // Fix for default markers in React Leaflet
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -19,22 +16,22 @@ L.Icon.Default.mergeOptions({
 });
 
 const fontAwesomeIcon = L.divIcon({
-  html: '<i class="fa-solid fa-location-dot fa-3x" style="color:#111; text-shadow: 0 0 4px white, 0 0 4px white;"></i>',
+  html: '<i class="fa-solid fa-location-dot fa-3x"></i>',
   iconSize: [20, 20],
   className: 'myDivIcon'
 });
 
 function MapEvents() {
-  const { state, dispatch } = useAppContext();
+  const { dispatch } = useAppContext();
 
   useMapEvents({
     click: (e) => {
-      if (!state.pickingEnabled) return;
+      // Add new time series point on map click
       dispatch({
         type: 'ADD_TIME_SERIES_POINT',
         payload: {
           position: [e.latlng.lat, e.latlng.lng],
-          name: `Point ${Date.now().toString().slice(-4)}`
+          name: `Point ${Date.now().toString().slice(-4)}` // Short unique name
         }
       });
     },
@@ -53,18 +50,6 @@ function MousePosition() {
     return () => {
       mousePositionControl.remove();
     };
-  }, [map]);
-
-  return null;
-}
-
-function ScaleBar() {
-  const map = useMap();
-
-  useEffect(() => {
-    const scale = L.control.scale({ position: 'bottomleft', imperial: true, metric: true, maxWidth: 150 });
-    scale.addTo(map);
-    return () => { scale.remove(); };
   }, [map]);
 
   return null;
@@ -107,8 +92,8 @@ function RasterTileLayer() {
         params.algorithm = currentDatasetInfo.algorithm;
       }
 
-      // Add shift for reference point if available and re-referencing is enabled
-      if (state.refEnabled && state.refValues[state.currentDataset] && currentDatasetInfo.algorithm === 'shift') {
+      // Add shift for reference point if available
+      if (state.refValues[state.currentDataset] && currentDatasetInfo.algorithm === 'shift') {
         const shift = state.refValues[state.currentDataset][timeIdx];
         if (shift !== undefined) {
           params.algorithm_params = JSON.stringify({ shift });
@@ -124,20 +109,6 @@ function RasterTileLayer() {
         params.url = url;
         if (maskUrl) params.mask = encodeURIComponent(maskUrl);
         if (maskMinValue !== undefined) params.mask_min_value = maskMinValue.toString();
-        if (state.customMaskPath) params.custom_mask = state.customMaskPath;
-        params.time_idx = timeIdx.toString();
-      }
-
-      // Layer masks (both modes)
-      if (state.layerMasks.length > 0) {
-        params.layer_masks = JSON.stringify(
-          state.layerMasks.map(m => ({ dataset: m.dataset, threshold: m.threshold, mode: m.mode }))
-        );
-      }
-
-      // MD mode: custom mask path
-      if (state.dataMode === 'md') {
-        if (state.customMaskPath) params.custom_mask_path = state.customMaskPath;
       }
 
       const urlParams = new URLSearchParams(params).toString();
@@ -167,12 +138,9 @@ function RasterTileLayer() {
     state.dataMode,
     state.refValues,
     state.refMarkerPosition,
-    state.refEnabled,
     state.colormap,
     state.vmin,
-    state.vmax,
-    state.layerMasks,
-    state.customMaskPath,
+    state.vmax
   ]);
 
   if (!tileUrl) return null;
@@ -327,27 +295,8 @@ export default function MapContainer() {
 
   const center = getInitialCenter();
   const hasDatasets = Object.keys(state.datasetInfo).length > 0;
-  const [measureActive, setMeasureActive] = useState(false);
-  const [profileActive, setProfileActive] = useState(false);
 
   return (
-    <div className="map-container">
-      <div className="map-toolbar">
-        <button
-          className={`map-tool-btn${measureActive ? ' active' : ''}`}
-          title="Measure distance (click points, double-click to finish)"
-          onClick={() => { setMeasureActive(v => !v); setProfileActive(false); }}
-        >
-          <i className="fa-solid fa-ruler"></i>
-        </button>
-        <button
-          className={`map-tool-btn${profileActive ? ' active' : ''}`}
-          title="Draw profile line (click start, click end, double-click to extract)"
-          onClick={() => { setProfileActive(v => !v); setMeasureActive(false); }}
-        >
-          <i className="fa-solid fa-chart-area"></i>
-        </button>
-      </div>
     <LeafletMapContainer
       key={hasDatasets ? 'with-data' : 'no-data'} // Force re-render when data loads
       center={center}
@@ -364,11 +313,6 @@ export default function MapContainer() {
       <MarkerEventHandlers />
       <MapEvents />
       <MousePosition />
-      <ScaleBar />
-      <MeasureTool active={measureActive} onDeactivate={() => setMeasureActive(false)} />
-      <ProfileTool active={profileActive} onDeactivate={() => setProfileActive(false)} />
-      <RefPointChart />
     </LeafletMapContainer>
-    </div>
   );
 }

--- a/build/lib/components/PointManagerPanel.tsx
+++ b/build/lib/components/PointManagerPanel.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+
+export default function PointManagerPanel() {
+  const { state, dispatch } = useAppContext();
+  const [showPanel, setShowPanel] = useState(false);
+
+  const handleTogglePointVisibility = (pointId: string) => {
+    const point = state.timeSeriesPoints.find(p => p.id === pointId);
+    if (point) {
+      dispatch({
+        type: 'UPDATE_TIME_SERIES_POINT',
+        payload: {
+          id: pointId,
+          updates: { visible: !point.visible }
+        }
+      });
+    }
+  };
+
+  const handlePointNameChange = (pointId: string, newName: string) => {
+    dispatch({
+      type: 'UPDATE_TIME_SERIES_POINT',
+      payload: {
+        id: pointId,
+        updates: { name: newName }
+      }
+    });
+  };
+
+  const handleRemovePoint = (pointId: string) => {
+    dispatch({ type: 'REMOVE_TIME_SERIES_POINT', payload: pointId });
+  };
+
+  const handleSelectPoint = (pointId: string) => {
+    dispatch({ type: 'SET_SELECTED_POINT', payload: pointId });
+  };
+
+  const handleClearAllPoints = () => {
+    if (confirm('Remove all time series points?')) {
+      state.timeSeriesPoints.forEach(point => {
+        dispatch({ type: 'REMOVE_TIME_SERIES_POINT', payload: point.id });
+      });
+    }
+  };
+
+  const handleToggleTrends = () => {
+    dispatch({ type: 'TOGGLE_TRENDS' });
+  };
+
+  if (!showPanel) {
+    return (
+      <div className="point-manager-toggle">
+        <button
+          className="pure-button"
+          onClick={() => setShowPanel(true)}
+          title="Manage Time Series Points"
+        >
+          <i className="fa-solid fa-list"></i> Points ({state.timeSeriesPoints.length})
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="point-manager-panel">
+      <div className="point-manager-header">
+        <h3>
+          <i className="fa-solid fa-map-pin"></i> Time Series Points
+        </h3>
+        <button
+          className="pure-button"
+          onClick={() => setShowPanel(false)}
+          title="Close Panel"
+        >
+          <i className="fa-solid fa-times"></i>
+        </button>
+      </div>
+
+      <div className="point-manager-controls">
+        <button
+          className="pure-button pure-button-primary"
+          onClick={handleToggleTrends}
+          title="Toggle trend display"
+        >
+          <i className={`fa-solid ${state.showTrends ? 'fa-eye-slash' : 'fa-eye'}`}></i>
+          {state.showTrends ? 'Hide' : 'Show'} Trends
+        </button>
+        
+        {state.timeSeriesPoints.length > 0 && (
+          <button
+            className="pure-button button-warning"
+            onClick={handleClearAllPoints}
+            title="Remove all points"
+          >
+            <i className="fa-solid fa-trash"></i> Clear All
+          </button>
+        )}
+      </div>
+
+      <div className="point-list">
+        {state.timeSeriesPoints.length === 0 ? (
+          <div className="no-points">
+            <p>No time series points selected.</p>
+            <p><small>Click on the map to add points.</small></p>
+          </div>
+        ) : (
+          state.timeSeriesPoints.map((point) => (
+            <div 
+              key={point.id} 
+              className={`point-item ${state.selectedPointId === point.id ? 'selected' : ''}`}
+              onClick={() => handleSelectPoint(point.id)}
+            >
+              <div className="point-item-header">
+                <div 
+                  className="point-color-indicator"
+                  style={{ backgroundColor: point.color }}
+                ></div>
+                <input
+                  type="text"
+                  value={point.name}
+                  onChange={(e) => handlePointNameChange(point.id, e.target.value)}
+                  className="point-name-input"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </div>
+              
+              <div className="point-item-info">
+                <div className="point-coordinates">
+                  <small>
+                    Lat: {point.position[0].toFixed(6)}, 
+                    Lon: {point.position[1].toFixed(6)}
+                  </small>
+                </div>
+                
+                {state.showTrends && point.trendData && point.trendData[state.currentDataset] && (
+                  <div className="point-trend-info">
+                    <small>
+                      Rate: {point.trendData[state.currentDataset].mmPerYear?.toFixed(2) || 'N/A'} mm/year
+                      (R²: {point.trendData[state.currentDataset].rSquared.toFixed(3)})
+                    </small>
+                  </div>
+                )}
+              </div>
+              
+              <div className="point-item-controls">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleTogglePointVisibility(point.id);
+                  }}
+                  className="pure-button"
+                  title={point.visible ? 'Hide point' : 'Show point'}
+                >
+                  <i className={`fa-solid ${point.visible ? 'fa-eye' : 'fa-eye-slash'}`}></i>
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemovePoint(point.id);
+                  }}
+                  className="pure-button button-error"
+                  title="Remove point"
+                >
+                  <i className="fa-solid fa-trash"></i>
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+      
+      <div className="point-manager-help">
+        <small>
+          • Click map to add points<br/>
+          • Double-click markers to remove<br/>
+          • Drag markers to move
+        </small>
+      </div>
+    </div>
+  );
+}

--- a/build/lib/components/TimeSeriesChart.tsx
+++ b/build/lib/components/TimeSeriesChart.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, InteractionItem } from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import 'chartjs-adapter-date-fns';
+import { useAppContext } from '../context/AppContext';
+import { useApi } from '../hooks/useApi';
+import { MultiPointTimeSeriesData } from '../types';
+
+// Register Chart.js components
+ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+export default function TimeSeriesChart() {
+  const { state, dispatch } = useAppContext();
+  const { fetchMultiPointTimeSeries } = useApi();
+  const [chartData, setChartData] = useState<MultiPointTimeSeriesData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const updateChart = useCallback(async () => {
+    if (!state.showChart || !state.currentDataset || state.timeSeriesPoints.length === 0) {
+      setChartData(null);
+      return;
+    }
+
+    setIsLoading(true);
+    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
+
+    // Filter visible points
+    const visiblePoints = state.timeSeriesPoints.filter(p => p.visible);
+
+    if (visiblePoints.length === 0) {
+      setChartData(null);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      // Format points for API
+      const apiPoints = visiblePoints.map(point => ({
+        id: point.id,
+        lat: point.position[0],
+        lon: point.position[1],
+        color: point.color,
+        name: point.name,
+      }));
+
+      // Fetch multi-point data
+      let refLon, refLat;
+      if (currentDatasetInfo?.uses_spatial_ref) {
+        [refLat, refLon] = state.refMarkerPosition;
+      }
+
+      const tsData = await fetchMultiPointTimeSeries(
+        apiPoints,
+        state.currentDataset,
+        refLon,
+        refLat,
+        state.showTrends
+      );
+
+      if (tsData) {
+        setChartData(tsData);
+
+        // Update trend data in state only if trends are being calculated
+        if (state.showTrends && tsData.datasets) {
+          // Use setTimeout to avoid re-render loop during state updates
+          setTimeout(() => {
+            tsData.datasets.forEach(dataset => {
+              if (dataset.trend) {
+                dispatch({
+                  type: 'SET_POINT_TREND_DATA',
+                  payload: {
+                    pointId: dataset.pointId,
+                    dataset: state.currentDataset,
+                    trend: {
+                      slope: dataset.trend.slope,
+                      intercept: dataset.trend.intercept,
+                      rSquared: dataset.trend.rSquared,
+                      mmPerYear: dataset.trend.mmPerYear,
+                    },
+                  },
+                });
+              }
+            });
+          }, 0);
+        }
+      }
+    } catch (error) {
+      console.error('Error updating chart:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    state.showChart,
+    state.currentDataset,
+    JSON.stringify(state.timeSeriesPoints.map(p => ({ id: p.id, position: p.position, visible: p.visible }))), // Only track relevant point changes
+    state.refMarkerPosition,
+    state.datasetInfo,
+    state.showTrends,
+    fetchMultiPointTimeSeries,
+  ]);
+
+  useEffect(() => {
+    updateChart();
+  }, [
+    updateChart,
+  ]);
+
+  const handleChartClick = useCallback((_event: any, elements: InteractionItem[]) => {
+    if (elements.length === 0 || !chartData) return;
+
+    const element = elements[0];
+    const dataIndex = element.index;
+
+    // Update the current time index to sync with the clicked point
+    if (dataIndex !== undefined && dataIndex < chartData.labels.length) {
+      dispatch({ type: 'SET_TIME_INDEX', payload: dataIndex });
+    }
+  }, [chartData, dispatch]);
+
+  const handleExportToCSV = useCallback(() => {
+    if (!chartData || !chartData.datasets || chartData.datasets.length === 0) return;
+
+    // Build CSV header
+    const headers = ['Time', ...chartData.datasets.map(d => d.label)];
+
+    // Build data rows
+    const rows: string[][] = [];
+    chartData.labels.forEach((label, idx) => {
+      const row = [label];
+      chartData.datasets.forEach(dataset => {
+        const dataPoint = dataset.data[idx];
+        row.push(dataPoint ? dataPoint.y.toString() : '');
+      });
+      rows.push(row);
+    });
+
+    // Add trend information if available
+    const trendRows: string[][] = [];
+    if (state.showTrends && chartData.datasets.some(d => d.trend)) {
+      trendRows.push(['']); // Empty row separator
+      trendRows.push(['Point', 'Rate (mm/year)', 'R²', 'Slope', 'Intercept']);
+      chartData.datasets.forEach(dataset => {
+        if (dataset.trend) {
+          trendRows.push([
+            dataset.label,
+            dataset.trend.mmPerYear.toFixed(6),
+            dataset.trend.rSquared.toFixed(6),
+            dataset.trend.slope.toFixed(6),
+            dataset.trend.intercept.toFixed(6),
+          ]);
+        }
+      });
+    }
+
+    // Combine all rows and convert to CSV
+    const allRows = [headers, ...rows, ...trendRows];
+    const csvContent = allRows.map(row => row.join(',')).join('\n');
+
+    // Create and trigger download
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+    link.setAttribute('href', url);
+    link.setAttribute('download', `time-series-${state.currentDataset}-${timestamp}.csv`);
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, [chartData, state.showTrends, state.currentDataset]);
+
+  const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: {
+      duration: 300,
+    },
+    interaction: {
+      mode: 'index' as const,
+      intersect: false,
+    },
+    plugins: {
+      legend: {
+        display: true,
+        position: 'top' as const,
+        labels: {
+          usePointStyle: true,
+          padding: 20,
+          generateLabels: (_chart: any) => {
+            if (!chartData?.datasets) return [];
+
+            return chartData.datasets.map((dataset, index) => ({
+              text: `${dataset.label}${dataset.trend && dataset.trend.mmPerYear !== undefined ? ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)` : ''}`,
+              pointStyle: 'circle' as const,
+              fillStyle: dataset.borderColor,
+              strokeStyle: dataset.borderColor,
+              lineWidth: 2,
+              datasetIndex: index,
+            }));
+          },
+        },
+      },
+      tooltip: {
+        callbacks: {
+          title: (context: any) => {
+            return `Time: ${context[0]?.label || ''}`;
+          },
+          label: (context: any) => {
+            const dataset = chartData?.datasets?.[context.datasetIndex];
+            if (!dataset) return '';
+
+            let label = `${dataset.label}: ${context.parsed.y.toFixed(3)}`;
+
+            if (dataset.trend && dataset.trend.mmPerYear !== undefined && state.showTrends) {
+              label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
+            }
+
+            return label;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        type: 'time' as const,
+        time: {
+          displayFormats: {
+            month: 'MMM yyyy',
+            year: 'yyyy',
+          },
+        },
+        title: {
+          display: true,
+          text: 'Time',
+        },
+      },
+      y: {
+        title: {
+          display: true,
+          text: 'Displacement (m)',
+        },
+        suggestedMin: state.vmin,
+        suggestedMax: state.vmax,
+      },
+    },
+    onClick: handleChartClick,
+  };
+
+  if (!state.showChart) {
+    return null;
+  }
+
+  if (state.timeSeriesPoints.length === 0) {
+    return (
+      <div id="chart-container">
+        <div className="chart-placeholder">
+          <p>No time series points selected.</p>
+          <p><small>Click on the map to add points.</small></p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div id="chart-container">
+        <div className="chart-placeholder">
+          <p>Loading time series data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!chartData || !chartData.datasets || chartData.datasets.length === 0) {
+    return (
+      <div id="chart-container">
+        <div className="chart-placeholder">
+          <p>No data available for selected points.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Format data for Chart.js
+  const formattedChartData = {
+    labels: chartData.labels,
+    datasets: chartData.datasets.map(dataset => ({
+      label: dataset.label,
+      data: dataset.data,
+      borderColor: dataset.borderColor,
+      backgroundColor: dataset.backgroundColor,
+      borderWidth: 2,
+      pointRadius: 3,
+      pointHoverRadius: 5,
+      tension: 0.1,
+      fill: false,
+    })),
+  };
+
+  return (
+    <div id="chart-container">
+      <div className="chart-header">
+        <h4>Time Series Analysis</h4>
+        <div className="chart-controls">
+          <button
+            className="pure-button"
+            onClick={() => dispatch({ type: 'TOGGLE_TRENDS' })}
+            title="Toggle trend analysis"
+          >
+            <i className={`fa-solid ${state.showTrends ? 'fa-chart-line' : 'fa-chart-simple'}`}></i>
+            {state.showTrends ? 'Hide' : 'Show'} Trends
+          </button>
+          <button
+            className="pure-button"
+            onClick={handleExportToCSV}
+            title="Export data to CSV"
+          >
+            <i className="fa-solid fa-download"></i>
+            Export CSV
+          </button>
+        </div>
+      </div>
+      <div className="chart-content">
+        <Line data={formattedChartData} options={chartOptions} />
+      </div>
+      <div className="chart-help">
+        <small>Click on chart points to sync map time • Trends show mm/year rates</small>
+      </div>
+    </div>
+  );
+}

--- a/build/lib/context/AppContext.tsx
+++ b/build/lib/context/AppContext.tsx
@@ -34,18 +34,6 @@ const initialState: AppState = {
   showChart: false,
   selectedPointId: null,
   showTrends: false,
-  showResiduals: false,
-  layerMasks: [],
-  customMaskPath: null,
-  bufferEnabled: false,
-  bufferRadius: 500,
-  bufferSamples: 10,
-  pickingEnabled: true,
-  refEnabled: true,
-  showProfile: false,
-  refBufferEnabled: false,
-  refBufferRadius: 500,
-  showRefChart: false,
 };
 
 function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppState {
@@ -185,39 +173,6 @@ function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppSt
       return { ...state, vmax: action.payload };
     case 'SET_OPACITY':
       return { ...state, opacity: action.payload };
-    case 'TOGGLE_RESIDUALS':
-      return { ...state, showResiduals: !state.showResiduals };
-    case 'ADD_LAYER_MASK':
-      return { ...state, layerMasks: [...state.layerMasks, action.payload] };
-    case 'REMOVE_LAYER_MASK':
-      return { ...state, layerMasks: state.layerMasks.filter(m => m.id !== action.payload) };
-    case 'UPDATE_LAYER_MASK':
-      return {
-        ...state,
-        layerMasks: state.layerMasks.map(m =>
-          m.id === action.payload.id ? { ...m, ...action.payload.updates } : m
-        ),
-      };
-    case 'SET_CUSTOM_MASK_PATH':
-      return { ...state, customMaskPath: action.payload };
-    case 'TOGGLE_BUFFER':
-      return { ...state, bufferEnabled: !state.bufferEnabled };
-    case 'SET_BUFFER_RADIUS':
-      return { ...state, bufferRadius: action.payload };
-    case 'SET_BUFFER_SAMPLES':
-      return { ...state, bufferSamples: action.payload };
-    case 'TOGGLE_PICKING':
-      return { ...state, pickingEnabled: !state.pickingEnabled };
-    case 'TOGGLE_REF_ENABLED':
-      return { ...state, refEnabled: !state.refEnabled };
-    case 'TOGGLE_PROFILE':
-      return { ...state, showProfile: !state.showProfile };
-    case 'TOGGLE_REF_BUFFER':
-      return { ...state, refBufferEnabled: !state.refBufferEnabled };
-    case 'SET_REF_BUFFER_RADIUS':
-      return { ...state, refBufferRadius: action.payload };
-    case 'TOGGLE_REF_CHART':
-      return { ...state, showRefChart: !state.showRefChart };
     case 'TOGGLE_CHART':
       return { ...state, showChart: !state.showChart };
     default:

--- a/build/lib/hooks/useApi.ts
+++ b/build/lib/hooks/useApi.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { MultiPointTimeSeriesData, LayerMask } from '../types';
+import { MultiPointTimeSeriesData } from '../types';
 
 export function useApi() {
   const fetchDatasets = useCallback(async () => {
@@ -63,9 +63,7 @@ export function useApi() {
     datasetName: string,
     refLon?: number,
     refLat?: number,
-    calculateTrends: boolean = false,
-    layerMasks: LayerMask[] = [],
-    refBufferM: number = 0,
+    calculateTrends: boolean = false
   ): Promise<MultiPointTimeSeriesData | undefined> => {
     const payload = {
       points,
@@ -73,8 +71,6 @@ export function useApi() {
       ref_lon: refLon,
       ref_lat: refLat,
       calculate_trends: calculateTrends,
-      layer_masks: layerMasks.map(m => ({ dataset: m.dataset, threshold: m.threshold, mode: m.mode })),
-      ref_buffer_m: refBufferM,
     };
 
     try {
@@ -130,40 +126,6 @@ export function useApi() {
     }
   }, []);
 
-  const fetchBufferTimeSeries = useCallback(async (
-    lon: number,
-    lat: number,
-    datasetName: string,
-    bufferM: number,
-    nSamples: number,
-    refLon?: number,
-    refLat?: number,
-    layerMasks: LayerMask[] = [],
-    refBufferM: number = 0,
-  ) => {
-    try {
-      const response = await fetch('/buffer_timeseries', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          lon, lat,
-          dataset_name: datasetName,
-          buffer_m: bufferM,
-          n_samples: nSamples,
-          ref_lon: refLon ?? null,
-          ref_lat: refLat ?? null,
-          layer_masks: layerMasks.map(m => ({ dataset: m.dataset, threshold: m.threshold, mode: m.mode })),
-          ref_buffer_m: refBufferM,
-        }),
-      });
-      if (!response.ok) return undefined;
-      return await response.json();
-    } catch (error) {
-      console.error('Error fetching buffer time series:', error);
-      return undefined;
-    }
-  }, []);
-
   return {
     fetchDatasets,
     fetchDataMode,
@@ -172,6 +134,5 @@ export function useApi() {
     fetchMultiPointTimeSeries,
     fetchTrendAnalysis,
     fetchTimeBounds,
-    fetchBufferTimeSeries,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "chart.js": "^4.4.1",
         "chartjs-adapter-date-fns": "^3.0.0",
+        "chartjs-plugin-zoom": "^2.2.0",
+        "hammerjs": "^2.0.8",
         "leaflet": "^1.9.4",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
@@ -1674,6 +1676,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/leaflet": {
       "version": "1.9.18",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.18.tgz",
@@ -2329,6 +2337,19 @@
       "peerDependencies": {
         "chart.js": ">=2.8.0",
         "date-fns": ">=2.0.0"
+      }
+    },
+    "node_modules/chartjs-plugin-zoom": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz",
+      "integrity": "sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.45",
+        "hammerjs": "^2.0.8"
+      },
+      "peerDependencies": {
+        "chart.js": ">=3.2.0"
       }
     },
     "node_modules/check-error": {
@@ -3121,6 +3142,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "dependencies": {
     "chart.js": "^4.4.1",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-plugin-zoom": "^2.2.0",
+    "hammerjs": "^2.0.8",
     "leaflet": "^1.9.4",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/pixi.lock
+++ b/pixi.lock
@@ -10,8 +10,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.15-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -39,7 +41,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.11-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_3.conda
@@ -84,7 +86,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf50df08_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
@@ -260,7 +262,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.23-h8e187f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.1-py312h4ebe9ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -397,6 +399,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/0a/2356305c423a975000867de56888b79e44ec2192c690ff93c3109fd78081/pyzmq-27.0.1-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
@@ -427,8 +430,10 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.12.15-py312h6daa0e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asf_search-9.0.9-pyhd8ed1ab_0.conda
@@ -455,7 +460,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.9-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.9-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hd8f9ff3_3.conda
@@ -489,7 +494,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.10.3-py312h93ff630_12.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.1-hc9a1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-h1d7e6e1_2.conda
@@ -634,7 +639,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.1-py312h286a95b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -751,6 +756,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/9b/c0957041067c7724b310f22c398be46399297c12ed834c3bc42200a2756f/pyzmq-27.0.1-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
@@ -789,8 +795,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.15-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -818,7 +826,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.11-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_3.conda
@@ -863,7 +871,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf50df08_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
@@ -1039,7 +1047,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.23-h8e187f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.1-py312h4ebe9ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -1113,6 +1121,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/09/6c/6ca6ed6b93c9879e6a804515169faefcd99e02114ef113598de9b71d27be/morecantile-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/e8/15e0e077a004db0edd530da96c60c948689c888c464ee5d14b82405ebd86/numexpr-2.11.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/16/8a35212bb8433528e07d52bd1f56f193bed74666019b5e46f6bed9436bb4/rio_tiler-7.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bd/400b0bd372a5666addf2540c7358bfc3841b9ce5cdbc5cc4ad2f61627ad8/simplejson-3.20.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
@@ -1123,8 +1132,10 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.12.15-py312h6daa0e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asf_search-9.0.9-pyhd8ed1ab_0.conda
@@ -1151,7 +1162,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.9-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.9-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hd8f9ff3_3.conda
@@ -1185,7 +1196,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.10.3-py312h93ff630_12.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.1-hc9a1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-h1d7e6e1_2.conda
@@ -1330,7 +1341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.1-py312h286a95b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -1383,6 +1394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/09/6c/6ca6ed6b93c9879e6a804515169faefcd99e02114ef113598de9b71d27be/morecantile-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/46/3a26b84e44f4739ec98de0ede4b95b4b8096f721e22d0e97517eeb02017e/numexpr-2.11.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/16/8a35212bb8433528e07d52bd1f56f193bed74666019b5e46f6bed9436bb4/rio_tiler-7.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/05/2b5ecb33b776c34bb5cace5de5d7669f9b60e3ca13c113037b2ca86edfbd/simplejson-3.20.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
@@ -1401,8 +1413,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.15-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1430,7 +1444,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.11-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_3.conda
@@ -1475,7 +1489,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf50df08_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
@@ -1651,7 +1665,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.23-h8e187f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.1-py312h4ebe9ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -1740,6 +1754,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/16/8a35212bb8433528e07d52bd1f56f193bed74666019b5e46f6bed9436bb4/rio_tiler-7.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bd/400b0bd372a5666addf2540c7358bfc3841b9ce5cdbc5cc4ad2f61627ad8/simplejson-3.20.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
@@ -1754,8 +1769,10 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.12.15-py312h6daa0e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asf_search-9.0.9-pyhd8ed1ab_0.conda
@@ -1782,7 +1799,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.9-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.9-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hd8f9ff3_3.conda
@@ -1816,7 +1833,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.10.3-py312h93ff630_12.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.1-hc9a1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-h1d7e6e1_2.conda
@@ -1961,7 +1978,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.1-py312h286a95b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -2029,6 +2046,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/16/8a35212bb8433528e07d52bd1f56f193bed74666019b5e46f6bed9436bb4/rio_tiler-7.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/05/2b5ecb33b776c34bb5cace5de5d7669f9b60e3ca13c113037b2ca86edfbd/simplejson-3.20.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
@@ -2051,8 +2069,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.15-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -2080,7 +2100,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.11-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_3.conda
@@ -2125,7 +2145,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf50df08_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
@@ -2301,7 +2321,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.23-h8e187f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.1-py312h4ebe9ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -2435,6 +2455,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/0a/2356305c423a975000867de56888b79e44ec2192c690ff93c3109fd78081/pyzmq-27.0.1-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
@@ -2465,8 +2486,10 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.12.15-py312h6daa0e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asf_search-9.0.9-pyhd8ed1ab_0.conda
@@ -2493,7 +2516,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.40.9-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.9-pyge310_1234567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hd8f9ff3_3.conda
@@ -2527,7 +2550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.10.3-py312h93ff630_12.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.1-hc9a1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-h1d7e6e1_2.conda
@@ -2672,7 +2695,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.1-py312h286a95b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -2786,6 +2809,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/9b/c0957041067c7724b310f22c398be46399297c12ed834c3bc42200a2756f/pyzmq-27.0.1-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
@@ -2847,6 +2871,25 @@ packages:
   - pkg:pypi/affine?source=hash-mapping
   size: 19164
   timestamp: 1733762153202
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.25.2-pyhcf101f3_0.conda
+  sha256: 922fb146148449c6bc374a37fa9edb89b3af1c385392391339206d3ab3d571a3
+  md5: 6e90a60dbb939d24a6295e19377cf0e6
+  depends:
+  - python >=3.10
+  - aiohttp >=3.9.2,<4.0.0
+  - aioitertools >=0.5.1,<1.0.0
+  - botocore >=1.40.46,<1.40.71
+  - python-dateutil >=2.1,<3.0.0
+  - jmespath >=0.7.1,<2.0.0
+  - multidict >=6.0.0,<7.0.0
+  - wrapt >=1.10.10,<2.0.0
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/aiobotocore?source=hash-mapping
+  size: 80900
+  timestamp: 1762893423043
 - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
   sha256: 7842ddc678e77868ba7b92a726b437575b23aaec293bca0d40826f1026d90e27
   md5: 18fd895e0e775622906cdabfc3cf0fb4
@@ -2900,6 +2943,18 @@ packages:
   - pkg:pypi/aiohttp?source=compressed-mapping
   size: 978588
   timestamp: 1753805356065
+- conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
+  sha256: 41bc8d85274c5badabe6c333cdd2e77e9c6bc0fb64251211988a71e1fd83486b
+  md5: 65d5134ff98cb3727022a4f23993a2e6
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/aioitertools?source=hash-mapping
+  size: 25450
+  timestamp: 1768757675539
 - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
   sha256: 8dc149a6828d19bf104ea96382a9d04dae185d4a03cc6beb1bc7b84c428e3ca2
   md5: 421a865222cd0c9d83ff08bc78bf3a61
@@ -3671,9 +3726,9 @@ packages:
   - pkg:pypi/boto3?source=hash-mapping
   size: 83925
   timestamp: 1755162758291
-- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.11-pyge310_1234567_0.conda
-  sha256: 668f388b0173d40058f8db97b0f65d9bfb4f2d80c648d5c69c7ac686f080aa8e
-  md5: 4c1db26e038473c5373f11fa618fc312
+- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.70-pyhd8ed1ab_0.conda
+  sha256: 92e3b65d162600eec4c858a870e2b7593886d837c965ca51bf8bd1ed0e6f1e27
+  md5: 280a8a31bface0a6b1cf49ea85004128
   depends:
   - jmespath >=0.7.1,<2.0.0
   - python >=3.10
@@ -3683,26 +3738,12 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/botocore?source=hash-mapping
-  size: 7922569
-  timestamp: 1755329810128
-- conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.9-pyge310_1234567_0.conda
-  sha256: b931590b8219610ffdfde5ae8fd194355fb5882178f852043a9dea585d7b80fa
-  md5: 1bb020ca3d641fe677e44c333802ede9
-  depends:
-  - jmespath >=0.7.1,<2.0.0
-  - python >=3.10
-  - python-dateutil >=2.1,<3.0.0
-  - urllib3 >=1.25.4,!=2.2.0,<3
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/botocore?source=hash-mapping
-  size: 7973244
-  timestamp: 1755158592822
+  size: 8150945
+  timestamp: 1762813779810
 - pypi: ./
   name: bowser-insar
-  version: 0.1.0.post1.dev149+gd92e061cd.d20251016
-  sha256: d3752128378155cec22075b06a8bbb22f430c9b5a39089d6adbdf19138ae8163
+  version: 0.3.0.post1.dev65+g89eb54bf5.d20260417
+  sha256: 5a64e7a9dc8181a320e9247bc1da8df12d7e07571d777d888d6764b1cccc3f84
   requires_dist:
   - titiler-xarray[http,minimal]
   - starlette-cramjam
@@ -3714,6 +3755,11 @@ packages:
   - rioxarray
   - matplotlib
   - pydantic-settings
+  - rich
+  - s3fs>=2024.1.0
+  - aiobotocore>=2.13.0
+  - python-multipart
+  - starlette>=0.40.0,<1.0.0
   - requests ; extra == 'widget'
   - jupyter ; extra == 'widget'
   - matplotlib ; extra == 'widget'
@@ -4676,17 +4722,17 @@ packages:
   - pkg:pypi/frozenlist?source=hash-mapping
   size: 52265
   timestamp: 1752167495152
-- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.7.0-pyhd8ed1ab_0.conda
-  sha256: f734d98cd046392fbd9872df89ac043d72ac15f6a2529f129d912e28ab44609c
-  md5: a31ce802cd0ebfce298f342c02757019
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.3.0-pyhd8ed1ab_0.conda
+  sha256: b4a7aec32167502dd4a2d1fb1208c63760828d7111339aa5b305b2d776afa70f
+  md5: c18d2ba7577cdc618a20d45f1e31d14b
   depends:
-  - python >=3.9
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/fsspec?source=hash-mapping
-  size: 145357
-  timestamp: 1752608821935
+  size: 148973
+  timestamp: 1774699581537
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf50df08_12.conda
   sha256: c860506b4ef13f6e62f72d8c70ff4b9c4e7cf569922277bc6af1a88090a8f722
   md5: 1fde0e8872364f83298f22133ba83ca3
@@ -9519,6 +9565,11 @@ packages:
   - mkdocs-literate-nav ; extra == 'dev'
   - mike ; extra == 'dev'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl
+  name: python-multipart
+  version: 0.0.26
+  sha256: c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.2-pyhd8ed1ab_0.conda
   sha256: e8392a8044d56ad017c08fec2b0eb10ae3d1235ac967d0aab8bd7b41c4a5eaf0
   md5: 88476ae6ebd24f39261e0854ac244f33
@@ -9952,18 +10003,20 @@ packages:
   purls: []
   size: 383097
   timestamp: 1753407970803
-- conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-0.4.2-py_0.tar.bz2
-  sha256: 7a4cb574ff7edf773e5e4c396733dcb08ffcfd6e4f8b27e5b84b35fd4666ef5b
-  md5: ead328eb12f01d88706126ba061e7a69
+- conda: https://conda.anaconda.org/conda-forge/noarch/s3fs-2026.3.0-pyhd8ed1ab_0.conda
+  sha256: 887887cfd8f5549dba20f04e4d61e0665eb8657dd70b6616f9affb8959c1ea4d
+  md5: b15d41b1c4c56f09673bbefee39934f3
   depends:
-  - boto3
-  - fsspec >=0.6.0
-  - python >=3.5
-  license: BSD 3-Clause
+  - aiobotocore >=2.19.0,<4.0.0
+  - aiohttp
+  - fsspec 2026.3.0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/s3fs?source=hash-mapping
-  size: 21157
-  timestamp: 1585670623844
+  size: 35728
+  timestamp: 1774716020943
 - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.13.1-pyhd8ed1ab_0.conda
   sha256: a9cc762b0a472ed3bb69784ebe71e99a72661cdf38001c5e717cb4c2a2505d6f
   md5: d66713a183295206013e8f93db001e99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ rioxarray = "*"
 matplotlib = "*"
 pydantic-settings = "*"
 python-dateutil = ">=2.9.0.post0,<3"
+s3fs = ">=2024.1.0"
+aiobotocore = ">=2.13.0"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "rioxarray",
   "matplotlib",
   "pydantic-settings",
+  "rich",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
   "matplotlib",
   "pydantic-settings",
   "rich",
+  "s3fs>=2024.1.0",
+  "aiobotocore>=2.13.0",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "rich",
   "s3fs>=2024.1.0",
   "aiobotocore>=2.13.0",
+  "python-multipart",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "s3fs>=2024.1.0",
   "aiobotocore>=2.13.0",
   "python-multipart",
+  "starlette>=0.40.0,<1.0.0",
 ]
 
 classifiers = [

--- a/src/bowser/_prepare_disp_s1.py
+++ b/src/bowser/_prepare_disp_s1.py
@@ -24,7 +24,7 @@ CORRECTION_DATASETS = [
 
 def get_disp_s1_outputs(disp_s1_dir: Path | str):
     def _glob(pattern: str, subdir: str) -> list[str]:
-        return [str(p) for p in sorted((Path(disp_s1_dir) / subdir).glob(pattern))]
+        return [str(p.resolve()) for p in sorted((Path(disp_s1_dir) / subdir).glob(pattern))]
 
     return [
         {

--- a/src/bowser/_prepare_utils.py
+++ b/src/bowser/_prepare_utils.py
@@ -10,7 +10,6 @@ from opera_utils.disp import open_h5
 from osgeo import gdal
 from tqdm.contrib.concurrent import process_map
 
-from bowser.add_overviews import add_overviews
 
 logger = logging.getLogger("bowser")
 
@@ -133,12 +132,23 @@ def process_single_file(
 
         vrt_path = cur_output_dir / vrt_filename
 
-        # Create VRT file
+        # Create VRT file (use absolute path so VRT is portable across working dirs).
+        # S3 paths must not go through Path.resolve() — that would mangle the
+        # double-slash in s3://.  Map them directly to /vsis3/ for GDAL.
+        nc_str = str(netcdf_file)
+        if nc_str.startswith("s3://"):
+            gdal_netcdf = nc_str.replace("s3://", "/vsis3/", 1)
+        else:
+            gdal_netcdf = str(Path(netcdf_file).resolve())
         gdal.Translate(
             str(vrt_path),
-            f"netcdf:{netcdf_file.replace('s3://', '/vsis3/')}:{in_dataset}",
+            f"netcdf:{gdal_netcdf}:{in_dataset}",
+            outputType=gdal.GDT_Float32,  # Float64 breaks PNG tile rendering in titiler
             callback=gdal.TermProgress_nocb,
         )
 
-        # Build overviews using GDAL function with compression
-        add_overviews(vrt_path, external=True)
+        # Build overviews
+        ds = gdal.Open(str(vrt_path))
+        if ds is not None:
+            ds.BuildOverviews("NEAREST", [2, 4, 8, 16, 32])
+            ds = None

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -72,6 +72,11 @@ def cli_app():
     is_flag=True,
     help="Don't use recommended mask for `displacement` ",
 )
+@click.option(
+    "--title",
+    default="",
+    help="Title to display on the map.",
+)
 def run(
     stack_file,
     rasters_file,
@@ -82,6 +87,7 @@ def run(
     ignore_sidecar_files,
     no_spatial_reference,
     no_recommended_mask,
+    title,
 ):
     """Run the web server."""
     import uvicorn
@@ -97,6 +103,8 @@ def run(
         "NO" if no_spatial_reference else "YES"
     )
     os.environ["BOWSER_USE_RECOMMENDED_MASK"] = "NO" if no_recommended_mask else "YES"
+    if title:
+        os.environ["BOWSER_TITLE"] = title
 
     print(f"Setting up on http://localhost:{port}")
     uvicorn.run(
@@ -284,7 +292,7 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
                 return result
         return []
 
-    wd = dolphin_work_dir.rstrip("/")
+    wd = str(Path(dolphin_work_dir).resolve())
 
     dolphin_outputs = [
         {
@@ -378,6 +386,15 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
         {
             "name": "Amplitude dispersion",
             "file_list": _glob(f"{wd}/interferograms/amp_dispersion_looked*.tif"),
+            "algorithm": Algorithm.AMPLITUDE.value,
+        },
+        {
+            "name": "Amplitude mean",
+            "file_list": _glob_first(
+                f"{wd}/interferograms/amp_mean_looked*.tif",
+                f"{wd}/interferograms/amp_mean*.tif",
+            ),
+            "algorithm": Algorithm.AMPLITUDE.value,
         },
         {
             "name": "SHP counts",

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -39,7 +39,7 @@ def cli_app():
 @click.option(
     "--workers",
     "-w",
-    default=1,
+    default=4,
     type=int,
     help="Number of uvicorn workers to spawn",
     show_default=True,

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -400,8 +400,8 @@ def setup_dolphin(dolphin_work_dir, timeseries_mask, output, include_ifgs: bool 
                 "algorithm": Algorithm.PHASE.value,
             }
         )
+    # NOTE would be interesting to load amplitude timeseries
     amplitude_files = _glob(f"{wd}/amplitude_db/2*_amp_db.tif")
-    print(amplitude_files)
     if amplitude_files:
         dolphin_outputs.append(
             {

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -463,12 +463,18 @@ def _find_available_port(port_request: int = 8000):
 def prepare_disp_s1(input_files, output_dir, corrections: bool):
     """Process NetCDF files to create VRT files with overviews.
 
-    INPUT_FILES: Paths to input NetCDF files.
+    INPUT_FILES: Paths to input NetCDF files or directories containing .nc files.
     """
     from bowser._prepare_disp_s1 import CORE_DATASETS, CORRECTION_DATASETS
     from bowser._prepare_utils import process_netcdf_files
 
-    input_paths = list(input_files)
+    input_paths = []
+    for f in input_files:
+        p = Path(f)
+        if p.is_dir():
+            input_paths.extend(sorted(p.glob("*.nc")))
+        else:
+            input_paths.append(p)
 
     datasets_to_process = (
         CORE_DATASETS + CORRECTION_DATASETS if corrections else CORE_DATASETS

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -39,7 +39,7 @@ def cli_app():
 @click.option(
     "--workers",
     "-w",
-    default=4,
+    default=1,
     type=int,
     help="Number of uvicorn workers to spawn",
     show_default=True,

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -77,6 +77,21 @@ def cli_app():
     default="",
     help="Title to display on the map.",
 )
+@click.option(
+    "--ssl-certfile",
+    default=None,
+    help="Path to TLS certificate file (PEM). Enables HTTPS when set.",
+)
+@click.option(
+    "--ssl-keyfile",
+    default=None,
+    help="Path to TLS private key file (PEM). Required when --ssl-certfile is set.",
+)
+@click.option(
+    "--htpasswd-file",
+    default=None,
+    help="Path to htpasswd file for HTTP Basic Auth. No auth when omitted.",
+)
 def run(
     stack_file,
     rasters_file,
@@ -88,6 +103,9 @@ def run(
     no_spatial_reference,
     no_recommended_mask,
     title,
+    ssl_certfile,
+    ssl_keyfile,
+    htpasswd_file,
 ):
     """Run the web server."""
     import uvicorn
@@ -105,14 +123,19 @@ def run(
     os.environ["BOWSER_USE_RECOMMENDED_MASK"] = "NO" if no_recommended_mask else "YES"
     if title:
         os.environ["BOWSER_TITLE"] = title
+    if htpasswd_file:
+        os.environ["BOWSER_HTPASSWD_FILE"] = htpasswd_file
 
-    print(f"Setting up on http://localhost:{port}")
+    protocol = "https" if ssl_certfile else "http"
+    print(f"Setting up on {protocol}://localhost:{port}")
     uvicorn.run(
         "bowser.main:app",
         port=port,
         reload=reload,
         workers=workers,
         log_level=log_level,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
     )
 
 

--- a/src/bowser/config.py
+++ b/src/bowser/config.py
@@ -13,6 +13,8 @@ class Settings(BaseSettings):
     BOWSER_STACK_DATA_FILE: str = ""
     BOWSER_TITLE: str = ""
     LOG_LEVEL: str = "WARNING"
+    # Path to an htpasswd-format file for HTTP Basic Auth (empty = no auth)
+    BOWSER_HTPASSWD_FILE: str = ""
 
     # SECRET_KEY: str = secrets.token_urlsafe(32)
     # SERVER_NAME: str

--- a/src/bowser/config.py
+++ b/src/bowser/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     # Can be overridden by environment variable:
     BOWSER_DATASET_CONFIG_FILE: str = "bowser_rasters.json"
     BOWSER_STACK_DATA_FILE: str = ""
+    BOWSER_TITLE: str = ""
     LOG_LEVEL: str = "WARNING"
 
     # SECRET_KEY: str = secrets.token_urlsafe(32)

--- a/src/bowser/dist/index.css
+++ b/src/bowser/dist/index.css
@@ -937,6 +937,14 @@ body {
 }
 
 /* ── Masking section ────────────────────────────────────────── */
+.layer-mask-row {
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
+  background: rgba(255,255,255,0.03);
+}
+
 .custom-mask-row {
   display: flex;
   flex-direction: column;

--- a/src/bowser/dist/index.css
+++ b/src/bowser/dist/index.css
@@ -686,6 +686,15 @@ svg.leaflet-image-layer.leaflet-interactive path {
 }
 
 /* ── Theme toggle button ───────────────────────────────────── */
+.sidebar-title {
+  padding: 8px 12px 4px;
+  font-size: 0.95em;
+  font-weight: 600;
+  color: var(--sb-text);
+  text-align: center;
+  word-break: break-word;
+}
+
 .sidebar-theme-toggle {
   display: flex;
   justify-content: flex-end;
@@ -1151,6 +1160,47 @@ img.huechange { filter: hue-rotate(120deg); }
   color: var(--sb-muted);
   text-align: center;
   font-size: 0.75em;
+}
+
+/* ── Animation controls (chart bottom + sidebar) ─────────────── */
+.chart-animation-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--sb-border);
+  flex-wrap: wrap;
+}
+
+.chart-anim-speed {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 120px;
+  font-size: 0.78em;
+  color: var(--sb-muted);
+}
+
+.chart-anim-speed input[type="range"] {
+  flex: 1;
+}
+
+.chart-anim-speed span:last-child {
+  min-width: 28px;
+  text-align: right;
+  color: var(--sb-text);
+}
+
+.anim-controls {
+  margin-top: 6px;
+}
+
+.anim-play-btn {
+  width: 100%;
+  justify-content: center;
+  margin-bottom: 2px;
 }
 
 /* ── Mouse position control ─────────────────────────────────── */

--- a/src/bowser/dist/index.css
+++ b/src/bowser/dist/index.css
@@ -685,6 +685,45 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--sb-bg);
 }
 
+/* ── Theme toggle button ───────────────────────────────────── */
+.sidebar-theme-toggle {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 10px 0;
+}
+
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  color: var(--sb-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 0.85em;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.theme-toggle-btn:hover {
+  color: var(--sb-text);
+  border-color: var(--sb-accent);
+}
+
+/* ── Light theme ───────────────────────────────────────────── */
+[data-theme="light"] {
+  --sb-bg:        #f0f2f8;
+  --sb-surface:   #ffffff;
+  --sb-surface2:  #e4e7f0;
+  --sb-border:    #c8cce0;
+  --sb-text:      #1a1d2e;
+  --sb-muted:     #6068a0;
+  --sb-accent:    #2478c8;
+  --sb-accent2:   #1a5fa0;
+  --sb-green:     #1e8f50;
+  --sb-red:       #c0303e;
+  color: var(--sb-text);
+  background-color: var(--sb-bg);
+}
+
 a { font-weight: 500; color: var(--sb-accent); text-decoration: none; }
 a:hover { color: var(--sb-accent2); }
 
@@ -1035,11 +1074,11 @@ img.huechange { filter: hue-rotate(120deg); }
   bottom: 20px;
   right: 20px;
   padding: 14px;
-  background: rgba(19, 21, 31, 0.95);
+  background: var(--sb-surface);
   backdrop-filter: blur(8px);
   z-index: 3000;
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   border: 1px solid var(--sb-border);
   display: flex;
   flex-direction: column;
@@ -1116,12 +1155,13 @@ img.huechange { filter: hue-rotate(120deg); }
 
 /* ── Mouse position control ─────────────────────────────────── */
 .leaflet-control-mouseposition {
-  background-color: rgba(19, 21, 31, 0.8);
-  box-shadow: 0 0 5px rgba(0,0,0,0.4);
+  background-color: var(--sb-surface);
+  box-shadow: 0 0 5px rgba(0,0,0,0.3);
   padding: 2px 6px;
   color: var(--sb-text);
   font: 11px/1.5 "Inter", "Helvetica Neue", Arial, sans-serif;
   border-radius: 4px;
+  border: 1px solid var(--sb-border);
 }
 
 /* ── Point Manager Panel ────────────────────────────────────── */
@@ -1350,14 +1390,37 @@ img.huechange { filter: hue-rotate(120deg); }
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  width: 500px;
-  max-width: 90vw;
-  background: rgba(19, 21, 31, 0.95);
+  width: 540px;
+  max-width: 92vw;
+  background: var(--sb-surface);
   border: 1px solid var(--sb-border);
   border-radius: 12px;
   padding: 12px 14px;
   z-index: 3500;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   backdrop-filter: blur(8px);
   color: var(--sb-text);
+}
+
+.profile-radius-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 4px;
+}
+
+.profile-radius-input {
+  width: 70px;
+  background: var(--sb-surface2);
+  border: 1px solid var(--sb-border);
+  border-radius: 5px;
+  color: var(--sb-text);
+  font-size: 0.8em;
+  padding: 2px 5px;
+  text-align: right;
+}
+
+.profile-radius-input:focus {
+  outline: none;
+  border-color: var(--sb-accent);
 }

--- a/src/bowser/dist/index.css
+++ b/src/bowser/dist/index.css
@@ -1075,13 +1075,9 @@ img.huechange { filter: hue-rotate(120deg); }
 
 /* ── Time Series Chart ──────────────────────────────────────── */
 #chart-container {
-  width: 38vw;
-  max-width: 560px;
-  min-width: 320px;
-  height: 420px;
   position: fixed;
-  bottom: 20px;
-  right: 20px;
+  min-width: 320px;
+  min-height: 260px;
   padding: 14px;
   background: var(--sb-surface);
   backdrop-filter: blur(8px);
@@ -1092,6 +1088,7 @@ img.huechange { filter: hue-rotate(120deg); }
   display: flex;
   flex-direction: column;
   color: var(--sb-text);
+  user-select: none;
 }
 
 .chart-header {
@@ -1134,6 +1131,40 @@ img.huechange { filter: hue-rotate(120deg); }
   background: var(--sb-accent);
   color: white;
   border-color: var(--sb-accent);
+}
+
+.chart-sliders {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--sb-border);
+}
+
+.chart-slider-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78em;
+  color: var(--sb-muted);
+}
+
+.chart-slider-label input[type="range"] {
+  width: 80px;
+  accent-color: var(--sb-accent);
+  cursor: pointer;
+}
+
+.chart-slider-label input[type="date"] {
+  background: var(--sb-surface2);
+  color: var(--sb-text);
+  border: 1px solid var(--sb-border);
+  border-radius: 4px;
+  padding: 2px 5px;
+  font-size: 0.85em;
+  cursor: pointer;
 }
 
 .chart-content {
@@ -1437,15 +1468,15 @@ img.huechange { filter: hue-rotate(120deg); }
 /* ── Profile panel ──────────────────────────────────────────── */
 .profile-panel {
   position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 540px;
-  max-width: 92vw;
+  min-width: 320px;
+  min-height: 160px;
+  user-select: none;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 14px;
   background: var(--sb-surface);
   border: 1px solid var(--sb-border);
   border-radius: 12px;
-  padding: 12px 14px;
   z-index: 3500;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   backdrop-filter: blur(8px);

--- a/src/bowser/dist/index.css
+++ b/src/bowser/dist/index.css
@@ -756,6 +756,42 @@ body {
   grid-template-columns: 22em auto;
   height: 100vh;
   width: 100vw;
+  transition: grid-template-columns 0.2s ease;
+}
+
+.app-container.sidebar-hidden {
+  grid-template-columns: 0 auto;
+}
+
+.app-container.sidebar-hidden #menu {
+  overflow: hidden;
+  border-right: none;
+}
+
+.sidebar-toggle-btn {
+  position: absolute;
+  top: 50%;
+  left: 8px;
+  transform: translateY(-50%);
+  z-index: 1100;
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border);
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--sb-text);
+  font-size: 0.75em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  padding: 0;
+  transition: left 0.2s ease;
+}
+
+.sidebar-toggle-btn:hover {
+  background: var(--sb-surface2);
 }
 
 /* ── Sidebar ────────────────────────────────────────────────── */

--- a/src/bowser/dist/index.js
+++ b/src/bowser/dist/index.js
@@ -7049,11 +7049,13 @@ const initialState = {
   bufferEnabled: false,
   bufferRadius: 500,
   bufferSamples: 10,
-  pickingEnabled: true,
+  pickingEnabled: false,
   refEnabled: true,
   refBufferEnabled: false,
   refBufferRadius: 500,
-  showRefChart: false
+  showRefChart: false,
+  isPlaying: false,
+  animationSpeed: 500
 };
 function appReducer(state, action) {
   switch (action.type) {
@@ -7206,6 +7208,12 @@ function appReducer(state, action) {
       return { ...state, refBufferRadius: action.payload };
     case "TOGGLE_REF_CHART":
       return { ...state, showRefChart: !state.showRefChart };
+    case "TOGGLE_PLAYING":
+      return { ...state, isPlaying: !state.isPlaying };
+    case "SET_PLAYING":
+      return { ...state, isPlaying: action.payload };
+    case "SET_ANIMATION_SPEED":
+      return { ...state, animationSpeed: action.payload };
     case "TOGGLE_CHART":
       return { ...state, showChart: !state.showChart };
     default:
@@ -7233,6 +7241,10 @@ function useApi() {
     const response = await fetch("/mode");
     const data = await response.json();
     return data.mode;
+  }, []);
+  const fetchConfig = reactExports.useCallback(async () => {
+    const response = await fetch("/config");
+    return await response.json();
   }, []);
   const fetchPointTimeSeries = reactExports.useCallback(async (lon, lat, datasetName) => {
     const params = new URLSearchParams({
@@ -7345,6 +7357,7 @@ function useApi() {
   return {
     fetchDatasets,
     fetchDataMode,
+    fetchConfig,
     fetchPointTimeSeries,
     fetchChartTimeSeries,
     fetchMultiPointTimeSeries,
@@ -8450,15 +8463,15 @@ var leafletSrc = { exports: {} };
     var CRS = {
       // @method latLngToPoint(latlng: LatLng, zoom: Number): Point
       // Projects geographical coordinates into pixel coordinates for a given zoom.
-      latLngToPoint: function(latlng, zoom2) {
-        var projectedPoint = this.projection.project(latlng), scale2 = this.scale(zoom2);
+      latLngToPoint: function(latlng, zoom3) {
+        var projectedPoint = this.projection.project(latlng), scale2 = this.scale(zoom3);
         return this.transformation._transform(projectedPoint, scale2);
       },
       // @method pointToLatLng(point: Point, zoom: Number): LatLng
       // The inverse of `latLngToPoint`. Projects pixel coordinates on a given
       // zoom into geographical coordinates.
-      pointToLatLng: function(point, zoom2) {
-        var scale2 = this.scale(zoom2), untransformedPoint = this.transformation.untransform(point, scale2);
+      pointToLatLng: function(point, zoom3) {
+        var scale2 = this.scale(zoom3), untransformedPoint = this.transformation.untransform(point, scale2);
         return this.projection.unproject(untransformedPoint);
       },
       // @method project(latlng: LatLng): Point
@@ -8477,8 +8490,8 @@ var leafletSrc = { exports: {} };
       // Returns the scale used when transforming projected coordinates into
       // pixel coordinates for a particular zoom. For example, it returns
       // `256 * 2^zoom` for Mercator-based CRS.
-      scale: function(zoom2) {
-        return 256 * Math.pow(2, zoom2);
+      scale: function(zoom3) {
+        return 256 * Math.pow(2, zoom3);
       },
       // @method zoom(scale: Number): Number
       // Inverse of `scale()`, returns the zoom level corresponding to a scale
@@ -8488,11 +8501,11 @@ var leafletSrc = { exports: {} };
       },
       // @method getProjectedBounds(zoom: Number): Bounds
       // Returns the projection's bounds scaled and transformed for the provided `zoom`.
-      getProjectedBounds: function(zoom2) {
+      getProjectedBounds: function(zoom3) {
         if (this.infinite) {
           return null;
         }
-        var b = this.projection.bounds, s = this.scale(zoom2), min = this.transformation.transform(b.min, s), max = this.transformation.transform(b.max, s);
+        var b = this.projection.bounds, s = this.scale(zoom3), min = this.transformation.transform(b.min, s), max = this.transformation.transform(b.max, s);
         return new Bounds(min, max);
       },
       // @method distance(latlng1: LatLng, latlng2: LatLng): Number
@@ -9488,9 +9501,9 @@ var leafletSrc = { exports: {} };
       // @method setView(center: LatLng, zoom: Number, options?: Zoom/pan options): this
       // Sets the view of the map (geographical center and zoom) with the given
       // animation options.
-      setView: function(center, zoom2, options) {
-        zoom2 = zoom2 === void 0 ? this._zoom : this._limitZoom(zoom2);
-        center = this._limitCenter(toLatLng(center), zoom2, this.options.maxBounds);
+      setView: function(center, zoom3, options) {
+        zoom3 = zoom3 === void 0 ? this._zoom : this._limitZoom(zoom3);
+        center = this._limitCenter(toLatLng(center), zoom3, this.options.maxBounds);
         options = options || {};
         this._stop();
         if (this._loaded && !options.reset && options !== true) {
@@ -9498,23 +9511,23 @@ var leafletSrc = { exports: {} };
             options.zoom = extend({ animate: options.animate }, options.zoom);
             options.pan = extend({ animate: options.animate, duration: options.duration }, options.pan);
           }
-          var moved = this._zoom !== zoom2 ? this._tryAnimatedZoom && this._tryAnimatedZoom(center, zoom2, options.zoom) : this._tryAnimatedPan(center, options.pan);
+          var moved = this._zoom !== zoom3 ? this._tryAnimatedZoom && this._tryAnimatedZoom(center, zoom3, options.zoom) : this._tryAnimatedPan(center, options.pan);
           if (moved) {
             clearTimeout(this._sizeTimer);
             return this;
           }
         }
-        this._resetView(center, zoom2, options.pan && options.pan.noMoveStart);
+        this._resetView(center, zoom3, options.pan && options.pan.noMoveStart);
         return this;
       },
       // @method setZoom(zoom: Number, options?: Zoom/pan options): this
       // Sets the zoom of the map.
-      setZoom: function(zoom2, options) {
+      setZoom: function(zoom3, options) {
         if (!this._loaded) {
-          this._zoom = zoom2;
+          this._zoom = zoom3;
           return this;
         }
-        return this.setView(this.getCenter(), zoom2, { zoom: options });
+        return this.setView(this.getCenter(), zoom3, { zoom: options });
       },
       // @method zoomIn(delta?: Number, options?: Zoom options): this
       // Increases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
@@ -9534,25 +9547,25 @@ var leafletSrc = { exports: {} };
       // @alternative
       // @method setZoomAround(offset: Point, zoom: Number, options: Zoom options): this
       // Zooms the map while keeping a specified pixel on the map (relative to the top-left corner) stationary.
-      setZoomAround: function(latlng, zoom2, options) {
-        var scale2 = this.getZoomScale(zoom2), viewHalf = this.getSize().divideBy(2), containerPoint = latlng instanceof Point ? latlng : this.latLngToContainerPoint(latlng), centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale2), newCenter = this.containerPointToLatLng(viewHalf.add(centerOffset));
-        return this.setView(newCenter, zoom2, { zoom: options });
+      setZoomAround: function(latlng, zoom3, options) {
+        var scale2 = this.getZoomScale(zoom3), viewHalf = this.getSize().divideBy(2), containerPoint = latlng instanceof Point ? latlng : this.latLngToContainerPoint(latlng), centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale2), newCenter = this.containerPointToLatLng(viewHalf.add(centerOffset));
+        return this.setView(newCenter, zoom3, { zoom: options });
       },
       _getBoundsCenterZoom: function(bounds, options) {
         options = options || {};
         bounds = bounds.getBounds ? bounds.getBounds() : toLatLngBounds(bounds);
-        var paddingTL = toPoint(options.paddingTopLeft || options.padding || [0, 0]), paddingBR = toPoint(options.paddingBottomRight || options.padding || [0, 0]), zoom2 = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR));
-        zoom2 = typeof options.maxZoom === "number" ? Math.min(options.maxZoom, zoom2) : zoom2;
-        if (zoom2 === Infinity) {
+        var paddingTL = toPoint(options.paddingTopLeft || options.padding || [0, 0]), paddingBR = toPoint(options.paddingBottomRight || options.padding || [0, 0]), zoom3 = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR));
+        zoom3 = typeof options.maxZoom === "number" ? Math.min(options.maxZoom, zoom3) : zoom3;
+        if (zoom3 === Infinity) {
           return {
             center: bounds.getCenter(),
-            zoom: zoom2
+            zoom: zoom3
           };
         }
-        var paddingOffset = paddingBR.subtract(paddingTL).divideBy(2), swPoint = this.project(bounds.getSouthWest(), zoom2), nePoint = this.project(bounds.getNorthEast(), zoom2), center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom2);
+        var paddingOffset = paddingBR.subtract(paddingTL).divideBy(2), swPoint = this.project(bounds.getSouthWest(), zoom3), nePoint = this.project(bounds.getNorthEast(), zoom3), center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom3);
         return {
           center,
-          zoom: zoom2
+          zoom: zoom3
         };
       },
       // @method fitBounds(bounds: LatLngBounds, options?: fitBounds options): this
@@ -9690,26 +9703,26 @@ var leafletSrc = { exports: {} };
       },
       // @method setMinZoom(zoom: Number): this
       // Sets the lower limit for the available zoom levels (see the [minZoom](#map-minzoom) option).
-      setMinZoom: function(zoom2) {
+      setMinZoom: function(zoom3) {
         var oldZoom = this.options.minZoom;
-        this.options.minZoom = zoom2;
-        if (this._loaded && oldZoom !== zoom2) {
+        this.options.minZoom = zoom3;
+        if (this._loaded && oldZoom !== zoom3) {
           this.fire("zoomlevelschange");
           if (this.getZoom() < this.options.minZoom) {
-            return this.setZoom(zoom2);
+            return this.setZoom(zoom3);
           }
         }
         return this;
       },
       // @method setMaxZoom(zoom: Number): this
       // Sets the upper limit for the available zoom levels (see the [maxZoom](#map-maxzoom) option).
-      setMaxZoom: function(zoom2) {
+      setMaxZoom: function(zoom3) {
         var oldZoom = this.options.maxZoom;
-        this.options.maxZoom = zoom2;
-        if (this._loaded && oldZoom !== zoom2) {
+        this.options.maxZoom = zoom3;
+        if (this._loaded && oldZoom !== zoom3) {
           this.fire("zoomlevelschange");
           if (this.getZoom() > this.options.maxZoom) {
-            return this.setZoom(zoom2);
+            return this.setZoom(zoom3);
           }
         }
         return this;
@@ -9865,8 +9878,8 @@ var leafletSrc = { exports: {} };
         }
         var lat = pos.coords.latitude, lng = pos.coords.longitude, latlng = new LatLng(lat, lng), bounds = latlng.toBounds(pos.coords.accuracy * 2), options = this._locateOptions;
         if (options.setView) {
-          var zoom2 = this.getBoundsZoom(bounds);
-          this.setView(latlng, options.maxZoom ? Math.min(zoom2, options.maxZoom) : zoom2);
+          var zoom3 = this.getBoundsZoom(bounds);
+          this.setView(latlng, options.maxZoom ? Math.min(zoom3, options.maxZoom) : zoom3);
         }
         var data = {
           latlng,
@@ -9992,13 +10005,13 @@ var leafletSrc = { exports: {} };
       getBoundsZoom: function(bounds, inside, padding) {
         bounds = toLatLngBounds(bounds);
         padding = toPoint(padding || [0, 0]);
-        var zoom2 = this.getZoom() || 0, min = this.getMinZoom(), max = this.getMaxZoom(), nw = bounds.getNorthWest(), se2 = bounds.getSouthEast(), size = this.getSize().subtract(padding), boundsSize = toBounds(this.project(se2, zoom2), this.project(nw, zoom2)).getSize(), snap = Browser.any3d ? this.options.zoomSnap : 1, scalex = size.x / boundsSize.x, scaley = size.y / boundsSize.y, scale2 = inside ? Math.max(scalex, scaley) : Math.min(scalex, scaley);
-        zoom2 = this.getScaleZoom(scale2, zoom2);
+        var zoom3 = this.getZoom() || 0, min = this.getMinZoom(), max = this.getMaxZoom(), nw = bounds.getNorthWest(), se2 = bounds.getSouthEast(), size = this.getSize().subtract(padding), boundsSize = toBounds(this.project(se2, zoom3), this.project(nw, zoom3)).getSize(), snap = Browser.any3d ? this.options.zoomSnap : 1, scalex = size.x / boundsSize.x, scaley = size.y / boundsSize.y, scale2 = inside ? Math.max(scalex, scaley) : Math.min(scalex, scaley);
+        zoom3 = this.getScaleZoom(scale2, zoom3);
         if (snap) {
-          zoom2 = Math.round(zoom2 / (snap / 100)) * (snap / 100);
-          zoom2 = inside ? Math.ceil(zoom2 / snap) * snap : Math.floor(zoom2 / snap) * snap;
+          zoom3 = Math.round(zoom3 / (snap / 100)) * (snap / 100);
+          zoom3 = inside ? Math.ceil(zoom3 / snap) * snap : Math.floor(zoom3 / snap) * snap;
         }
-        return Math.max(min, Math.min(max, zoom2));
+        return Math.max(min, Math.min(max, zoom3));
       },
       // @method getSize(): Point
       // Returns the current size of the map container (in pixels).
@@ -10015,8 +10028,8 @@ var leafletSrc = { exports: {} };
       // @method getPixelBounds(): Bounds
       // Returns the bounds of the current map view in projected pixel
       // coordinates (sometimes useful in layer and overlay implementations).
-      getPixelBounds: function(center, zoom2) {
-        var topLeftPoint = this._getTopLeftPoint(center, zoom2);
+      getPixelBounds: function(center, zoom3) {
+        var topLeftPoint = this._getTopLeftPoint(center, zoom3);
         return new Bounds(topLeftPoint, topLeftPoint.add(this.getSize()));
       },
       // TODO: Check semantics - isn't the pixel origin the 0,0 coord relative to
@@ -10032,8 +10045,8 @@ var leafletSrc = { exports: {} };
       // @method getPixelWorldBounds(zoom?: Number): Bounds
       // Returns the world's bounds in pixel coordinates for zoom level `zoom`.
       // If `zoom` is omitted, the map's current zoom level is used.
-      getPixelWorldBounds: function(zoom2) {
-        return this.options.crs.getProjectedBounds(zoom2 === void 0 ? this.getZoom() : zoom2);
+      getPixelWorldBounds: function(zoom3) {
+        return this.options.crs.getProjectedBounds(zoom3 === void 0 ? this.getZoom() : zoom3);
       },
       // @section Other Methods
       // @method getPane(pane: String|HTMLElement): HTMLElement
@@ -10068,23 +10081,23 @@ var leafletSrc = { exports: {} };
       getScaleZoom: function(scale2, fromZoom) {
         var crs = this.options.crs;
         fromZoom = fromZoom === void 0 ? this._zoom : fromZoom;
-        var zoom2 = crs.zoom(scale2 * crs.scale(fromZoom));
-        return isNaN(zoom2) ? Infinity : zoom2;
+        var zoom3 = crs.zoom(scale2 * crs.scale(fromZoom));
+        return isNaN(zoom3) ? Infinity : zoom3;
       },
       // @method project(latlng: LatLng, zoom: Number): Point
       // Projects a geographical coordinate `LatLng` according to the projection
       // of the map's CRS, then scales it according to `zoom` and the CRS's
       // `Transformation`. The result is pixel coordinate relative to
       // the CRS origin.
-      project: function(latlng, zoom2) {
-        zoom2 = zoom2 === void 0 ? this._zoom : zoom2;
-        return this.options.crs.latLngToPoint(toLatLng(latlng), zoom2);
+      project: function(latlng, zoom3) {
+        zoom3 = zoom3 === void 0 ? this._zoom : zoom3;
+        return this.options.crs.latLngToPoint(toLatLng(latlng), zoom3);
       },
       // @method unproject(point: Point, zoom: Number): LatLng
       // Inverse of [`project`](#map-project).
-      unproject: function(point, zoom2) {
-        zoom2 = zoom2 === void 0 ? this._zoom : zoom2;
-        return this.options.crs.pointToLatLng(toPoint(point), zoom2);
+      unproject: function(point, zoom3) {
+        zoom3 = zoom3 === void 0 ? this._zoom : zoom3;
+        return this.options.crs.pointToLatLng(toPoint(point), zoom3);
       },
       // @method layerPointToLatLng(point: Point): LatLng
       // Given a pixel coordinate relative to the [origin pixel](#map-getpixelorigin),
@@ -10209,14 +10222,14 @@ var leafletSrc = { exports: {} };
       },
       // private methods that modify map state
       // @section Map state change events
-      _resetView: function(center, zoom2, noMoveStart) {
+      _resetView: function(center, zoom3, noMoveStart) {
         setPosition(this._mapPane, new Point(0, 0));
         var loading = !this._loaded;
         this._loaded = true;
-        zoom2 = this._limitZoom(zoom2);
+        zoom3 = this._limitZoom(zoom3);
         this.fire("viewprereset");
-        var zoomChanged = this._zoom !== zoom2;
-        this._moveStart(zoomChanged, noMoveStart)._move(center, zoom2)._moveEnd(zoomChanged);
+        var zoomChanged = this._zoom !== zoom3;
+        this._moveStart(zoomChanged, noMoveStart)._move(center, zoom3)._moveEnd(zoomChanged);
         this.fire("viewreset");
         if (loading) {
           this.fire("load");
@@ -10231,12 +10244,12 @@ var leafletSrc = { exports: {} };
         }
         return this;
       },
-      _move: function(center, zoom2, data, supressEvent) {
-        if (zoom2 === void 0) {
-          zoom2 = this._zoom;
+      _move: function(center, zoom3, data, supressEvent) {
+        if (zoom3 === void 0) {
+          zoom3 = this._zoom;
         }
-        var zoomChanged = this._zoom !== zoom2;
-        this._zoom = zoom2;
+        var zoomChanged = this._zoom !== zoom3;
+        this._zoom = zoom3;
         this._lastCenter = center;
         this._pixelOrigin = this._getNewPixelOrigin(center);
         if (!supressEvent) {
@@ -10427,25 +10440,25 @@ var leafletSrc = { exports: {} };
         var pos = this._getMapPanePos();
         return pos && !pos.equals([0, 0]);
       },
-      _getTopLeftPoint: function(center, zoom2) {
-        var pixelOrigin = center && zoom2 !== void 0 ? this._getNewPixelOrigin(center, zoom2) : this.getPixelOrigin();
+      _getTopLeftPoint: function(center, zoom3) {
+        var pixelOrigin = center && zoom3 !== void 0 ? this._getNewPixelOrigin(center, zoom3) : this.getPixelOrigin();
         return pixelOrigin.subtract(this._getMapPanePos());
       },
-      _getNewPixelOrigin: function(center, zoom2) {
+      _getNewPixelOrigin: function(center, zoom3) {
         var viewHalf = this.getSize()._divideBy(2);
-        return this.project(center, zoom2)._subtract(viewHalf)._add(this._getMapPanePos())._round();
+        return this.project(center, zoom3)._subtract(viewHalf)._add(this._getMapPanePos())._round();
       },
-      _latLngToNewLayerPoint: function(latlng, zoom2, center) {
-        var topLeft = this._getNewPixelOrigin(center, zoom2);
-        return this.project(latlng, zoom2)._subtract(topLeft);
+      _latLngToNewLayerPoint: function(latlng, zoom3, center) {
+        var topLeft = this._getNewPixelOrigin(center, zoom3);
+        return this.project(latlng, zoom3)._subtract(topLeft);
       },
-      _latLngBoundsToNewLayerBounds: function(latLngBounds, zoom2, center) {
-        var topLeft = this._getNewPixelOrigin(center, zoom2);
+      _latLngBoundsToNewLayerBounds: function(latLngBounds, zoom3, center) {
+        var topLeft = this._getNewPixelOrigin(center, zoom3);
         return toBounds([
-          this.project(latLngBounds.getSouthWest(), zoom2)._subtract(topLeft),
-          this.project(latLngBounds.getNorthWest(), zoom2)._subtract(topLeft),
-          this.project(latLngBounds.getSouthEast(), zoom2)._subtract(topLeft),
-          this.project(latLngBounds.getNorthEast(), zoom2)._subtract(topLeft)
+          this.project(latLngBounds.getSouthWest(), zoom3)._subtract(topLeft),
+          this.project(latLngBounds.getNorthWest(), zoom3)._subtract(topLeft),
+          this.project(latLngBounds.getSouthEast(), zoom3)._subtract(topLeft),
+          this.project(latLngBounds.getNorthEast(), zoom3)._subtract(topLeft)
         ]);
       },
       // layer point of the current center
@@ -10457,15 +10470,15 @@ var leafletSrc = { exports: {} };
         return this.latLngToLayerPoint(latlng).subtract(this._getCenterLayerPoint());
       },
       // adjust center for view to get inside bounds
-      _limitCenter: function(center, zoom2, bounds) {
+      _limitCenter: function(center, zoom3, bounds) {
         if (!bounds) {
           return center;
         }
-        var centerPoint = this.project(center, zoom2), viewHalf = this.getSize().divideBy(2), viewBounds = new Bounds(centerPoint.subtract(viewHalf), centerPoint.add(viewHalf)), offset = this._getBoundsOffset(viewBounds, bounds, zoom2);
+        var centerPoint = this.project(center, zoom3), viewHalf = this.getSize().divideBy(2), viewBounds = new Bounds(centerPoint.subtract(viewHalf), centerPoint.add(viewHalf)), offset = this._getBoundsOffset(viewBounds, bounds, zoom3);
         if (Math.abs(offset.x) <= 1 && Math.abs(offset.y) <= 1) {
           return center;
         }
-        return this.unproject(centerPoint.add(offset), zoom2);
+        return this.unproject(centerPoint.add(offset), zoom3);
       },
       // adjust offset for view to get inside bounds
       _limitOffset: function(offset, bounds) {
@@ -10476,22 +10489,22 @@ var leafletSrc = { exports: {} };
         return offset.add(this._getBoundsOffset(newBounds, bounds));
       },
       // returns offset needed for pxBounds to get inside maxBounds at a specified zoom
-      _getBoundsOffset: function(pxBounds, maxBounds, zoom2) {
+      _getBoundsOffset: function(pxBounds, maxBounds, zoom3) {
         var projectedMaxBounds = toBounds(
-          this.project(maxBounds.getNorthEast(), zoom2),
-          this.project(maxBounds.getSouthWest(), zoom2)
+          this.project(maxBounds.getNorthEast(), zoom3),
+          this.project(maxBounds.getSouthWest(), zoom3)
         ), minOffset = projectedMaxBounds.min.subtract(pxBounds.min), maxOffset = projectedMaxBounds.max.subtract(pxBounds.max), dx = this._rebound(minOffset.x, -maxOffset.x), dy = this._rebound(minOffset.y, -maxOffset.y);
         return new Point(dx, dy);
       },
       _rebound: function(left, right) {
         return left + right > 0 ? Math.round(left - right) / 2 : Math.max(0, Math.ceil(left)) - Math.max(0, Math.floor(right));
       },
-      _limitZoom: function(zoom2) {
+      _limitZoom: function(zoom3) {
         var min = this.getMinZoom(), max = this.getMaxZoom(), snap = Browser.any3d ? this.options.zoomSnap : 1;
         if (snap) {
-          zoom2 = Math.round(zoom2 / snap) * snap;
+          zoom3 = Math.round(zoom3 / snap) * snap;
         }
-        return Math.max(min, Math.min(max, zoom2));
+        return Math.max(min, Math.min(max, zoom3));
       },
       _onPanTransitionStep: function() {
         this.fire("move");
@@ -10538,36 +10551,36 @@ var leafletSrc = { exports: {} };
       _nothingToAnimate: function() {
         return !this._container.getElementsByClassName("leaflet-zoom-animated").length;
       },
-      _tryAnimatedZoom: function(center, zoom2, options) {
+      _tryAnimatedZoom: function(center, zoom3, options) {
         if (this._animatingZoom) {
           return true;
         }
         options = options || {};
-        if (!this._zoomAnimated || options.animate === false || this._nothingToAnimate() || Math.abs(zoom2 - this._zoom) > this.options.zoomAnimationThreshold) {
+        if (!this._zoomAnimated || options.animate === false || this._nothingToAnimate() || Math.abs(zoom3 - this._zoom) > this.options.zoomAnimationThreshold) {
           return false;
         }
-        var scale2 = this.getZoomScale(zoom2), offset = this._getCenterOffset(center)._divideBy(1 - 1 / scale2);
+        var scale2 = this.getZoomScale(zoom3), offset = this._getCenterOffset(center)._divideBy(1 - 1 / scale2);
         if (options.animate !== true && !this.getSize().contains(offset)) {
           return false;
         }
         requestAnimFrame2(function() {
-          this._moveStart(true, options.noMoveStart || false)._animateZoom(center, zoom2, true);
+          this._moveStart(true, options.noMoveStart || false)._animateZoom(center, zoom3, true);
         }, this);
         return true;
       },
-      _animateZoom: function(center, zoom2, startAnim, noUpdate) {
+      _animateZoom: function(center, zoom3, startAnim, noUpdate) {
         if (!this._mapPane) {
           return;
         }
         if (startAnim) {
           this._animatingZoom = true;
           this._animateToCenter = center;
-          this._animateToZoom = zoom2;
+          this._animateToZoom = zoom3;
           addClass(this._mapPane, "leaflet-zoom-anim");
         }
         this.fire("zoomanim", {
           center,
-          zoom: zoom2,
+          zoom: zoom3,
           noUpdate
         });
         if (!this._tempFireZoomEvent) {
@@ -10968,11 +10981,11 @@ var leafletSrc = { exports: {} };
         this._refocusOnMap();
       },
       _checkDisabledLayers: function() {
-        var inputs = this._layerControlInputs, input, layer, zoom2 = this._map.getZoom();
+        var inputs = this._layerControlInputs, input, layer, zoom3 = this._map.getZoom();
         for (var i = inputs.length - 1; i >= 0; i--) {
           input = inputs[i];
           layer = this._getLayer(input.layerId).layer;
-          input.disabled = layer.options.minZoom !== void 0 && zoom2 < layer.options.minZoom || layer.options.maxZoom !== void 0 && zoom2 > layer.options.maxZoom;
+          input.disabled = layer.options.minZoom !== void 0 && zoom3 < layer.options.minZoom || layer.options.maxZoom !== void 0 && zoom3 > layer.options.maxZoom;
         }
       },
       _expandIfNotCollapsed: function() {
@@ -11095,7 +11108,7 @@ var leafletSrc = { exports: {} };
         this.addControl(this.zoomControl);
       }
     });
-    var zoom = function(options) {
+    var zoom2 = function(options) {
       return new Zoom(options);
     };
     var Scale2 = Control.extend({
@@ -11283,7 +11296,7 @@ var leafletSrc = { exports: {} };
     Control.Scale = Scale2;
     Control.Attribution = Attribution;
     control.layers = layers;
-    control.zoom = zoom;
+    control.zoom = zoom2;
     control.scale = scale;
     control.attribution = attribution;
     var Handler = Class.extend({
@@ -11798,8 +11811,8 @@ var leafletSrc = { exports: {} };
     var Simple = extend({}, CRS, {
       projection: LonLat,
       transformation: toTransformation(1, 0, -1, 0),
-      scale: function(zoom2) {
-        return Math.pow(2, zoom2);
+      scale: function(zoom3) {
+        return Math.pow(2, zoom3);
       },
       zoom: function(scale2) {
         return Math.log(scale2) / Math.LN2;
@@ -14895,14 +14908,14 @@ var leafletSrc = { exports: {} };
         this.getPane().appendChild(this._container);
       },
       _updateLevels: function() {
-        var zoom2 = this._tileZoom, maxZoom = this.options.maxZoom;
-        if (zoom2 === void 0) {
+        var zoom3 = this._tileZoom, maxZoom = this.options.maxZoom;
+        if (zoom3 === void 0) {
           return void 0;
         }
         for (var z2 in this._levels) {
           z2 = Number(z2);
-          if (this._levels[z2].el.children.length || z2 === zoom2) {
-            this._levels[z2].el.style.zIndex = maxZoom - Math.abs(zoom2 - z2);
+          if (this._levels[z2].el.children.length || z2 === zoom3) {
+            this._levels[z2].el.style.zIndex = maxZoom - Math.abs(zoom3 - z2);
             this._onUpdateLevel(z2);
           } else {
             remove(this._levels[z2].el);
@@ -14911,13 +14924,13 @@ var leafletSrc = { exports: {} };
             delete this._levels[z2];
           }
         }
-        var level = this._levels[zoom2], map2 = this._map;
+        var level = this._levels[zoom3], map2 = this._map;
         if (!level) {
-          level = this._levels[zoom2] = {};
+          level = this._levels[zoom3] = {};
           level.el = create$1("div", "leaflet-tile-container leaflet-zoom-animated", this._container);
           level.el.style.zIndex = maxZoom;
-          level.origin = map2.project(map2.unproject(map2.getPixelOrigin()), zoom2).round();
-          level.zoom = zoom2;
+          level.origin = map2.project(map2.unproject(map2.getPixelOrigin()), zoom3).round();
+          level.zoom = zoom3;
           this._setZoomTransform(level, map2.getCenter(), map2.getZoom());
           falseFn(level.el.offsetWidth);
           this._onCreateLevel(level);
@@ -14933,8 +14946,8 @@ var leafletSrc = { exports: {} };
           return;
         }
         var key, tile;
-        var zoom2 = this._map.getZoom();
-        if (zoom2 > this.options.maxZoom || zoom2 < this.options.minZoom) {
+        var zoom3 = this._map.getZoom();
+        if (zoom3 > this.options.maxZoom || zoom3 < this.options.minZoom) {
           this._removeAllTiles();
           return;
         }
@@ -14957,9 +14970,9 @@ var leafletSrc = { exports: {} };
           }
         }
       },
-      _removeTilesAtZoom: function(zoom2) {
+      _removeTilesAtZoom: function(zoom3) {
         for (var key in this._tiles) {
-          if (this._tiles[key].coords.z !== zoom2) {
+          if (this._tiles[key].coords.z !== zoom3) {
             continue;
           }
           this._removeTile(key);
@@ -15019,18 +15032,18 @@ var leafletSrc = { exports: {} };
       _animateZoom: function(e) {
         this._setView(e.center, e.zoom, true, e.noUpdate);
       },
-      _clampZoom: function(zoom2) {
+      _clampZoom: function(zoom3) {
         var options = this.options;
-        if (void 0 !== options.minNativeZoom && zoom2 < options.minNativeZoom) {
+        if (void 0 !== options.minNativeZoom && zoom3 < options.minNativeZoom) {
           return options.minNativeZoom;
         }
-        if (void 0 !== options.maxNativeZoom && options.maxNativeZoom < zoom2) {
+        if (void 0 !== options.maxNativeZoom && options.maxNativeZoom < zoom3) {
           return options.maxNativeZoom;
         }
-        return zoom2;
+        return zoom3;
       },
-      _setView: function(center, zoom2, noPrune, noUpdate) {
-        var tileZoom = Math.round(zoom2);
+      _setView: function(center, zoom3, noPrune, noUpdate) {
+        var tileZoom = Math.round(zoom3);
         if (this.options.maxZoom !== void 0 && tileZoom > this.options.maxZoom || this.options.minZoom !== void 0 && tileZoom < this.options.minZoom) {
           tileZoom = void 0;
         } else {
@@ -15052,15 +15065,15 @@ var leafletSrc = { exports: {} };
           }
           this._noPrune = !!noPrune;
         }
-        this._setZoomTransforms(center, zoom2);
+        this._setZoomTransforms(center, zoom3);
       },
-      _setZoomTransforms: function(center, zoom2) {
+      _setZoomTransforms: function(center, zoom3) {
         for (var i in this._levels) {
-          this._setZoomTransform(this._levels[i], center, zoom2);
+          this._setZoomTransform(this._levels[i], center, zoom3);
         }
       },
-      _setZoomTransform: function(level, center, zoom2) {
-        var scale2 = this._map.getZoomScale(zoom2, level.zoom), translate = level.origin.multiplyBy(scale2).subtract(this._map._getNewPixelOrigin(center, zoom2)).round();
+      _setZoomTransform: function(level, center, zoom3) {
+        var scale2 = this._map.getZoomScale(zoom3, level.zoom), translate = level.origin.multiplyBy(scale2).subtract(this._map._getNewPixelOrigin(center, zoom3)).round();
         if (Browser.any3d) {
           setTransform(level.el, translate, scale2);
         } else {
@@ -15098,7 +15111,7 @@ var leafletSrc = { exports: {} };
         if (!map2) {
           return;
         }
-        var zoom2 = this._clampZoom(map2.getZoom());
+        var zoom3 = this._clampZoom(map2.getZoom());
         if (center === void 0) {
           center = map2.getCenter();
         }
@@ -15118,8 +15131,8 @@ var leafletSrc = { exports: {} };
             this._tiles[key].current = false;
           }
         }
-        if (Math.abs(zoom2 - this._tileZoom) > 1) {
-          this._setView(center, zoom2);
+        if (Math.abs(zoom3 - this._tileZoom) > 1) {
+          this._setView(center, zoom3);
           return;
         }
         for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {
@@ -15439,11 +15452,11 @@ var leafletSrc = { exports: {} };
         e.tile.onload = null;
       },
       _getZoomForUrl: function() {
-        var zoom2 = this._tileZoom, maxZoom = this.options.maxZoom, zoomReverse = this.options.zoomReverse, zoomOffset = this.options.zoomOffset;
+        var zoom3 = this._tileZoom, maxZoom = this.options.maxZoom, zoomReverse = this.options.zoomReverse, zoomOffset = this.options.zoomOffset;
         if (zoomReverse) {
-          zoom2 = maxZoom - zoom2;
+          zoom3 = maxZoom - zoom3;
         }
-        return zoom2 + zoomOffset;
+        return zoom3 + zoomOffset;
       },
       _getSubdomain: function(tilePoint) {
         var index2 = Math.abs(tilePoint.x + tilePoint.y) % this.options.subdomains.length;
@@ -15608,8 +15621,8 @@ var leafletSrc = { exports: {} };
       _onZoom: function() {
         this._updateTransform(this._map.getCenter(), this._map.getZoom());
       },
-      _updateTransform: function(center, zoom2) {
-        var scale2 = this._map.getZoomScale(zoom2, this._zoom), viewHalf = this._map.getSize().multiplyBy(0.5 + this.options.padding), currentCenterPoint = this._map.project(this._center, zoom2), topLeftOffset = viewHalf.multiplyBy(-scale2).add(currentCenterPoint).subtract(this._map._getNewPixelOrigin(center, zoom2));
+      _updateTransform: function(center, zoom3) {
+        var scale2 = this._map.getZoomScale(zoom3, this._zoom), viewHalf = this._map.getSize().multiplyBy(0.5 + this.options.padding), currentCenterPoint = this._map.project(this._center, zoom3), topLeftOffset = viewHalf.multiplyBy(-scale2).add(currentCenterPoint).subtract(this._map._getNewPixelOrigin(center, zoom3));
         if (Browser.any3d) {
           setTransform(this._container, topLeftOffset, scale2);
         } else {
@@ -16381,11 +16394,11 @@ var leafletSrc = { exports: {} };
         this._map.off("dblclick", this._onDoubleClick, this);
       },
       _onDoubleClick: function(e) {
-        var map2 = this._map, oldZoom = map2.getZoom(), delta = map2.options.zoomDelta, zoom2 = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
+        var map2 = this._map, oldZoom = map2.getZoom(), delta = map2.options.zoomDelta, zoom3 = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
         if (map2.options.doubleClickZoom === "center") {
-          map2.setZoom(zoom2);
+          map2.setZoom(zoom3);
         } else {
-          map2.setZoomAround(e.containerPoint, zoom2);
+          map2.setZoomAround(e.containerPoint, zoom3);
         }
       }
     });
@@ -16631,13 +16644,13 @@ var leafletSrc = { exports: {} };
           keys[codes.up[i]] = [0, -1 * panDelta];
         }
       },
-      _setZoomDelta: function(zoomDelta) {
+      _setZoomDelta: function(zoomDelta2) {
         var keys = this._zoomKeys = {}, codes = this.keyCodes, i, len;
         for (i = 0, len = codes.zoomIn.length; i < len; i++) {
-          keys[codes.zoomIn[i]] = zoomDelta;
+          keys[codes.zoomIn[i]] = zoomDelta2;
         }
         for (i = 0, len = codes.zoomOut.length; i < len; i++) {
-          keys[codes.zoomOut[i]] = -zoomDelta;
+          keys[codes.zoomOut[i]] = -zoomDelta2;
         }
       },
       _addHooks: function() {
@@ -16716,18 +16729,18 @@ var leafletSrc = { exports: {} };
         stop(e);
       },
       _performZoom: function() {
-        var map2 = this._map, zoom2 = map2.getZoom(), snap = this._map.options.zoomSnap || 0;
+        var map2 = this._map, zoom3 = map2.getZoom(), snap = this._map.options.zoomSnap || 0;
         map2._stop();
-        var d2 = this._delta / (this._map.options.wheelPxPerZoomLevel * 4), d3 = 4 * Math.log(2 / (1 + Math.exp(-Math.abs(d2)))) / Math.LN2, d4 = snap ? Math.ceil(d3 / snap) * snap : d3, delta = map2._limitZoom(zoom2 + (this._delta > 0 ? d4 : -d4)) - zoom2;
+        var d2 = this._delta / (this._map.options.wheelPxPerZoomLevel * 4), d3 = 4 * Math.log(2 / (1 + Math.exp(-Math.abs(d2)))) / Math.LN2, d4 = snap ? Math.ceil(d3 / snap) * snap : d3, delta = map2._limitZoom(zoom3 + (this._delta > 0 ? d4 : -d4)) - zoom3;
         this._delta = 0;
         this._startTime = null;
         if (!delta) {
           return;
         }
         if (map2.options.scrollWheelZoom === "center") {
-          map2.setZoom(zoom2 + delta);
+          map2.setZoom(zoom3 + delta);
         } else {
-          map2.setZoomAround(this._lastMousePos, zoom2 + delta);
+          map2.setZoomAround(this._lastMousePos, zoom3 + delta);
         }
       }
     });
@@ -17093,7 +17106,7 @@ function _extends() {
   };
   return _extends.apply(this, arguments);
 }
-function MapContainerComponent({ bounds, boundsOptions, center, children, className, id: id2, placeholder, style, whenReady, zoom, ...options }, forwardedRef) {
+function MapContainerComponent({ bounds, boundsOptions, center, children, className, id: id2, placeholder, style, whenReady, zoom: zoom2, ...options }, forwardedRef) {
   const [props] = reactExports.useState({
     className,
     id: id2,
@@ -17106,8 +17119,8 @@ function MapContainerComponent({ bounds, boundsOptions, center, children, classN
   const mapRef = reactExports.useCallback((node) => {
     if (node !== null && context === null) {
       const map2 = new leafletSrcExports.Map(node, options);
-      if (center != null && zoom != null) {
-        map2.setView(center, zoom);
+      if (center != null && zoom2 != null) {
+        map2.setView(center, zoom2);
       } else if (bounds != null) {
         map2.fitBounds(bounds, boundsOptions);
       }
@@ -18296,7 +18309,7 @@ function throttled(fn, thisArg) {
     }
   };
 }
-function debounce(fn, delay) {
+function debounce$1(fn, delay) {
   let timeout;
   return function(...args) {
     if (delay) {
@@ -24435,14 +24448,14 @@ class PluginService {
   _notify(descriptors2, chart, hook, args) {
     args = args || {};
     for (const descriptor of descriptors2) {
-      const plugin = descriptor.plugin;
-      const method = plugin[hook];
+      const plugin2 = descriptor.plugin;
+      const method = plugin2[hook];
       const params = [
         chart,
         args,
         descriptor.options
       ];
-      if (callback(method, params, plugin) === false && args.cancelable) {
+      if (callback(method, params, plugin2) === false && args.cancelable) {
         return false;
       }
     }
@@ -24485,10 +24498,10 @@ function allPlugins(config) {
   }
   const local = config.plugins || [];
   for (let i = 0; i < local.length; i++) {
-    const plugin = local[i];
-    if (plugins.indexOf(plugin) === -1) {
-      plugins.push(plugin);
-      localIds[plugin.id] = true;
+    const plugin2 = local[i];
+    if (plugins.indexOf(plugin2) === -1) {
+      plugins.push(plugin2);
+      localIds[plugin2.id] = true;
     }
   }
   return {
@@ -24508,27 +24521,27 @@ function getOpts(options, all) {
 function createDescriptors(chart, { plugins, localIds }, options, all) {
   const result = [];
   const context = chart.getContext();
-  for (const plugin of plugins) {
-    const id2 = plugin.id;
+  for (const plugin2 of plugins) {
+    const id2 = plugin2.id;
     const opts = getOpts(options[id2], all);
     if (opts === null) {
       continue;
     }
     result.push({
-      plugin,
+      plugin: plugin2,
       options: pluginOpts(chart.config, {
-        plugin,
+        plugin: plugin2,
         local: localIds[id2]
       }, opts, context)
     });
   }
   return result;
 }
-function pluginOpts(config, { plugin, local }, opts, context) {
-  const keys = config.pluginScopeKeys(plugin);
+function pluginOpts(config, { plugin: plugin2, local }, opts, context) {
+  const keys = config.pluginScopeKeys(plugin2);
   const scopes = config.getOptionScopes(opts, keys);
-  if (local && plugin.defaults) {
-    scopes.push(plugin.defaults);
+  if (local && plugin2.defaults) {
+    scopes.push(plugin2.defaults);
   }
   return config.createResolver(scopes, context, [
     ""
@@ -24753,13 +24766,13 @@ class Config {
       ]
     ]);
   }
-  pluginScopeKeys(plugin) {
-    const id2 = plugin.id;
+  pluginScopeKeys(plugin2) {
+    const id2 = plugin2.id;
     const type = this.type;
     return cachedKeys(`${type}-plugin-${id2}`, () => [
       [
         `plugins.${id2}`,
-        ...plugin.additionalOptionScopes || []
+        ...plugin2.additionalOptionScopes || []
       ]
     ]);
   }
@@ -24869,7 +24882,7 @@ function needContext(proxy, names2) {
   }
   return false;
 }
-var version = "4.4.9";
+var version$1 = "4.4.9";
 const KNOWN_POSITIONS = [
   "top",
   "bottom",
@@ -24986,7 +24999,7 @@ let Chart$1 = (_b = class {
     this.attached = false;
     this._animationsDisabled = void 0;
     this.$context = void 0;
-    this._doResize = debounce((mode) => this.update(mode), options.resizeDelay || 0);
+    this._doResize = debounce$1((mode) => this.update(mode), options.resizeDelay || 0);
     this._dataChanges = [];
     instances[this.id] = this;
     if (!context || !canvas) {
@@ -25700,7 +25713,7 @@ let Chart$1 = (_b = class {
       cancelable: true,
       inChartArea: this.isPointInArea(e)
     };
-    const eventFilter = (plugin) => (plugin.options.events || this.options.events).includes(e.native.type);
+    const eventFilter = (plugin2) => (plugin2.options.events || this.options.events).includes(e.native.type);
     if (this.notifyPlugins("beforeEvent", args, eventFilter) === false) {
       return;
     }
@@ -25751,7 +25764,7 @@ let Chart$1 = (_b = class {
     const hoverOptions = this.options.hover;
     return this.getElementsAtEventForMode(e, hoverOptions.mode, hoverOptions, useFinalPosition);
   }
-}, __publicField(_b, "defaults", defaults), __publicField(_b, "instances", instances), __publicField(_b, "overrides", overrides), __publicField(_b, "registry", registry), __publicField(_b, "version", version), __publicField(_b, "getChart", getChart), _b);
+}, __publicField(_b, "defaults", defaults), __publicField(_b, "instances", instances), __publicField(_b, "overrides", overrides), __publicField(_b, "registry", registry), __publicField(_b, "version", version$1), __publicField(_b, "getChart", getChart), _b);
 function invalidatePlugins() {
   return each(Chart$1.instances, (chart) => chart._plugins.invalidate());
 }
@@ -25900,7 +25913,7 @@ function strokePathDirect(ctx, line, start, count) {
   }
 }
 const usePath2D = typeof Path2D === "function";
-function draw(ctx, line, start, count) {
+function draw$1(ctx, line, start, count) {
   if (usePath2D && !line.options.segment) {
     strokePathWithCache(ctx, line, start, count);
   } else {
@@ -26009,7 +26022,7 @@ class LineElement extends Element$1 {
     const points = this.points || [];
     if (points.length && options.borderWidth) {
       ctx.save();
-      draw(ctx, this, start, count);
+      draw$1(ctx, this, start, count);
       ctx.restore();
     }
     if (this.animated) {
@@ -29558,7 +29571,8 @@ function RasterTileLayer() {
         params.algorithm = currentDatasetInfo.algorithm;
       }
       if (state.refEnabled && state.refValues[state.currentDataset] && currentDatasetInfo.algorithm === "shift") {
-        const shift = state.refValues[state.currentDataset][timeIdx];
+        const refArr = state.refValues[state.currentDataset];
+        const shift = refArr[timeIdx] ?? refArr[0];
         if (shift !== void 0) {
           params.algorithm_params = JSON.stringify({ shift });
         }
@@ -29859,7 +29873,7 @@ function Histogram() {
   const [histData, setHistData] = reactExports.useState(null);
   const [loading, setLoading] = reactExports.useState(false);
   const fetchHistogram = reactExports.useCallback(async () => {
-    if (!state.currentDataset) return;
+    if (!state.currentDataset || state.isPlaying) return;
     setLoading(true);
     try {
       const params = new URLSearchParams({ time_index: String(state.currentTimeIndex) });
@@ -29873,7 +29887,7 @@ function Histogram() {
     } finally {
       setLoading(false);
     }
-  }, [state.currentDataset, state.currentTimeIndex]);
+  }, [state.currentDataset, state.currentTimeIndex, state.isPlaying]);
   reactExports.useEffect(() => {
     fetchHistogram();
   }, [fetchHistogram]);
@@ -29963,12 +29977,15 @@ const colormapOptions = [
   { value: "gray", label: "Grays" },
   { value: "jet", label: "Jet" }
 ];
-function ControlPanel() {
+function ControlPanel({ title }) {
+  var _a2;
   const { state, dispatch } = useAppContext();
   const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [draftVmin, setDraftVmin] = reactExports.useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = reactExports.useState(String(state.vmax));
   const [lightTheme, setLightTheme] = reactExports.useState(false);
+  const [draftRefLat, setDraftRefLat] = reactExports.useState(String(state.refMarkerPosition[0]));
+  const [draftRefLon, setDraftRefLon] = reactExports.useState(String(state.refMarkerPosition[1]));
   const [datasetRanges, setDatasetRanges] = reactExports.useState({});
   reactExports.useEffect(() => {
     const missing = state.layerMasks.map((m2) => m2.dataset).filter((ds) => ds && !(ds in datasetRanges));
@@ -29991,6 +30008,10 @@ function ControlPanel() {
   };
   reactExports.useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
   reactExports.useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
+  reactExports.useEffect(() => {
+    setDraftRefLat(state.refMarkerPosition[0].toFixed(6));
+    setDraftRefLon(state.refMarkerPosition[1].toFixed(6));
+  }, [state.refMarkerPosition]);
   reactExports.useEffect(() => {
     const datasetName = state.currentDataset;
     if (!datasetName) return;
@@ -30042,14 +30063,14 @@ function ControlPanel() {
     if (!Number.isNaN(v2)) dispatch({ type: "SET_VMAX", payload: v2 });
   }, [draftVmax, dispatch]);
   const setRefValues = async (ds) => {
-    var _a2, _b2, _c;
+    var _a3, _b2, _c;
     const [lat, lng] = state.refMarkerPosition;
     try {
       let values;
       if (state.refBufferEnabled && state.refBufferRadius > 0) {
         const result = await fetchBufferTimeSeries(lng, lat, ds, state.refBufferRadius, 0);
         if (result == null ? void 0 : result.median) {
-          const xValues = ((_b2 = (_a2 = state.datasetInfo[ds]) == null ? void 0 : _a2.x_values) == null ? void 0 : _b2.map(String)) ?? ((_c = result.labels) == null ? void 0 : _c.map(String)) ?? [];
+          const xValues = ((_b2 = (_a3 = state.datasetInfo[ds]) == null ? void 0 : _a3.x_values) == null ? void 0 : _b2.map(String)) ?? ((_c = result.labels) == null ? void 0 : _c.map(String)) ?? [];
           const byX = Object.fromEntries(result.median.map((pt) => [String(pt.x), pt.y]));
           values = xValues.map((x2) => byX[x2] ?? NaN);
         }
@@ -30062,10 +30083,32 @@ function ControlPanel() {
       console.error("Error setting reference values:", error);
     }
   };
+  const commitRefPosition = reactExports.useCallback(() => {
+    var _a3;
+    const lat = parseFloat(draftRefLat);
+    const lon = parseFloat(draftRefLon);
+    if (isNaN(lat) || isNaN(lon)) return;
+    dispatch({ type: "SET_REF_MARKER_POSITION", payload: [lat, lon] });
+    const ds = state.currentDataset;
+    if (ds && ((_a3 = state.datasetInfo[ds]) == null ? void 0 : _a3.uses_spatial_ref)) setRefValues(ds);
+  }, [draftRefLat, draftRefLon, state.currentDataset, state.datasetInfo, dispatch]);
   const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
   const currentTimeValue = currentDatasetInfo ? currentDatasetInfo.x_values[state.currentTimeIndex] : "";
+  const nTimes = ((_a2 = currentDatasetInfo == null ? void 0 : currentDatasetInfo.x_values) == null ? void 0 : _a2.length) ?? 0;
+  const timeIndexRef = reactExports.useRef(state.currentTimeIndex);
+  timeIndexRef.current = state.currentTimeIndex;
+  const nTimesRef = reactExports.useRef(nTimes);
+  nTimesRef.current = nTimes;
+  reactExports.useEffect(() => {
+    if (!state.isPlaying || nTimes === 0) return;
+    const id2 = setInterval(() => {
+      dispatch({ type: "SET_TIME_INDEX", payload: (timeIndexRef.current + 1) % nTimesRef.current });
+    }, state.animationSpeed);
+    return () => clearInterval(id2);
+  }, [state.isPlaying, state.animationSpeed, nTimes, dispatch]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "menu", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sidebar-theme-toggle", children: /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "theme-toggle-btn", onClick: toggleTheme, title: lightTheme ? "Switch to dark theme" : "Switch to light theme", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${lightTheme ? "fa-moon" : "fa-sun"}` }) }) }),
+    title && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sidebar-title", children: title }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-layer-group" }),
@@ -30096,7 +30139,41 @@ function ControlPanel() {
             value: state.currentTimeIndex,
             onChange: (e) => dispatch({ type: "SET_TIME_INDEX", payload: parseInt(e.target.value) })
           }
-        )
+        ),
+        currentDatasetInfo.x_values.length > 1 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "anim-controls", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "button",
+            {
+              className: `toggle-pill anim-play-btn${state.isPlaying ? " active" : ""}`,
+              onClick: () => dispatch({ type: "TOGGLE_PLAYING" }),
+              title: state.isPlaying ? "Pause animation" : "Play animation",
+              children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.isPlaying ? "fa-pause" : "fa-play"}` }),
+                state.isPlaying ? "Pause" : "Play"
+              ]
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", style: { marginTop: 4 }, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Speed" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
+              (1e3 / state.animationSpeed).toFixed(1),
+              "×"
+            ] })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "range",
+              className: "sidebar-range",
+              min: "100",
+              max: "2000",
+              step: "100",
+              value: 2100 - state.animationSpeed,
+              onChange: (e) => dispatch({ type: "SET_ANIMATION_SPEED", payload: 2100 - parseInt(e.target.value) }),
+              title: "Animation speed"
+            }
+          )
+        ] })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
@@ -30236,7 +30313,7 @@ function ControlPanel() {
                 onChange: (e) => {
                   const ds = e.target.value;
                   const newRange = datasetRanges[ds];
-                  const defaultThreshold = newRange ? newRange.p2 ?? newRange.min : 0.5;
+                  const defaultThreshold = newRange ? (mask.mode === "max" ? newRange.p98 ?? newRange.max : newRange.p2 ?? newRange.min) ?? 0.5 : 0.5;
                   dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
                 },
                 children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
@@ -30248,7 +30325,12 @@ function ControlPanel() {
                 className: "sidebar-select",
                 style: { width: 56, fontSize: "0.78em", padding: "2px 4px" },
                 value: mask.mode,
-                onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: e.target.value } } }),
+                onChange: (e) => {
+                  const newMode = e.target.value;
+                  const r2 = datasetRanges[mask.dataset];
+                  const newThreshold = r2 ? (newMode === "max" ? r2.p98 ?? r2.max : r2.p2 ?? r2.min) ?? mask.threshold : mask.threshold;
+                  dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: newMode, threshold: newThreshold } } });
+                },
                 children: [
                   /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "min", children: "≥" }),
                   /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "max", children: "≤" })
@@ -30336,8 +30418,8 @@ function ControlPanel() {
                 accept: ".tif,.tiff",
                 style: { display: "none" },
                 onChange: async (e) => {
-                  var _a2;
-                  const f2 = (_a2 = e.target.files) == null ? void 0 : _a2[0];
+                  var _a3;
+                  const f2 = (_a3 = e.target.files) == null ? void 0 : _a3[0];
                   if (!f2) return;
                   const form = new FormData();
                   form.append("file", f2);
@@ -30424,9 +30506,41 @@ function ControlPanel() {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-crosshairs" }),
-        " Reference Buffer"
+        " Reference Point"
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-row", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "Lat" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              className: "sidebar-input",
+              type: "text",
+              inputMode: "decimal",
+              value: draftRefLat,
+              onChange: (e) => setDraftRefLat(e.target.value),
+              onBlur: commitRefPosition,
+              onKeyDown: (e) => e.key === "Enter" && commitRefPosition()
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "Lon" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              className: "sidebar-input",
+              type: "text",
+              inputMode: "decimal",
+              value: draftRefLon,
+              onChange: (e) => setDraftRefLon(e.target.value),
+              onBlur: commitRefPosition,
+              onKeyDown: (e) => e.key === "Enter" && commitRefPosition()
+            }
+          )
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", style: { marginTop: 6 }, children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "Sample around ref marker" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "button",
@@ -34211,6 +34325,2755 @@ adapters._date.override({
     }
   }
 });
+var hammer = { exports: {} };
+/*! Hammer.JS - v2.0.7 - 2016-04-22
+ * http://hammerjs.github.io/
+ *
+ * Copyright (c) 2016 Jorik Tangelder;
+ * Licensed under the MIT license */
+(function(module) {
+  (function(window2, document2, exportName, undefined$1) {
+    var VENDOR_PREFIXES = ["", "webkit", "Moz", "MS", "ms", "o"];
+    var TEST_ELEMENT = document2.createElement("div");
+    var TYPE_FUNCTION = "function";
+    var round2 = Math.round;
+    var abs = Math.abs;
+    var now = Date.now;
+    function setTimeoutContext(fn, timeout, context) {
+      return setTimeout(bindFn(fn, context), timeout);
+    }
+    function invokeArrayArg(arg, fn, context) {
+      if (Array.isArray(arg)) {
+        each2(arg, context[fn], context);
+        return true;
+      }
+      return false;
+    }
+    function each2(obj, iterator, context) {
+      var i;
+      if (!obj) {
+        return;
+      }
+      if (obj.forEach) {
+        obj.forEach(iterator, context);
+      } else if (obj.length !== undefined$1) {
+        i = 0;
+        while (i < obj.length) {
+          iterator.call(context, obj[i], i, obj);
+          i++;
+        }
+      } else {
+        for (i in obj) {
+          obj.hasOwnProperty(i) && iterator.call(context, obj[i], i, obj);
+        }
+      }
+    }
+    function deprecate(method, name, message2) {
+      var deprecationMessage = "DEPRECATED METHOD: " + name + "\n" + message2 + " AT \n";
+      return function() {
+        var e = new Error("get-stack-trace");
+        var stack = e && e.stack ? e.stack.replace(/^[^\(]+?[\n$]/gm, "").replace(/^\s+at\s+/gm, "").replace(/^Object.<anonymous>\s*\(/gm, "{anonymous}()@") : "Unknown Stack Trace";
+        var log = window2.console && (window2.console.warn || window2.console.log);
+        if (log) {
+          log.call(window2.console, deprecationMessage, stack);
+        }
+        return method.apply(this, arguments);
+      };
+    }
+    var assign;
+    if (typeof Object.assign !== "function") {
+      assign = function assign2(target) {
+        if (target === undefined$1 || target === null) {
+          throw new TypeError("Cannot convert undefined or null to object");
+        }
+        var output = Object(target);
+        for (var index = 1; index < arguments.length; index++) {
+          var source = arguments[index];
+          if (source !== undefined$1 && source !== null) {
+            for (var nextKey in source) {
+              if (source.hasOwnProperty(nextKey)) {
+                output[nextKey] = source[nextKey];
+              }
+            }
+          }
+        }
+        return output;
+      };
+    } else {
+      assign = Object.assign;
+    }
+    var extend = deprecate(function extend2(dest, src, merge3) {
+      var keys = Object.keys(src);
+      var i = 0;
+      while (i < keys.length) {
+        if (!merge3 || merge3 && dest[keys[i]] === undefined$1) {
+          dest[keys[i]] = src[keys[i]];
+        }
+        i++;
+      }
+      return dest;
+    }, "extend", "Use `assign`.");
+    var merge2 = deprecate(function merge3(dest, src) {
+      return extend(dest, src, true);
+    }, "merge", "Use `assign`.");
+    function inherit(child, base, properties) {
+      var baseP = base.prototype, childP;
+      childP = child.prototype = Object.create(baseP);
+      childP.constructor = child;
+      childP._super = baseP;
+      if (properties) {
+        assign(childP, properties);
+      }
+    }
+    function bindFn(fn, context) {
+      return function boundFn() {
+        return fn.apply(context, arguments);
+      };
+    }
+    function boolOrFn(val, args) {
+      if (typeof val == TYPE_FUNCTION) {
+        return val.apply(args ? args[0] || undefined$1 : undefined$1, args);
+      }
+      return val;
+    }
+    function ifUndefined(val1, val2) {
+      return val1 === undefined$1 ? val2 : val1;
+    }
+    function addEventListeners(target, types, handler) {
+      each2(splitStr(types), function(type) {
+        target.addEventListener(type, handler, false);
+      });
+    }
+    function removeEventListeners(target, types, handler) {
+      each2(splitStr(types), function(type) {
+        target.removeEventListener(type, handler, false);
+      });
+    }
+    function hasParent(node, parent) {
+      while (node) {
+        if (node == parent) {
+          return true;
+        }
+        node = node.parentNode;
+      }
+      return false;
+    }
+    function inStr(str, find) {
+      return str.indexOf(find) > -1;
+    }
+    function splitStr(str) {
+      return str.trim().split(/\s+/g);
+    }
+    function inArray(src, find, findByKey) {
+      if (src.indexOf && !findByKey) {
+        return src.indexOf(find);
+      } else {
+        var i = 0;
+        while (i < src.length) {
+          if (findByKey && src[i][findByKey] == find || !findByKey && src[i] === find) {
+            return i;
+          }
+          i++;
+        }
+        return -1;
+      }
+    }
+    function toArray(obj) {
+      return Array.prototype.slice.call(obj, 0);
+    }
+    function uniqueArray(src, key, sort) {
+      var results = [];
+      var values = [];
+      var i = 0;
+      while (i < src.length) {
+        var val = src[i][key];
+        if (inArray(values, val) < 0) {
+          results.push(src[i]);
+        }
+        values[i] = val;
+        i++;
+      }
+      {
+        {
+          results = results.sort(function sortUniqueArray(a, b) {
+            return a[key] > b[key];
+          });
+        }
+      }
+      return results;
+    }
+    function prefixed(obj, property) {
+      var prefix, prop;
+      var camelProp = property[0].toUpperCase() + property.slice(1);
+      var i = 0;
+      while (i < VENDOR_PREFIXES.length) {
+        prefix = VENDOR_PREFIXES[i];
+        prop = prefix ? prefix + camelProp : property;
+        if (prop in obj) {
+          return prop;
+        }
+        i++;
+      }
+      return undefined$1;
+    }
+    var _uniqueId = 1;
+    function uniqueId() {
+      return _uniqueId++;
+    }
+    function getWindowForElement(element) {
+      var doc = element.ownerDocument || element;
+      return doc.defaultView || doc.parentWindow || window2;
+    }
+    var MOBILE_REGEX = /mobile|tablet|ip(ad|hone|od)|android/i;
+    var SUPPORT_TOUCH = "ontouchstart" in window2;
+    var SUPPORT_POINTER_EVENTS = prefixed(window2, "PointerEvent") !== undefined$1;
+    var SUPPORT_ONLY_TOUCH = SUPPORT_TOUCH && MOBILE_REGEX.test(navigator.userAgent);
+    var INPUT_TYPE_TOUCH = "touch";
+    var INPUT_TYPE_PEN = "pen";
+    var INPUT_TYPE_MOUSE = "mouse";
+    var INPUT_TYPE_KINECT = "kinect";
+    var COMPUTE_INTERVAL = 25;
+    var INPUT_START = 1;
+    var INPUT_MOVE = 2;
+    var INPUT_END = 4;
+    var INPUT_CANCEL = 8;
+    var DIRECTION_NONE = 1;
+    var DIRECTION_LEFT = 2;
+    var DIRECTION_RIGHT = 4;
+    var DIRECTION_UP = 8;
+    var DIRECTION_DOWN = 16;
+    var DIRECTION_HORIZONTAL = DIRECTION_LEFT | DIRECTION_RIGHT;
+    var DIRECTION_VERTICAL = DIRECTION_UP | DIRECTION_DOWN;
+    var DIRECTION_ALL = DIRECTION_HORIZONTAL | DIRECTION_VERTICAL;
+    var PROPS_XY = ["x", "y"];
+    var PROPS_CLIENT_XY = ["clientX", "clientY"];
+    function Input(manager, callback2) {
+      var self2 = this;
+      this.manager = manager;
+      this.callback = callback2;
+      this.element = manager.element;
+      this.target = manager.options.inputTarget;
+      this.domHandler = function(ev) {
+        if (boolOrFn(manager.options.enable, [manager])) {
+          self2.handler(ev);
+        }
+      };
+      this.init();
+    }
+    Input.prototype = {
+      /**
+       * should handle the inputEvent data and trigger the callback
+       * @virtual
+       */
+      handler: function() {
+      },
+      /**
+       * bind the events
+       */
+      init: function() {
+        this.evEl && addEventListeners(this.element, this.evEl, this.domHandler);
+        this.evTarget && addEventListeners(this.target, this.evTarget, this.domHandler);
+        this.evWin && addEventListeners(getWindowForElement(this.element), this.evWin, this.domHandler);
+      },
+      /**
+       * unbind the events
+       */
+      destroy: function() {
+        this.evEl && removeEventListeners(this.element, this.evEl, this.domHandler);
+        this.evTarget && removeEventListeners(this.target, this.evTarget, this.domHandler);
+        this.evWin && removeEventListeners(getWindowForElement(this.element), this.evWin, this.domHandler);
+      }
+    };
+    function createInputInstance(manager) {
+      var Type;
+      var inputClass = manager.options.inputClass;
+      if (inputClass) {
+        Type = inputClass;
+      } else if (SUPPORT_POINTER_EVENTS) {
+        Type = PointerEventInput;
+      } else if (SUPPORT_ONLY_TOUCH) {
+        Type = TouchInput;
+      } else if (!SUPPORT_TOUCH) {
+        Type = MouseInput;
+      } else {
+        Type = TouchMouseInput;
+      }
+      return new Type(manager, inputHandler);
+    }
+    function inputHandler(manager, eventType, input) {
+      var pointersLen = input.pointers.length;
+      var changedPointersLen = input.changedPointers.length;
+      var isFirst = eventType & INPUT_START && pointersLen - changedPointersLen === 0;
+      var isFinal = eventType & (INPUT_END | INPUT_CANCEL) && pointersLen - changedPointersLen === 0;
+      input.isFirst = !!isFirst;
+      input.isFinal = !!isFinal;
+      if (isFirst) {
+        manager.session = {};
+      }
+      input.eventType = eventType;
+      computeInputData(manager, input);
+      manager.emit("hammer.input", input);
+      manager.recognize(input);
+      manager.session.prevInput = input;
+    }
+    function computeInputData(manager, input) {
+      var session = manager.session;
+      var pointers = input.pointers;
+      var pointersLength = pointers.length;
+      if (!session.firstInput) {
+        session.firstInput = simpleCloneInputData(input);
+      }
+      if (pointersLength > 1 && !session.firstMultiple) {
+        session.firstMultiple = simpleCloneInputData(input);
+      } else if (pointersLength === 1) {
+        session.firstMultiple = false;
+      }
+      var firstInput = session.firstInput;
+      var firstMultiple = session.firstMultiple;
+      var offsetCenter = firstMultiple ? firstMultiple.center : firstInput.center;
+      var center = input.center = getCenter2(pointers);
+      input.timeStamp = now();
+      input.deltaTime = input.timeStamp - firstInput.timeStamp;
+      input.angle = getAngle(offsetCenter, center);
+      input.distance = getDistance(offsetCenter, center);
+      computeDeltaXY(session, input);
+      input.offsetDirection = getDirection(input.deltaX, input.deltaY);
+      var overallVelocity = getVelocity(input.deltaTime, input.deltaX, input.deltaY);
+      input.overallVelocityX = overallVelocity.x;
+      input.overallVelocityY = overallVelocity.y;
+      input.overallVelocity = abs(overallVelocity.x) > abs(overallVelocity.y) ? overallVelocity.x : overallVelocity.y;
+      input.scale = firstMultiple ? getScale(firstMultiple.pointers, pointers) : 1;
+      input.rotation = firstMultiple ? getRotation(firstMultiple.pointers, pointers) : 0;
+      input.maxPointers = !session.prevInput ? input.pointers.length : input.pointers.length > session.prevInput.maxPointers ? input.pointers.length : session.prevInput.maxPointers;
+      computeIntervalInputData(session, input);
+      var target = manager.element;
+      if (hasParent(input.srcEvent.target, target)) {
+        target = input.srcEvent.target;
+      }
+      input.target = target;
+    }
+    function computeDeltaXY(session, input) {
+      var center = input.center;
+      var offset = session.offsetDelta || {};
+      var prevDelta = session.prevDelta || {};
+      var prevInput = session.prevInput || {};
+      if (input.eventType === INPUT_START || prevInput.eventType === INPUT_END) {
+        prevDelta = session.prevDelta = {
+          x: prevInput.deltaX || 0,
+          y: prevInput.deltaY || 0
+        };
+        offset = session.offsetDelta = {
+          x: center.x,
+          y: center.y
+        };
+      }
+      input.deltaX = prevDelta.x + (center.x - offset.x);
+      input.deltaY = prevDelta.y + (center.y - offset.y);
+    }
+    function computeIntervalInputData(session, input) {
+      var last = session.lastInterval || input, deltaTime = input.timeStamp - last.timeStamp, velocity, velocityX, velocityY, direction;
+      if (input.eventType != INPUT_CANCEL && (deltaTime > COMPUTE_INTERVAL || last.velocity === undefined$1)) {
+        var deltaX = input.deltaX - last.deltaX;
+        var deltaY = input.deltaY - last.deltaY;
+        var v2 = getVelocity(deltaTime, deltaX, deltaY);
+        velocityX = v2.x;
+        velocityY = v2.y;
+        velocity = abs(v2.x) > abs(v2.y) ? v2.x : v2.y;
+        direction = getDirection(deltaX, deltaY);
+        session.lastInterval = input;
+      } else {
+        velocity = last.velocity;
+        velocityX = last.velocityX;
+        velocityY = last.velocityY;
+        direction = last.direction;
+      }
+      input.velocity = velocity;
+      input.velocityX = velocityX;
+      input.velocityY = velocityY;
+      input.direction = direction;
+    }
+    function simpleCloneInputData(input) {
+      var pointers = [];
+      var i = 0;
+      while (i < input.pointers.length) {
+        pointers[i] = {
+          clientX: round2(input.pointers[i].clientX),
+          clientY: round2(input.pointers[i].clientY)
+        };
+        i++;
+      }
+      return {
+        timeStamp: now(),
+        pointers,
+        center: getCenter2(pointers),
+        deltaX: input.deltaX,
+        deltaY: input.deltaY
+      };
+    }
+    function getCenter2(pointers) {
+      var pointersLength = pointers.length;
+      if (pointersLength === 1) {
+        return {
+          x: round2(pointers[0].clientX),
+          y: round2(pointers[0].clientY)
+        };
+      }
+      var x2 = 0, y2 = 0, i = 0;
+      while (i < pointersLength) {
+        x2 += pointers[i].clientX;
+        y2 += pointers[i].clientY;
+        i++;
+      }
+      return {
+        x: round2(x2 / pointersLength),
+        y: round2(y2 / pointersLength)
+      };
+    }
+    function getVelocity(deltaTime, x2, y2) {
+      return {
+        x: x2 / deltaTime || 0,
+        y: y2 / deltaTime || 0
+      };
+    }
+    function getDirection(x2, y2) {
+      if (x2 === y2) {
+        return DIRECTION_NONE;
+      }
+      if (abs(x2) >= abs(y2)) {
+        return x2 < 0 ? DIRECTION_LEFT : DIRECTION_RIGHT;
+      }
+      return y2 < 0 ? DIRECTION_UP : DIRECTION_DOWN;
+    }
+    function getDistance(p1, p2, props) {
+      if (!props) {
+        props = PROPS_XY;
+      }
+      var x2 = p2[props[0]] - p1[props[0]], y2 = p2[props[1]] - p1[props[1]];
+      return Math.sqrt(x2 * x2 + y2 * y2);
+    }
+    function getAngle(p1, p2, props) {
+      if (!props) {
+        props = PROPS_XY;
+      }
+      var x2 = p2[props[0]] - p1[props[0]], y2 = p2[props[1]] - p1[props[1]];
+      return Math.atan2(y2, x2) * 180 / Math.PI;
+    }
+    function getRotation(start, end) {
+      return getAngle(end[1], end[0], PROPS_CLIENT_XY) + getAngle(start[1], start[0], PROPS_CLIENT_XY);
+    }
+    function getScale(start, end) {
+      return getDistance(end[0], end[1], PROPS_CLIENT_XY) / getDistance(start[0], start[1], PROPS_CLIENT_XY);
+    }
+    var MOUSE_INPUT_MAP = {
+      mousedown: INPUT_START,
+      mousemove: INPUT_MOVE,
+      mouseup: INPUT_END
+    };
+    var MOUSE_ELEMENT_EVENTS = "mousedown";
+    var MOUSE_WINDOW_EVENTS = "mousemove mouseup";
+    function MouseInput() {
+      this.evEl = MOUSE_ELEMENT_EVENTS;
+      this.evWin = MOUSE_WINDOW_EVENTS;
+      this.pressed = false;
+      Input.apply(this, arguments);
+    }
+    inherit(MouseInput, Input, {
+      /**
+       * handle mouse events
+       * @param {Object} ev
+       */
+      handler: function MEhandler(ev) {
+        var eventType = MOUSE_INPUT_MAP[ev.type];
+        if (eventType & INPUT_START && ev.button === 0) {
+          this.pressed = true;
+        }
+        if (eventType & INPUT_MOVE && ev.which !== 1) {
+          eventType = INPUT_END;
+        }
+        if (!this.pressed) {
+          return;
+        }
+        if (eventType & INPUT_END) {
+          this.pressed = false;
+        }
+        this.callback(this.manager, eventType, {
+          pointers: [ev],
+          changedPointers: [ev],
+          pointerType: INPUT_TYPE_MOUSE,
+          srcEvent: ev
+        });
+      }
+    });
+    var POINTER_INPUT_MAP = {
+      pointerdown: INPUT_START,
+      pointermove: INPUT_MOVE,
+      pointerup: INPUT_END,
+      pointercancel: INPUT_CANCEL,
+      pointerout: INPUT_CANCEL
+    };
+    var IE10_POINTER_TYPE_ENUM = {
+      2: INPUT_TYPE_TOUCH,
+      3: INPUT_TYPE_PEN,
+      4: INPUT_TYPE_MOUSE,
+      5: INPUT_TYPE_KINECT
+      // see https://twitter.com/jacobrossi/status/480596438489890816
+    };
+    var POINTER_ELEMENT_EVENTS = "pointerdown";
+    var POINTER_WINDOW_EVENTS = "pointermove pointerup pointercancel";
+    if (window2.MSPointerEvent && !window2.PointerEvent) {
+      POINTER_ELEMENT_EVENTS = "MSPointerDown";
+      POINTER_WINDOW_EVENTS = "MSPointerMove MSPointerUp MSPointerCancel";
+    }
+    function PointerEventInput() {
+      this.evEl = POINTER_ELEMENT_EVENTS;
+      this.evWin = POINTER_WINDOW_EVENTS;
+      Input.apply(this, arguments);
+      this.store = this.manager.session.pointerEvents = [];
+    }
+    inherit(PointerEventInput, Input, {
+      /**
+       * handle mouse events
+       * @param {Object} ev
+       */
+      handler: function PEhandler(ev) {
+        var store = this.store;
+        var removePointer = false;
+        var eventTypeNormalized = ev.type.toLowerCase().replace("ms", "");
+        var eventType = POINTER_INPUT_MAP[eventTypeNormalized];
+        var pointerType = IE10_POINTER_TYPE_ENUM[ev.pointerType] || ev.pointerType;
+        var isTouch = pointerType == INPUT_TYPE_TOUCH;
+        var storeIndex = inArray(store, ev.pointerId, "pointerId");
+        if (eventType & INPUT_START && (ev.button === 0 || isTouch)) {
+          if (storeIndex < 0) {
+            store.push(ev);
+            storeIndex = store.length - 1;
+          }
+        } else if (eventType & (INPUT_END | INPUT_CANCEL)) {
+          removePointer = true;
+        }
+        if (storeIndex < 0) {
+          return;
+        }
+        store[storeIndex] = ev;
+        this.callback(this.manager, eventType, {
+          pointers: store,
+          changedPointers: [ev],
+          pointerType,
+          srcEvent: ev
+        });
+        if (removePointer) {
+          store.splice(storeIndex, 1);
+        }
+      }
+    });
+    var SINGLE_TOUCH_INPUT_MAP = {
+      touchstart: INPUT_START,
+      touchmove: INPUT_MOVE,
+      touchend: INPUT_END,
+      touchcancel: INPUT_CANCEL
+    };
+    var SINGLE_TOUCH_TARGET_EVENTS = "touchstart";
+    var SINGLE_TOUCH_WINDOW_EVENTS = "touchstart touchmove touchend touchcancel";
+    function SingleTouchInput() {
+      this.evTarget = SINGLE_TOUCH_TARGET_EVENTS;
+      this.evWin = SINGLE_TOUCH_WINDOW_EVENTS;
+      this.started = false;
+      Input.apply(this, arguments);
+    }
+    inherit(SingleTouchInput, Input, {
+      handler: function TEhandler(ev) {
+        var type = SINGLE_TOUCH_INPUT_MAP[ev.type];
+        if (type === INPUT_START) {
+          this.started = true;
+        }
+        if (!this.started) {
+          return;
+        }
+        var touches = normalizeSingleTouches.call(this, ev, type);
+        if (type & (INPUT_END | INPUT_CANCEL) && touches[0].length - touches[1].length === 0) {
+          this.started = false;
+        }
+        this.callback(this.manager, type, {
+          pointers: touches[0],
+          changedPointers: touches[1],
+          pointerType: INPUT_TYPE_TOUCH,
+          srcEvent: ev
+        });
+      }
+    });
+    function normalizeSingleTouches(ev, type) {
+      var all = toArray(ev.touches);
+      var changed = toArray(ev.changedTouches);
+      if (type & (INPUT_END | INPUT_CANCEL)) {
+        all = uniqueArray(all.concat(changed), "identifier");
+      }
+      return [all, changed];
+    }
+    var TOUCH_INPUT_MAP = {
+      touchstart: INPUT_START,
+      touchmove: INPUT_MOVE,
+      touchend: INPUT_END,
+      touchcancel: INPUT_CANCEL
+    };
+    var TOUCH_TARGET_EVENTS = "touchstart touchmove touchend touchcancel";
+    function TouchInput() {
+      this.evTarget = TOUCH_TARGET_EVENTS;
+      this.targetIds = {};
+      Input.apply(this, arguments);
+    }
+    inherit(TouchInput, Input, {
+      handler: function MTEhandler(ev) {
+        var type = TOUCH_INPUT_MAP[ev.type];
+        var touches = getTouches.call(this, ev, type);
+        if (!touches) {
+          return;
+        }
+        this.callback(this.manager, type, {
+          pointers: touches[0],
+          changedPointers: touches[1],
+          pointerType: INPUT_TYPE_TOUCH,
+          srcEvent: ev
+        });
+      }
+    });
+    function getTouches(ev, type) {
+      var allTouches = toArray(ev.touches);
+      var targetIds = this.targetIds;
+      if (type & (INPUT_START | INPUT_MOVE) && allTouches.length === 1) {
+        targetIds[allTouches[0].identifier] = true;
+        return [allTouches, allTouches];
+      }
+      var i, targetTouches, changedTouches = toArray(ev.changedTouches), changedTargetTouches = [], target = this.target;
+      targetTouches = allTouches.filter(function(touch) {
+        return hasParent(touch.target, target);
+      });
+      if (type === INPUT_START) {
+        i = 0;
+        while (i < targetTouches.length) {
+          targetIds[targetTouches[i].identifier] = true;
+          i++;
+        }
+      }
+      i = 0;
+      while (i < changedTouches.length) {
+        if (targetIds[changedTouches[i].identifier]) {
+          changedTargetTouches.push(changedTouches[i]);
+        }
+        if (type & (INPUT_END | INPUT_CANCEL)) {
+          delete targetIds[changedTouches[i].identifier];
+        }
+        i++;
+      }
+      if (!changedTargetTouches.length) {
+        return;
+      }
+      return [
+        // merge targetTouches with changedTargetTouches so it contains ALL touches, including 'end' and 'cancel'
+        uniqueArray(targetTouches.concat(changedTargetTouches), "identifier"),
+        changedTargetTouches
+      ];
+    }
+    var DEDUP_TIMEOUT = 2500;
+    var DEDUP_DISTANCE = 25;
+    function TouchMouseInput() {
+      Input.apply(this, arguments);
+      var handler = bindFn(this.handler, this);
+      this.touch = new TouchInput(this.manager, handler);
+      this.mouse = new MouseInput(this.manager, handler);
+      this.primaryTouch = null;
+      this.lastTouches = [];
+    }
+    inherit(TouchMouseInput, Input, {
+      /**
+       * handle mouse and touch events
+       * @param {Hammer} manager
+       * @param {String} inputEvent
+       * @param {Object} inputData
+       */
+      handler: function TMEhandler(manager, inputEvent, inputData) {
+        var isTouch = inputData.pointerType == INPUT_TYPE_TOUCH, isMouse = inputData.pointerType == INPUT_TYPE_MOUSE;
+        if (isMouse && inputData.sourceCapabilities && inputData.sourceCapabilities.firesTouchEvents) {
+          return;
+        }
+        if (isTouch) {
+          recordTouches.call(this, inputEvent, inputData);
+        } else if (isMouse && isSyntheticEvent.call(this, inputData)) {
+          return;
+        }
+        this.callback(manager, inputEvent, inputData);
+      },
+      /**
+       * remove the event listeners
+       */
+      destroy: function destroy() {
+        this.touch.destroy();
+        this.mouse.destroy();
+      }
+    });
+    function recordTouches(eventType, eventData) {
+      if (eventType & INPUT_START) {
+        this.primaryTouch = eventData.changedPointers[0].identifier;
+        setLastTouch.call(this, eventData);
+      } else if (eventType & (INPUT_END | INPUT_CANCEL)) {
+        setLastTouch.call(this, eventData);
+      }
+    }
+    function setLastTouch(eventData) {
+      var touch = eventData.changedPointers[0];
+      if (touch.identifier === this.primaryTouch) {
+        var lastTouch = { x: touch.clientX, y: touch.clientY };
+        this.lastTouches.push(lastTouch);
+        var lts = this.lastTouches;
+        var removeLastTouch = function() {
+          var i = lts.indexOf(lastTouch);
+          if (i > -1) {
+            lts.splice(i, 1);
+          }
+        };
+        setTimeout(removeLastTouch, DEDUP_TIMEOUT);
+      }
+    }
+    function isSyntheticEvent(eventData) {
+      var x2 = eventData.srcEvent.clientX, y2 = eventData.srcEvent.clientY;
+      for (var i = 0; i < this.lastTouches.length; i++) {
+        var t2 = this.lastTouches[i];
+        var dx = Math.abs(x2 - t2.x), dy = Math.abs(y2 - t2.y);
+        if (dx <= DEDUP_DISTANCE && dy <= DEDUP_DISTANCE) {
+          return true;
+        }
+      }
+      return false;
+    }
+    var PREFIXED_TOUCH_ACTION = prefixed(TEST_ELEMENT.style, "touchAction");
+    var NATIVE_TOUCH_ACTION = PREFIXED_TOUCH_ACTION !== undefined$1;
+    var TOUCH_ACTION_COMPUTE = "compute";
+    var TOUCH_ACTION_AUTO = "auto";
+    var TOUCH_ACTION_MANIPULATION = "manipulation";
+    var TOUCH_ACTION_NONE = "none";
+    var TOUCH_ACTION_PAN_X = "pan-x";
+    var TOUCH_ACTION_PAN_Y = "pan-y";
+    var TOUCH_ACTION_MAP = getTouchActionProps();
+    function TouchAction(manager, value) {
+      this.manager = manager;
+      this.set(value);
+    }
+    TouchAction.prototype = {
+      /**
+       * set the touchAction value on the element or enable the polyfill
+       * @param {String} value
+       */
+      set: function(value) {
+        if (value == TOUCH_ACTION_COMPUTE) {
+          value = this.compute();
+        }
+        if (NATIVE_TOUCH_ACTION && this.manager.element.style && TOUCH_ACTION_MAP[value]) {
+          this.manager.element.style[PREFIXED_TOUCH_ACTION] = value;
+        }
+        this.actions = value.toLowerCase().trim();
+      },
+      /**
+       * just re-set the touchAction value
+       */
+      update: function() {
+        this.set(this.manager.options.touchAction);
+      },
+      /**
+       * compute the value for the touchAction property based on the recognizer's settings
+       * @returns {String} value
+       */
+      compute: function() {
+        var actions = [];
+        each2(this.manager.recognizers, function(recognizer) {
+          if (boolOrFn(recognizer.options.enable, [recognizer])) {
+            actions = actions.concat(recognizer.getTouchAction());
+          }
+        });
+        return cleanTouchActions(actions.join(" "));
+      },
+      /**
+       * this method is called on each input cycle and provides the preventing of the browser behavior
+       * @param {Object} input
+       */
+      preventDefaults: function(input) {
+        var srcEvent = input.srcEvent;
+        var direction = input.offsetDirection;
+        if (this.manager.session.prevented) {
+          srcEvent.preventDefault();
+          return;
+        }
+        var actions = this.actions;
+        var hasNone = inStr(actions, TOUCH_ACTION_NONE) && !TOUCH_ACTION_MAP[TOUCH_ACTION_NONE];
+        var hasPanY = inStr(actions, TOUCH_ACTION_PAN_Y) && !TOUCH_ACTION_MAP[TOUCH_ACTION_PAN_Y];
+        var hasPanX = inStr(actions, TOUCH_ACTION_PAN_X) && !TOUCH_ACTION_MAP[TOUCH_ACTION_PAN_X];
+        if (hasNone) {
+          var isTapPointer = input.pointers.length === 1;
+          var isTapMovement = input.distance < 2;
+          var isTapTouchTime = input.deltaTime < 250;
+          if (isTapPointer && isTapMovement && isTapTouchTime) {
+            return;
+          }
+        }
+        if (hasPanX && hasPanY) {
+          return;
+        }
+        if (hasNone || hasPanY && direction & DIRECTION_HORIZONTAL || hasPanX && direction & DIRECTION_VERTICAL) {
+          return this.preventSrc(srcEvent);
+        }
+      },
+      /**
+       * call preventDefault to prevent the browser's default behavior (scrolling in most cases)
+       * @param {Object} srcEvent
+       */
+      preventSrc: function(srcEvent) {
+        this.manager.session.prevented = true;
+        srcEvent.preventDefault();
+      }
+    };
+    function cleanTouchActions(actions) {
+      if (inStr(actions, TOUCH_ACTION_NONE)) {
+        return TOUCH_ACTION_NONE;
+      }
+      var hasPanX = inStr(actions, TOUCH_ACTION_PAN_X);
+      var hasPanY = inStr(actions, TOUCH_ACTION_PAN_Y);
+      if (hasPanX && hasPanY) {
+        return TOUCH_ACTION_NONE;
+      }
+      if (hasPanX || hasPanY) {
+        return hasPanX ? TOUCH_ACTION_PAN_X : TOUCH_ACTION_PAN_Y;
+      }
+      if (inStr(actions, TOUCH_ACTION_MANIPULATION)) {
+        return TOUCH_ACTION_MANIPULATION;
+      }
+      return TOUCH_ACTION_AUTO;
+    }
+    function getTouchActionProps() {
+      if (!NATIVE_TOUCH_ACTION) {
+        return false;
+      }
+      var touchMap = {};
+      var cssSupports = window2.CSS && window2.CSS.supports;
+      ["auto", "manipulation", "pan-y", "pan-x", "pan-x pan-y", "none"].forEach(function(val) {
+        touchMap[val] = cssSupports ? window2.CSS.supports("touch-action", val) : true;
+      });
+      return touchMap;
+    }
+    var STATE_POSSIBLE = 1;
+    var STATE_BEGAN = 2;
+    var STATE_CHANGED = 4;
+    var STATE_ENDED = 8;
+    var STATE_RECOGNIZED = STATE_ENDED;
+    var STATE_CANCELLED = 16;
+    var STATE_FAILED = 32;
+    function Recognizer(options) {
+      this.options = assign({}, this.defaults, options || {});
+      this.id = uniqueId();
+      this.manager = null;
+      this.options.enable = ifUndefined(this.options.enable, true);
+      this.state = STATE_POSSIBLE;
+      this.simultaneous = {};
+      this.requireFail = [];
+    }
+    Recognizer.prototype = {
+      /**
+       * @virtual
+       * @type {Object}
+       */
+      defaults: {},
+      /**
+       * set options
+       * @param {Object} options
+       * @return {Recognizer}
+       */
+      set: function(options) {
+        assign(this.options, options);
+        this.manager && this.manager.touchAction.update();
+        return this;
+      },
+      /**
+       * recognize simultaneous with an other recognizer.
+       * @param {Recognizer} otherRecognizer
+       * @returns {Recognizer} this
+       */
+      recognizeWith: function(otherRecognizer) {
+        if (invokeArrayArg(otherRecognizer, "recognizeWith", this)) {
+          return this;
+        }
+        var simultaneous = this.simultaneous;
+        otherRecognizer = getRecognizerByNameIfManager(otherRecognizer, this);
+        if (!simultaneous[otherRecognizer.id]) {
+          simultaneous[otherRecognizer.id] = otherRecognizer;
+          otherRecognizer.recognizeWith(this);
+        }
+        return this;
+      },
+      /**
+       * drop the simultaneous link. it doesnt remove the link on the other recognizer.
+       * @param {Recognizer} otherRecognizer
+       * @returns {Recognizer} this
+       */
+      dropRecognizeWith: function(otherRecognizer) {
+        if (invokeArrayArg(otherRecognizer, "dropRecognizeWith", this)) {
+          return this;
+        }
+        otherRecognizer = getRecognizerByNameIfManager(otherRecognizer, this);
+        delete this.simultaneous[otherRecognizer.id];
+        return this;
+      },
+      /**
+       * recognizer can only run when an other is failing
+       * @param {Recognizer} otherRecognizer
+       * @returns {Recognizer} this
+       */
+      requireFailure: function(otherRecognizer) {
+        if (invokeArrayArg(otherRecognizer, "requireFailure", this)) {
+          return this;
+        }
+        var requireFail = this.requireFail;
+        otherRecognizer = getRecognizerByNameIfManager(otherRecognizer, this);
+        if (inArray(requireFail, otherRecognizer) === -1) {
+          requireFail.push(otherRecognizer);
+          otherRecognizer.requireFailure(this);
+        }
+        return this;
+      },
+      /**
+       * drop the requireFailure link. it does not remove the link on the other recognizer.
+       * @param {Recognizer} otherRecognizer
+       * @returns {Recognizer} this
+       */
+      dropRequireFailure: function(otherRecognizer) {
+        if (invokeArrayArg(otherRecognizer, "dropRequireFailure", this)) {
+          return this;
+        }
+        otherRecognizer = getRecognizerByNameIfManager(otherRecognizer, this);
+        var index = inArray(this.requireFail, otherRecognizer);
+        if (index > -1) {
+          this.requireFail.splice(index, 1);
+        }
+        return this;
+      },
+      /**
+       * has require failures boolean
+       * @returns {boolean}
+       */
+      hasRequireFailures: function() {
+        return this.requireFail.length > 0;
+      },
+      /**
+       * if the recognizer can recognize simultaneous with an other recognizer
+       * @param {Recognizer} otherRecognizer
+       * @returns {Boolean}
+       */
+      canRecognizeWith: function(otherRecognizer) {
+        return !!this.simultaneous[otherRecognizer.id];
+      },
+      /**
+       * You should use `tryEmit` instead of `emit` directly to check
+       * that all the needed recognizers has failed before emitting.
+       * @param {Object} input
+       */
+      emit: function(input) {
+        var self2 = this;
+        var state = this.state;
+        function emit(event) {
+          self2.manager.emit(event, input);
+        }
+        if (state < STATE_ENDED) {
+          emit(self2.options.event + stateStr(state));
+        }
+        emit(self2.options.event);
+        if (input.additionalEvent) {
+          emit(input.additionalEvent);
+        }
+        if (state >= STATE_ENDED) {
+          emit(self2.options.event + stateStr(state));
+        }
+      },
+      /**
+       * Check that all the require failure recognizers has failed,
+       * if true, it emits a gesture event,
+       * otherwise, setup the state to FAILED.
+       * @param {Object} input
+       */
+      tryEmit: function(input) {
+        if (this.canEmit()) {
+          return this.emit(input);
+        }
+        this.state = STATE_FAILED;
+      },
+      /**
+       * can we emit?
+       * @returns {boolean}
+       */
+      canEmit: function() {
+        var i = 0;
+        while (i < this.requireFail.length) {
+          if (!(this.requireFail[i].state & (STATE_FAILED | STATE_POSSIBLE))) {
+            return false;
+          }
+          i++;
+        }
+        return true;
+      },
+      /**
+       * update the recognizer
+       * @param {Object} inputData
+       */
+      recognize: function(inputData) {
+        var inputDataClone = assign({}, inputData);
+        if (!boolOrFn(this.options.enable, [this, inputDataClone])) {
+          this.reset();
+          this.state = STATE_FAILED;
+          return;
+        }
+        if (this.state & (STATE_RECOGNIZED | STATE_CANCELLED | STATE_FAILED)) {
+          this.state = STATE_POSSIBLE;
+        }
+        this.state = this.process(inputDataClone);
+        if (this.state & (STATE_BEGAN | STATE_CHANGED | STATE_ENDED | STATE_CANCELLED)) {
+          this.tryEmit(inputDataClone);
+        }
+      },
+      /**
+       * return the state of the recognizer
+       * the actual recognizing happens in this method
+       * @virtual
+       * @param {Object} inputData
+       * @returns {Const} STATE
+       */
+      process: function(inputData) {
+      },
+      // jshint ignore:line
+      /**
+       * return the preferred touch-action
+       * @virtual
+       * @returns {Array}
+       */
+      getTouchAction: function() {
+      },
+      /**
+       * called when the gesture isn't allowed to recognize
+       * like when another is being recognized or it is disabled
+       * @virtual
+       */
+      reset: function() {
+      }
+    };
+    function stateStr(state) {
+      if (state & STATE_CANCELLED) {
+        return "cancel";
+      } else if (state & STATE_ENDED) {
+        return "end";
+      } else if (state & STATE_CHANGED) {
+        return "move";
+      } else if (state & STATE_BEGAN) {
+        return "start";
+      }
+      return "";
+    }
+    function directionStr(direction) {
+      if (direction == DIRECTION_DOWN) {
+        return "down";
+      } else if (direction == DIRECTION_UP) {
+        return "up";
+      } else if (direction == DIRECTION_LEFT) {
+        return "left";
+      } else if (direction == DIRECTION_RIGHT) {
+        return "right";
+      }
+      return "";
+    }
+    function getRecognizerByNameIfManager(otherRecognizer, recognizer) {
+      var manager = recognizer.manager;
+      if (manager) {
+        return manager.get(otherRecognizer);
+      }
+      return otherRecognizer;
+    }
+    function AttrRecognizer() {
+      Recognizer.apply(this, arguments);
+    }
+    inherit(AttrRecognizer, Recognizer, {
+      /**
+       * @namespace
+       * @memberof AttrRecognizer
+       */
+      defaults: {
+        /**
+         * @type {Number}
+         * @default 1
+         */
+        pointers: 1
+      },
+      /**
+       * Used to check if it the recognizer receives valid input, like input.distance > 10.
+       * @memberof AttrRecognizer
+       * @param {Object} input
+       * @returns {Boolean} recognized
+       */
+      attrTest: function(input) {
+        var optionPointers = this.options.pointers;
+        return optionPointers === 0 || input.pointers.length === optionPointers;
+      },
+      /**
+       * Process the input and return the state for the recognizer
+       * @memberof AttrRecognizer
+       * @param {Object} input
+       * @returns {*} State
+       */
+      process: function(input) {
+        var state = this.state;
+        var eventType = input.eventType;
+        var isRecognized = state & (STATE_BEGAN | STATE_CHANGED);
+        var isValid2 = this.attrTest(input);
+        if (isRecognized && (eventType & INPUT_CANCEL || !isValid2)) {
+          return state | STATE_CANCELLED;
+        } else if (isRecognized || isValid2) {
+          if (eventType & INPUT_END) {
+            return state | STATE_ENDED;
+          } else if (!(state & STATE_BEGAN)) {
+            return STATE_BEGAN;
+          }
+          return state | STATE_CHANGED;
+        }
+        return STATE_FAILED;
+      }
+    });
+    function PanRecognizer() {
+      AttrRecognizer.apply(this, arguments);
+      this.pX = null;
+      this.pY = null;
+    }
+    inherit(PanRecognizer, AttrRecognizer, {
+      /**
+       * @namespace
+       * @memberof PanRecognizer
+       */
+      defaults: {
+        event: "pan",
+        threshold: 10,
+        pointers: 1,
+        direction: DIRECTION_ALL
+      },
+      getTouchAction: function() {
+        var direction = this.options.direction;
+        var actions = [];
+        if (direction & DIRECTION_HORIZONTAL) {
+          actions.push(TOUCH_ACTION_PAN_Y);
+        }
+        if (direction & DIRECTION_VERTICAL) {
+          actions.push(TOUCH_ACTION_PAN_X);
+        }
+        return actions;
+      },
+      directionTest: function(input) {
+        var options = this.options;
+        var hasMoved = true;
+        var distance = input.distance;
+        var direction = input.direction;
+        var x2 = input.deltaX;
+        var y2 = input.deltaY;
+        if (!(direction & options.direction)) {
+          if (options.direction & DIRECTION_HORIZONTAL) {
+            direction = x2 === 0 ? DIRECTION_NONE : x2 < 0 ? DIRECTION_LEFT : DIRECTION_RIGHT;
+            hasMoved = x2 != this.pX;
+            distance = Math.abs(input.deltaX);
+          } else {
+            direction = y2 === 0 ? DIRECTION_NONE : y2 < 0 ? DIRECTION_UP : DIRECTION_DOWN;
+            hasMoved = y2 != this.pY;
+            distance = Math.abs(input.deltaY);
+          }
+        }
+        input.direction = direction;
+        return hasMoved && distance > options.threshold && direction & options.direction;
+      },
+      attrTest: function(input) {
+        return AttrRecognizer.prototype.attrTest.call(this, input) && (this.state & STATE_BEGAN || !(this.state & STATE_BEGAN) && this.directionTest(input));
+      },
+      emit: function(input) {
+        this.pX = input.deltaX;
+        this.pY = input.deltaY;
+        var direction = directionStr(input.direction);
+        if (direction) {
+          input.additionalEvent = this.options.event + direction;
+        }
+        this._super.emit.call(this, input);
+      }
+    });
+    function PinchRecognizer() {
+      AttrRecognizer.apply(this, arguments);
+    }
+    inherit(PinchRecognizer, AttrRecognizer, {
+      /**
+       * @namespace
+       * @memberof PinchRecognizer
+       */
+      defaults: {
+        event: "pinch",
+        threshold: 0,
+        pointers: 2
+      },
+      getTouchAction: function() {
+        return [TOUCH_ACTION_NONE];
+      },
+      attrTest: function(input) {
+        return this._super.attrTest.call(this, input) && (Math.abs(input.scale - 1) > this.options.threshold || this.state & STATE_BEGAN);
+      },
+      emit: function(input) {
+        if (input.scale !== 1) {
+          var inOut = input.scale < 1 ? "in" : "out";
+          input.additionalEvent = this.options.event + inOut;
+        }
+        this._super.emit.call(this, input);
+      }
+    });
+    function PressRecognizer() {
+      Recognizer.apply(this, arguments);
+      this._timer = null;
+      this._input = null;
+    }
+    inherit(PressRecognizer, Recognizer, {
+      /**
+       * @namespace
+       * @memberof PressRecognizer
+       */
+      defaults: {
+        event: "press",
+        pointers: 1,
+        time: 251,
+        // minimal time of the pointer to be pressed
+        threshold: 9
+        // a minimal movement is ok, but keep it low
+      },
+      getTouchAction: function() {
+        return [TOUCH_ACTION_AUTO];
+      },
+      process: function(input) {
+        var options = this.options;
+        var validPointers = input.pointers.length === options.pointers;
+        var validMovement = input.distance < options.threshold;
+        var validTime = input.deltaTime > options.time;
+        this._input = input;
+        if (!validMovement || !validPointers || input.eventType & (INPUT_END | INPUT_CANCEL) && !validTime) {
+          this.reset();
+        } else if (input.eventType & INPUT_START) {
+          this.reset();
+          this._timer = setTimeoutContext(function() {
+            this.state = STATE_RECOGNIZED;
+            this.tryEmit();
+          }, options.time, this);
+        } else if (input.eventType & INPUT_END) {
+          return STATE_RECOGNIZED;
+        }
+        return STATE_FAILED;
+      },
+      reset: function() {
+        clearTimeout(this._timer);
+      },
+      emit: function(input) {
+        if (this.state !== STATE_RECOGNIZED) {
+          return;
+        }
+        if (input && input.eventType & INPUT_END) {
+          this.manager.emit(this.options.event + "up", input);
+        } else {
+          this._input.timeStamp = now();
+          this.manager.emit(this.options.event, this._input);
+        }
+      }
+    });
+    function RotateRecognizer() {
+      AttrRecognizer.apply(this, arguments);
+    }
+    inherit(RotateRecognizer, AttrRecognizer, {
+      /**
+       * @namespace
+       * @memberof RotateRecognizer
+       */
+      defaults: {
+        event: "rotate",
+        threshold: 0,
+        pointers: 2
+      },
+      getTouchAction: function() {
+        return [TOUCH_ACTION_NONE];
+      },
+      attrTest: function(input) {
+        return this._super.attrTest.call(this, input) && (Math.abs(input.rotation) > this.options.threshold || this.state & STATE_BEGAN);
+      }
+    });
+    function SwipeRecognizer() {
+      AttrRecognizer.apply(this, arguments);
+    }
+    inherit(SwipeRecognizer, AttrRecognizer, {
+      /**
+       * @namespace
+       * @memberof SwipeRecognizer
+       */
+      defaults: {
+        event: "swipe",
+        threshold: 10,
+        velocity: 0.3,
+        direction: DIRECTION_HORIZONTAL | DIRECTION_VERTICAL,
+        pointers: 1
+      },
+      getTouchAction: function() {
+        return PanRecognizer.prototype.getTouchAction.call(this);
+      },
+      attrTest: function(input) {
+        var direction = this.options.direction;
+        var velocity;
+        if (direction & (DIRECTION_HORIZONTAL | DIRECTION_VERTICAL)) {
+          velocity = input.overallVelocity;
+        } else if (direction & DIRECTION_HORIZONTAL) {
+          velocity = input.overallVelocityX;
+        } else if (direction & DIRECTION_VERTICAL) {
+          velocity = input.overallVelocityY;
+        }
+        return this._super.attrTest.call(this, input) && direction & input.offsetDirection && input.distance > this.options.threshold && input.maxPointers == this.options.pointers && abs(velocity) > this.options.velocity && input.eventType & INPUT_END;
+      },
+      emit: function(input) {
+        var direction = directionStr(input.offsetDirection);
+        if (direction) {
+          this.manager.emit(this.options.event + direction, input);
+        }
+        this.manager.emit(this.options.event, input);
+      }
+    });
+    function TapRecognizer() {
+      Recognizer.apply(this, arguments);
+      this.pTime = false;
+      this.pCenter = false;
+      this._timer = null;
+      this._input = null;
+      this.count = 0;
+    }
+    inherit(TapRecognizer, Recognizer, {
+      /**
+       * @namespace
+       * @memberof PinchRecognizer
+       */
+      defaults: {
+        event: "tap",
+        pointers: 1,
+        taps: 1,
+        interval: 300,
+        // max time between the multi-tap taps
+        time: 250,
+        // max time of the pointer to be down (like finger on the screen)
+        threshold: 9,
+        // a minimal movement is ok, but keep it low
+        posThreshold: 10
+        // a multi-tap can be a bit off the initial position
+      },
+      getTouchAction: function() {
+        return [TOUCH_ACTION_MANIPULATION];
+      },
+      process: function(input) {
+        var options = this.options;
+        var validPointers = input.pointers.length === options.pointers;
+        var validMovement = input.distance < options.threshold;
+        var validTouchTime = input.deltaTime < options.time;
+        this.reset();
+        if (input.eventType & INPUT_START && this.count === 0) {
+          return this.failTimeout();
+        }
+        if (validMovement && validTouchTime && validPointers) {
+          if (input.eventType != INPUT_END) {
+            return this.failTimeout();
+          }
+          var validInterval = this.pTime ? input.timeStamp - this.pTime < options.interval : true;
+          var validMultiTap = !this.pCenter || getDistance(this.pCenter, input.center) < options.posThreshold;
+          this.pTime = input.timeStamp;
+          this.pCenter = input.center;
+          if (!validMultiTap || !validInterval) {
+            this.count = 1;
+          } else {
+            this.count += 1;
+          }
+          this._input = input;
+          var tapCount = this.count % options.taps;
+          if (tapCount === 0) {
+            if (!this.hasRequireFailures()) {
+              return STATE_RECOGNIZED;
+            } else {
+              this._timer = setTimeoutContext(function() {
+                this.state = STATE_RECOGNIZED;
+                this.tryEmit();
+              }, options.interval, this);
+              return STATE_BEGAN;
+            }
+          }
+        }
+        return STATE_FAILED;
+      },
+      failTimeout: function() {
+        this._timer = setTimeoutContext(function() {
+          this.state = STATE_FAILED;
+        }, this.options.interval, this);
+        return STATE_FAILED;
+      },
+      reset: function() {
+        clearTimeout(this._timer);
+      },
+      emit: function() {
+        if (this.state == STATE_RECOGNIZED) {
+          this._input.tapCount = this.count;
+          this.manager.emit(this.options.event, this._input);
+        }
+      }
+    });
+    function Hammer2(element, options) {
+      options = options || {};
+      options.recognizers = ifUndefined(options.recognizers, Hammer2.defaults.preset);
+      return new Manager(element, options);
+    }
+    Hammer2.VERSION = "2.0.7";
+    Hammer2.defaults = {
+      /**
+       * set if DOM events are being triggered.
+       * But this is slower and unused by simple implementations, so disabled by default.
+       * @type {Boolean}
+       * @default false
+       */
+      domEvents: false,
+      /**
+       * The value for the touchAction property/fallback.
+       * When set to `compute` it will magically set the correct value based on the added recognizers.
+       * @type {String}
+       * @default compute
+       */
+      touchAction: TOUCH_ACTION_COMPUTE,
+      /**
+       * @type {Boolean}
+       * @default true
+       */
+      enable: true,
+      /**
+       * EXPERIMENTAL FEATURE -- can be removed/changed
+       * Change the parent input target element.
+       * If Null, then it is being set the to main element.
+       * @type {Null|EventTarget}
+       * @default null
+       */
+      inputTarget: null,
+      /**
+       * force an input class
+       * @type {Null|Function}
+       * @default null
+       */
+      inputClass: null,
+      /**
+       * Default recognizer setup when calling `Hammer()`
+       * When creating a new Manager these will be skipped.
+       * @type {Array}
+       */
+      preset: [
+        // RecognizerClass, options, [recognizeWith, ...], [requireFailure, ...]
+        [RotateRecognizer, { enable: false }],
+        [PinchRecognizer, { enable: false }, ["rotate"]],
+        [SwipeRecognizer, { direction: DIRECTION_HORIZONTAL }],
+        [PanRecognizer, { direction: DIRECTION_HORIZONTAL }, ["swipe"]],
+        [TapRecognizer],
+        [TapRecognizer, { event: "doubletap", taps: 2 }, ["tap"]],
+        [PressRecognizer]
+      ],
+      /**
+       * Some CSS properties can be used to improve the working of Hammer.
+       * Add them to this method and they will be set when creating a new Manager.
+       * @namespace
+       */
+      cssProps: {
+        /**
+         * Disables text selection to improve the dragging gesture. Mainly for desktop browsers.
+         * @type {String}
+         * @default 'none'
+         */
+        userSelect: "none",
+        /**
+         * Disable the Windows Phone grippers when pressing an element.
+         * @type {String}
+         * @default 'none'
+         */
+        touchSelect: "none",
+        /**
+         * Disables the default callout shown when you touch and hold a touch target.
+         * On iOS, when you touch and hold a touch target such as a link, Safari displays
+         * a callout containing information about the link. This property allows you to disable that callout.
+         * @type {String}
+         * @default 'none'
+         */
+        touchCallout: "none",
+        /**
+         * Specifies whether zooming is enabled. Used by IE10>
+         * @type {String}
+         * @default 'none'
+         */
+        contentZooming: "none",
+        /**
+         * Specifies that an entire element should be draggable instead of its contents. Mainly for desktop browsers.
+         * @type {String}
+         * @default 'none'
+         */
+        userDrag: "none",
+        /**
+         * Overrides the highlight color shown when the user taps a link or a JavaScript
+         * clickable element in iOS. This property obeys the alpha value, if specified.
+         * @type {String}
+         * @default 'rgba(0,0,0,0)'
+         */
+        tapHighlightColor: "rgba(0,0,0,0)"
+      }
+    };
+    var STOP = 1;
+    var FORCED_STOP = 2;
+    function Manager(element, options) {
+      this.options = assign({}, Hammer2.defaults, options || {});
+      this.options.inputTarget = this.options.inputTarget || element;
+      this.handlers = {};
+      this.session = {};
+      this.recognizers = [];
+      this.oldCssProps = {};
+      this.element = element;
+      this.input = createInputInstance(this);
+      this.touchAction = new TouchAction(this, this.options.touchAction);
+      toggleCssProps(this, true);
+      each2(this.options.recognizers, function(item) {
+        var recognizer = this.add(new item[0](item[1]));
+        item[2] && recognizer.recognizeWith(item[2]);
+        item[3] && recognizer.requireFailure(item[3]);
+      }, this);
+    }
+    Manager.prototype = {
+      /**
+       * set options
+       * @param {Object} options
+       * @returns {Manager}
+       */
+      set: function(options) {
+        assign(this.options, options);
+        if (options.touchAction) {
+          this.touchAction.update();
+        }
+        if (options.inputTarget) {
+          this.input.destroy();
+          this.input.target = options.inputTarget;
+          this.input.init();
+        }
+        return this;
+      },
+      /**
+       * stop recognizing for this session.
+       * This session will be discarded, when a new [input]start event is fired.
+       * When forced, the recognizer cycle is stopped immediately.
+       * @param {Boolean} [force]
+       */
+      stop: function(force) {
+        this.session.stopped = force ? FORCED_STOP : STOP;
+      },
+      /**
+       * run the recognizers!
+       * called by the inputHandler function on every movement of the pointers (touches)
+       * it walks through all the recognizers and tries to detect the gesture that is being made
+       * @param {Object} inputData
+       */
+      recognize: function(inputData) {
+        var session = this.session;
+        if (session.stopped) {
+          return;
+        }
+        this.touchAction.preventDefaults(inputData);
+        var recognizer;
+        var recognizers = this.recognizers;
+        var curRecognizer = session.curRecognizer;
+        if (!curRecognizer || curRecognizer && curRecognizer.state & STATE_RECOGNIZED) {
+          curRecognizer = session.curRecognizer = null;
+        }
+        var i = 0;
+        while (i < recognizers.length) {
+          recognizer = recognizers[i];
+          if (session.stopped !== FORCED_STOP && // 1
+          (!curRecognizer || recognizer == curRecognizer || // 2
+          recognizer.canRecognizeWith(curRecognizer))) {
+            recognizer.recognize(inputData);
+          } else {
+            recognizer.reset();
+          }
+          if (!curRecognizer && recognizer.state & (STATE_BEGAN | STATE_CHANGED | STATE_ENDED)) {
+            curRecognizer = session.curRecognizer = recognizer;
+          }
+          i++;
+        }
+      },
+      /**
+       * get a recognizer by its event name.
+       * @param {Recognizer|String} recognizer
+       * @returns {Recognizer|Null}
+       */
+      get: function(recognizer) {
+        if (recognizer instanceof Recognizer) {
+          return recognizer;
+        }
+        var recognizers = this.recognizers;
+        for (var i = 0; i < recognizers.length; i++) {
+          if (recognizers[i].options.event == recognizer) {
+            return recognizers[i];
+          }
+        }
+        return null;
+      },
+      /**
+       * add a recognizer to the manager
+       * existing recognizers with the same event name will be removed
+       * @param {Recognizer} recognizer
+       * @returns {Recognizer|Manager}
+       */
+      add: function(recognizer) {
+        if (invokeArrayArg(recognizer, "add", this)) {
+          return this;
+        }
+        var existing = this.get(recognizer.options.event);
+        if (existing) {
+          this.remove(existing);
+        }
+        this.recognizers.push(recognizer);
+        recognizer.manager = this;
+        this.touchAction.update();
+        return recognizer;
+      },
+      /**
+       * remove a recognizer by name or instance
+       * @param {Recognizer|String} recognizer
+       * @returns {Manager}
+       */
+      remove: function(recognizer) {
+        if (invokeArrayArg(recognizer, "remove", this)) {
+          return this;
+        }
+        recognizer = this.get(recognizer);
+        if (recognizer) {
+          var recognizers = this.recognizers;
+          var index = inArray(recognizers, recognizer);
+          if (index !== -1) {
+            recognizers.splice(index, 1);
+            this.touchAction.update();
+          }
+        }
+        return this;
+      },
+      /**
+       * bind event
+       * @param {String} events
+       * @param {Function} handler
+       * @returns {EventEmitter} this
+       */
+      on: function(events, handler) {
+        if (events === undefined$1) {
+          return;
+        }
+        if (handler === undefined$1) {
+          return;
+        }
+        var handlers = this.handlers;
+        each2(splitStr(events), function(event) {
+          handlers[event] = handlers[event] || [];
+          handlers[event].push(handler);
+        });
+        return this;
+      },
+      /**
+       * unbind event, leave emit blank to remove all handlers
+       * @param {String} events
+       * @param {Function} [handler]
+       * @returns {EventEmitter} this
+       */
+      off: function(events, handler) {
+        if (events === undefined$1) {
+          return;
+        }
+        var handlers = this.handlers;
+        each2(splitStr(events), function(event) {
+          if (!handler) {
+            delete handlers[event];
+          } else {
+            handlers[event] && handlers[event].splice(inArray(handlers[event], handler), 1);
+          }
+        });
+        return this;
+      },
+      /**
+       * emit event to the listeners
+       * @param {String} event
+       * @param {Object} data
+       */
+      emit: function(event, data) {
+        if (this.options.domEvents) {
+          triggerDomEvent(event, data);
+        }
+        var handlers = this.handlers[event] && this.handlers[event].slice();
+        if (!handlers || !handlers.length) {
+          return;
+        }
+        data.type = event;
+        data.preventDefault = function() {
+          data.srcEvent.preventDefault();
+        };
+        var i = 0;
+        while (i < handlers.length) {
+          handlers[i](data);
+          i++;
+        }
+      },
+      /**
+       * destroy the manager and unbinds all events
+       * it doesn't unbind dom events, that is the user own responsibility
+       */
+      destroy: function() {
+        this.element && toggleCssProps(this, false);
+        this.handlers = {};
+        this.session = {};
+        this.input.destroy();
+        this.element = null;
+      }
+    };
+    function toggleCssProps(manager, add) {
+      var element = manager.element;
+      if (!element.style) {
+        return;
+      }
+      var prop;
+      each2(manager.options.cssProps, function(value, name) {
+        prop = prefixed(element.style, name);
+        if (add) {
+          manager.oldCssProps[prop] = element.style[prop];
+          element.style[prop] = value;
+        } else {
+          element.style[prop] = manager.oldCssProps[prop] || "";
+        }
+      });
+      if (!add) {
+        manager.oldCssProps = {};
+      }
+    }
+    function triggerDomEvent(event, data) {
+      var gestureEvent = document2.createEvent("Event");
+      gestureEvent.initEvent(event, true, true);
+      gestureEvent.gesture = data;
+      data.target.dispatchEvent(gestureEvent);
+    }
+    assign(Hammer2, {
+      INPUT_START,
+      INPUT_MOVE,
+      INPUT_END,
+      INPUT_CANCEL,
+      STATE_POSSIBLE,
+      STATE_BEGAN,
+      STATE_CHANGED,
+      STATE_ENDED,
+      STATE_RECOGNIZED,
+      STATE_CANCELLED,
+      STATE_FAILED,
+      DIRECTION_NONE,
+      DIRECTION_LEFT,
+      DIRECTION_RIGHT,
+      DIRECTION_UP,
+      DIRECTION_DOWN,
+      DIRECTION_HORIZONTAL,
+      DIRECTION_VERTICAL,
+      DIRECTION_ALL,
+      Manager,
+      Input,
+      TouchAction,
+      TouchInput,
+      MouseInput,
+      PointerEventInput,
+      TouchMouseInput,
+      SingleTouchInput,
+      Recognizer,
+      AttrRecognizer,
+      Tap: TapRecognizer,
+      Pan: PanRecognizer,
+      Swipe: SwipeRecognizer,
+      Pinch: PinchRecognizer,
+      Rotate: RotateRecognizer,
+      Press: PressRecognizer,
+      on: addEventListeners,
+      off: removeEventListeners,
+      each: each2,
+      merge: merge2,
+      extend,
+      assign,
+      inherit,
+      bindFn,
+      prefixed
+    });
+    var freeGlobal = typeof window2 !== "undefined" ? window2 : typeof self !== "undefined" ? self : {};
+    freeGlobal.Hammer = Hammer2;
+    if (module.exports) {
+      module.exports = Hammer2;
+    } else {
+      window2[exportName] = Hammer2;
+    }
+  })(window, document, "Hammer");
+})(hammer);
+var hammerExports = hammer.exports;
+const Hammer = /* @__PURE__ */ getDefaultExportFromCjs(hammerExports);
+/*!
+* chartjs-plugin-zoom v2.2.0
+* https://www.chartjs.org/chartjs-plugin-zoom/2.2.0/
+ * (c) 2016-2024 chartjs-plugin-zoom Contributors
+ * Released under the MIT License
+ */
+const getModifierKey = (opts) => opts && opts.enabled && opts.modifierKey;
+const keyPressed = (key, event) => key && event[key + "Key"];
+const keyNotPressed = (key, event) => key && !event[key + "Key"];
+function directionEnabled(mode, dir, chart) {
+  if (mode === void 0) {
+    return true;
+  } else if (typeof mode === "string") {
+    return mode.indexOf(dir) !== -1;
+  } else if (typeof mode === "function") {
+    return mode({ chart }).indexOf(dir) !== -1;
+  }
+  return false;
+}
+function directionsEnabled(mode, chart) {
+  if (typeof mode === "function") {
+    mode = mode({ chart });
+  }
+  if (typeof mode === "string") {
+    return { x: mode.indexOf("x") !== -1, y: mode.indexOf("y") !== -1 };
+  }
+  return { x: false, y: false };
+}
+function debounce(fn, delay) {
+  let timeout;
+  return function() {
+    clearTimeout(timeout);
+    timeout = setTimeout(fn, delay);
+    return delay;
+  };
+}
+function getScaleUnderPoint({ x: x2, y: y2 }, chart) {
+  const scales = chart.scales;
+  const scaleIds = Object.keys(scales);
+  for (let i = 0; i < scaleIds.length; i++) {
+    const scale = scales[scaleIds[i]];
+    if (y2 >= scale.top && y2 <= scale.bottom && x2 >= scale.left && x2 <= scale.right) {
+      return scale;
+    }
+  }
+  return null;
+}
+function getEnabledScalesByPoint(options, point, chart) {
+  const { mode = "xy", scaleMode, overScaleMode } = options || {};
+  const scale = getScaleUnderPoint(point, chart);
+  const enabled = directionsEnabled(mode, chart);
+  const scaleEnabled = directionsEnabled(scaleMode, chart);
+  if (overScaleMode) {
+    const overScaleEnabled = directionsEnabled(overScaleMode, chart);
+    for (const axis of ["x", "y"]) {
+      if (overScaleEnabled[axis]) {
+        scaleEnabled[axis] = enabled[axis];
+        enabled[axis] = false;
+      }
+    }
+  }
+  if (scale && scaleEnabled[scale.axis]) {
+    return [scale];
+  }
+  const enabledScales = [];
+  each(chart.scales, function(scaleItem) {
+    if (enabled[scaleItem.axis]) {
+      enabledScales.push(scaleItem);
+    }
+  });
+  return enabledScales;
+}
+const chartStates = /* @__PURE__ */ new WeakMap();
+function getState(chart) {
+  let state = chartStates.get(chart);
+  if (!state) {
+    state = {
+      originalScaleLimits: {},
+      updatedScaleLimits: {},
+      handlers: {},
+      panDelta: {},
+      dragging: false,
+      panning: false
+    };
+    chartStates.set(chart, state);
+  }
+  return state;
+}
+function removeState(chart) {
+  chartStates.delete(chart);
+}
+function zoomDelta(val, min, range, newRange) {
+  const minPercent = Math.max(0, Math.min(1, (val - min) / range || 0));
+  const maxPercent = 1 - minPercent;
+  return {
+    min: newRange * minPercent,
+    max: newRange * maxPercent
+  };
+}
+function getValueAtPoint(scale, point) {
+  const pixel = scale.isHorizontal() ? point.x : point.y;
+  return scale.getValueForPixel(pixel);
+}
+function linearZoomDelta(scale, zoom2, center) {
+  const range = scale.max - scale.min;
+  const newRange = range * (zoom2 - 1);
+  const centerValue = getValueAtPoint(scale, center);
+  return zoomDelta(centerValue, scale.min, range, newRange);
+}
+function logarithmicZoomRange(scale, zoom2, center) {
+  const centerValue = getValueAtPoint(scale, center);
+  if (centerValue === void 0) {
+    return { min: scale.min, max: scale.max };
+  }
+  const logMin = Math.log10(scale.min);
+  const logMax = Math.log10(scale.max);
+  const logCenter = Math.log10(centerValue);
+  const logRange = logMax - logMin;
+  const newLogRange = logRange * (zoom2 - 1);
+  const delta = zoomDelta(logCenter, logMin, logRange, newLogRange);
+  return {
+    min: Math.pow(10, logMin + delta.min),
+    max: Math.pow(10, logMax - delta.max)
+  };
+}
+function getScaleLimits(scale, limits) {
+  return limits && (limits[scale.id] || limits[scale.axis]) || {};
+}
+function getLimit(state, scale, scaleLimits, prop, fallback) {
+  let limit = scaleLimits[prop];
+  if (limit === "original") {
+    const original = state.originalScaleLimits[scale.id][prop];
+    limit = valueOrDefault(original.options, original.scale);
+  }
+  return valueOrDefault(limit, fallback);
+}
+function linearRange(scale, pixel0, pixel1) {
+  const v0 = scale.getValueForPixel(pixel0);
+  const v1 = scale.getValueForPixel(pixel1);
+  return {
+    min: Math.min(v0, v1),
+    max: Math.max(v0, v1)
+  };
+}
+function fixRange(range, { min, max, minLimit, maxLimit }, originalLimits) {
+  const offset = (range - max + min) / 2;
+  min -= offset;
+  max += offset;
+  const origMin = originalLimits.min.options ?? originalLimits.min.scale;
+  const origMax = originalLimits.max.options ?? originalLimits.max.scale;
+  const epsilon = range / 1e6;
+  if (almostEquals(min, origMin, epsilon)) {
+    min = origMin;
+  }
+  if (almostEquals(max, origMax, epsilon)) {
+    max = origMax;
+  }
+  if (min < minLimit) {
+    min = minLimit;
+    max = Math.min(minLimit + range, maxLimit);
+  } else if (max > maxLimit) {
+    max = maxLimit;
+    min = Math.max(maxLimit - range, minLimit);
+  }
+  return { min, max };
+}
+function updateRange(scale, { min, max }, limits, zoom2 = false) {
+  const state = getState(scale.chart);
+  const { options: scaleOpts } = scale;
+  const scaleLimits = getScaleLimits(scale, limits);
+  const { minRange = 0 } = scaleLimits;
+  const minLimit = getLimit(state, scale, scaleLimits, "min", -Infinity);
+  const maxLimit = getLimit(state, scale, scaleLimits, "max", Infinity);
+  if (zoom2 === "pan" && (min < minLimit || max > maxLimit)) {
+    return true;
+  }
+  const scaleRange = scale.max - scale.min;
+  const range = zoom2 ? Math.max(max - min, minRange) : scaleRange;
+  if (zoom2 && range === minRange && scaleRange <= minRange) {
+    return true;
+  }
+  const newRange = fixRange(range, { min, max, minLimit, maxLimit }, state.originalScaleLimits[scale.id]);
+  scaleOpts.min = newRange.min;
+  scaleOpts.max = newRange.max;
+  state.updatedScaleLimits[scale.id] = newRange;
+  return scale.parse(newRange.min) !== scale.min || scale.parse(newRange.max) !== scale.max;
+}
+function zoomNumericalScale(scale, zoom2, center, limits) {
+  const delta = linearZoomDelta(scale, zoom2, center);
+  const newRange = { min: scale.min + delta.min, max: scale.max - delta.max };
+  return updateRange(scale, newRange, limits, true);
+}
+function zoomLogarithmicScale(scale, zoom2, center, limits) {
+  const newRange = logarithmicZoomRange(scale, zoom2, center);
+  return updateRange(scale, newRange, limits, true);
+}
+function zoomRectNumericalScale(scale, from2, to2, limits) {
+  updateRange(scale, linearRange(scale, from2, to2), limits, true);
+}
+const integerChange = (v2) => v2 === 0 || isNaN(v2) ? 0 : v2 < 0 ? Math.min(Math.round(v2), -1) : Math.max(Math.round(v2), 1);
+function existCategoryFromMaxZoom(scale) {
+  const labels = scale.getLabels();
+  const maxIndex = labels.length - 1;
+  if (scale.min > 0) {
+    scale.min -= 1;
+  }
+  if (scale.max < maxIndex) {
+    scale.max += 1;
+  }
+}
+function zoomCategoryScale(scale, zoom2, center, limits) {
+  const delta = linearZoomDelta(scale, zoom2, center);
+  if (scale.min === scale.max && zoom2 < 1) {
+    existCategoryFromMaxZoom(scale);
+  }
+  const newRange = { min: scale.min + integerChange(delta.min), max: scale.max - integerChange(delta.max) };
+  return updateRange(scale, newRange, limits, true);
+}
+function scaleLength(scale) {
+  return scale.isHorizontal() ? scale.width : scale.height;
+}
+function panCategoryScale(scale, delta, limits) {
+  const labels = scale.getLabels();
+  const lastLabelIndex = labels.length - 1;
+  let { min, max } = scale;
+  const range = Math.max(max - min, 1);
+  const stepDelta = Math.round(scaleLength(scale) / Math.max(range, 10));
+  const stepSize = Math.round(Math.abs(delta / stepDelta));
+  let applied;
+  if (delta < -stepDelta) {
+    max = Math.min(max + stepSize, lastLabelIndex);
+    min = range === 1 ? max : max - range;
+    applied = max === lastLabelIndex;
+  } else if (delta > stepDelta) {
+    min = Math.max(0, min - stepSize);
+    max = range === 1 ? min : min + range;
+    applied = min === 0;
+  }
+  return updateRange(scale, { min, max }, limits) || applied;
+}
+const OFFSETS = {
+  second: 500,
+  minute: 30 * 1e3,
+  hour: 30 * 60 * 1e3,
+  day: 12 * 60 * 60 * 1e3,
+  week: 3.5 * 24 * 60 * 60 * 1e3,
+  month: 15 * 24 * 60 * 60 * 1e3,
+  quarter: 60 * 24 * 60 * 60 * 1e3,
+  year: 182 * 24 * 60 * 60 * 1e3
+};
+function panNumericalScale(scale, delta, limits, pan2 = false) {
+  const { min: prevStart, max: prevEnd, options } = scale;
+  const round2 = options.time && options.time.round;
+  const offset = OFFSETS[round2] || 0;
+  const newMin = scale.getValueForPixel(scale.getPixelForValue(prevStart + offset) - delta);
+  const newMax = scale.getValueForPixel(scale.getPixelForValue(prevEnd + offset) - delta);
+  if (isNaN(newMin) || isNaN(newMax)) {
+    return true;
+  }
+  return updateRange(scale, { min: newMin, max: newMax }, limits, pan2 ? "pan" : false);
+}
+function panNonLinearScale(scale, delta, limits) {
+  return panNumericalScale(scale, delta, limits, true);
+}
+const zoomFunctions = {
+  category: zoomCategoryScale,
+  default: zoomNumericalScale,
+  logarithmic: zoomLogarithmicScale
+};
+const zoomRectFunctions = {
+  default: zoomRectNumericalScale
+};
+const panFunctions = {
+  category: panCategoryScale,
+  default: panNumericalScale,
+  logarithmic: panNonLinearScale,
+  timeseries: panNonLinearScale
+};
+function shouldUpdateScaleLimits(scale, originalScaleLimits, updatedScaleLimits) {
+  const { id: id2, options: { min, max } } = scale;
+  if (!originalScaleLimits[id2] || !updatedScaleLimits[id2]) {
+    return true;
+  }
+  const previous = updatedScaleLimits[id2];
+  return previous.min !== min || previous.max !== max;
+}
+function removeMissingScales(limits, scales) {
+  each(limits, (opt, key) => {
+    if (!scales[key]) {
+      delete limits[key];
+    }
+  });
+}
+function storeOriginalScaleLimits(chart, state) {
+  const { scales } = chart;
+  const { originalScaleLimits, updatedScaleLimits } = state;
+  each(scales, function(scale) {
+    if (shouldUpdateScaleLimits(scale, originalScaleLimits, updatedScaleLimits)) {
+      originalScaleLimits[scale.id] = {
+        min: { scale: scale.min, options: scale.options.min },
+        max: { scale: scale.max, options: scale.options.max }
+      };
+    }
+  });
+  removeMissingScales(originalScaleLimits, scales);
+  removeMissingScales(updatedScaleLimits, scales);
+  return originalScaleLimits;
+}
+function doZoom(scale, amount, center, limits) {
+  const fn = zoomFunctions[scale.type] || zoomFunctions.default;
+  callback(fn, [scale, amount, center, limits]);
+}
+function doZoomRect(scale, from2, to2, limits) {
+  const fn = zoomRectFunctions[scale.type] || zoomRectFunctions.default;
+  callback(fn, [scale, from2, to2, limits]);
+}
+function getCenter(chart) {
+  const ca2 = chart.chartArea;
+  return {
+    x: (ca2.left + ca2.right) / 2,
+    y: (ca2.top + ca2.bottom) / 2
+  };
+}
+function zoom(chart, amount, transition = "none", trigger = "api") {
+  const { x: x2 = 1, y: y2 = 1, focalPoint = getCenter(chart) } = typeof amount === "number" ? { x: amount, y: amount } : amount;
+  const state = getState(chart);
+  const { options: { limits, zoom: zoomOptions } } = state;
+  storeOriginalScaleLimits(chart, state);
+  const xEnabled = x2 !== 1;
+  const yEnabled = y2 !== 1;
+  const enabledScales = getEnabledScalesByPoint(zoomOptions, focalPoint, chart);
+  each(enabledScales || chart.scales, function(scale) {
+    if (scale.isHorizontal() && xEnabled) {
+      doZoom(scale, x2, focalPoint, limits);
+    } else if (!scale.isHorizontal() && yEnabled) {
+      doZoom(scale, y2, focalPoint, limits);
+    }
+  });
+  chart.update(transition);
+  callback(zoomOptions.onZoom, [{ chart, trigger }]);
+}
+function zoomRect(chart, p0, p1, transition = "none", trigger = "api") {
+  const state = getState(chart);
+  const { options: { limits, zoom: zoomOptions } } = state;
+  const { mode = "xy" } = zoomOptions;
+  storeOriginalScaleLimits(chart, state);
+  const xEnabled = directionEnabled(mode, "x", chart);
+  const yEnabled = directionEnabled(mode, "y", chart);
+  each(chart.scales, function(scale) {
+    if (scale.isHorizontal() && xEnabled) {
+      doZoomRect(scale, p0.x, p1.x, limits);
+    } else if (!scale.isHorizontal() && yEnabled) {
+      doZoomRect(scale, p0.y, p1.y, limits);
+    }
+  });
+  chart.update(transition);
+  callback(zoomOptions.onZoom, [{ chart, trigger }]);
+}
+function zoomScale(chart, scaleId, range, transition = "none", trigger = "api") {
+  var _a2;
+  const state = getState(chart);
+  storeOriginalScaleLimits(chart, state);
+  const scale = chart.scales[scaleId];
+  updateRange(scale, range, void 0, true);
+  chart.update(transition);
+  callback((_a2 = state.options.zoom) == null ? void 0 : _a2.onZoom, [{ chart, trigger }]);
+}
+function resetZoom(chart, transition = "default") {
+  const state = getState(chart);
+  const originalScaleLimits = storeOriginalScaleLimits(chart, state);
+  each(chart.scales, function(scale) {
+    const scaleOptions = scale.options;
+    if (originalScaleLimits[scale.id]) {
+      scaleOptions.min = originalScaleLimits[scale.id].min.options;
+      scaleOptions.max = originalScaleLimits[scale.id].max.options;
+    } else {
+      delete scaleOptions.min;
+      delete scaleOptions.max;
+    }
+    delete state.updatedScaleLimits[scale.id];
+  });
+  chart.update(transition);
+  callback(state.options.zoom.onZoomComplete, [{ chart }]);
+}
+function getOriginalRange(state, scaleId) {
+  const original = state.originalScaleLimits[scaleId];
+  if (!original) {
+    return;
+  }
+  const { min, max } = original;
+  return valueOrDefault(max.options, max.scale) - valueOrDefault(min.options, min.scale);
+}
+function getZoomLevel(chart) {
+  const state = getState(chart);
+  let min = 1;
+  let max = 1;
+  each(chart.scales, function(scale) {
+    const origRange = getOriginalRange(state, scale.id);
+    if (origRange) {
+      const level = Math.round(origRange / (scale.max - scale.min) * 100) / 100;
+      min = Math.min(min, level);
+      max = Math.max(max, level);
+    }
+  });
+  return min < 1 ? min : max;
+}
+function panScale(scale, delta, limits, state) {
+  const { panDelta } = state;
+  const storedDelta = panDelta[scale.id] || 0;
+  if (sign(storedDelta) === sign(delta)) {
+    delta += storedDelta;
+  }
+  const fn = panFunctions[scale.type] || panFunctions.default;
+  if (callback(fn, [scale, delta, limits])) {
+    panDelta[scale.id] = 0;
+  } else {
+    panDelta[scale.id] = delta;
+  }
+}
+function pan(chart, delta, enabledScales, transition = "none") {
+  const { x: x2 = 0, y: y2 = 0 } = typeof delta === "number" ? { x: delta, y: delta } : delta;
+  const state = getState(chart);
+  const { options: { pan: panOptions, limits } } = state;
+  const { onPan } = panOptions || {};
+  storeOriginalScaleLimits(chart, state);
+  const xEnabled = x2 !== 0;
+  const yEnabled = y2 !== 0;
+  each(enabledScales || chart.scales, function(scale) {
+    if (scale.isHorizontal() && xEnabled) {
+      panScale(scale, x2, limits, state);
+    } else if (!scale.isHorizontal() && yEnabled) {
+      panScale(scale, y2, limits, state);
+    }
+  });
+  chart.update(transition);
+  callback(onPan, [{ chart }]);
+}
+function getInitialScaleBounds(chart) {
+  const state = getState(chart);
+  storeOriginalScaleLimits(chart, state);
+  const scaleBounds = {};
+  for (const scaleId of Object.keys(chart.scales)) {
+    const { min, max } = state.originalScaleLimits[scaleId] || { min: {}, max: {} };
+    scaleBounds[scaleId] = { min: min.scale, max: max.scale };
+  }
+  return scaleBounds;
+}
+function getZoomedScaleBounds(chart) {
+  const state = getState(chart);
+  const scaleBounds = {};
+  for (const scaleId of Object.keys(chart.scales)) {
+    scaleBounds[scaleId] = state.updatedScaleLimits[scaleId];
+  }
+  return scaleBounds;
+}
+function isZoomedOrPanned(chart) {
+  const scaleBounds = getInitialScaleBounds(chart);
+  for (const scaleId of Object.keys(chart.scales)) {
+    const { min: originalMin, max: originalMax } = scaleBounds[scaleId];
+    if (originalMin !== void 0 && chart.scales[scaleId].min !== originalMin) {
+      return true;
+    }
+    if (originalMax !== void 0 && chart.scales[scaleId].max !== originalMax) {
+      return true;
+    }
+  }
+  return false;
+}
+function isZoomingOrPanning(chart) {
+  const state = getState(chart);
+  return state.panning || state.dragging;
+}
+const clamp = (x2, from2, to2) => Math.min(to2, Math.max(from2, x2));
+function removeHandler(chart, type) {
+  const { handlers } = getState(chart);
+  const handler = handlers[type];
+  if (handler && handler.target) {
+    handler.target.removeEventListener(type, handler);
+    delete handlers[type];
+  }
+}
+function addHandler(chart, target, type, handler) {
+  const { handlers, options } = getState(chart);
+  const oldHandler = handlers[type];
+  if (oldHandler && oldHandler.target === target) {
+    return;
+  }
+  removeHandler(chart, type);
+  handlers[type] = (event) => handler(chart, event, options);
+  handlers[type].target = target;
+  const passive = type === "wheel" ? false : void 0;
+  target.addEventListener(type, handlers[type], { passive });
+}
+function mouseMove(chart, event) {
+  const state = getState(chart);
+  if (state.dragStart) {
+    state.dragging = true;
+    state.dragEnd = event;
+    chart.update("none");
+  }
+}
+function keyDown(chart, event) {
+  const state = getState(chart);
+  if (!state.dragStart || event.key !== "Escape") {
+    return;
+  }
+  removeHandler(chart, "keydown");
+  state.dragging = false;
+  state.dragStart = state.dragEnd = null;
+  chart.update("none");
+}
+function getPointPosition(event, chart) {
+  if (event.target !== chart.canvas) {
+    const canvasArea = chart.canvas.getBoundingClientRect();
+    return {
+      x: event.clientX - canvasArea.left,
+      y: event.clientY - canvasArea.top
+    };
+  }
+  return getRelativePosition(event, chart);
+}
+function zoomStart(chart, event, zoomOptions) {
+  const { onZoomStart, onZoomRejected } = zoomOptions;
+  if (onZoomStart) {
+    const point = getPointPosition(event, chart);
+    if (callback(onZoomStart, [{ chart, event, point }]) === false) {
+      callback(onZoomRejected, [{ chart, event }]);
+      return false;
+    }
+  }
+}
+function mouseDown(chart, event) {
+  if (chart.legend) {
+    const point = getRelativePosition(event, chart);
+    if (_isPointInArea(point, chart.legend)) {
+      return;
+    }
+  }
+  const state = getState(chart);
+  const { pan: panOptions, zoom: zoomOptions = {} } = state.options;
+  if (event.button !== 0 || keyPressed(getModifierKey(panOptions), event) || keyNotPressed(getModifierKey(zoomOptions.drag), event)) {
+    return callback(zoomOptions.onZoomRejected, [{ chart, event }]);
+  }
+  if (zoomStart(chart, event, zoomOptions) === false) {
+    return;
+  }
+  state.dragStart = event;
+  addHandler(chart, chart.canvas.ownerDocument, "mousemove", mouseMove);
+  addHandler(chart, window.document, "keydown", keyDown);
+}
+function applyAspectRatio({ begin, end }, aspectRatio) {
+  let width = end.x - begin.x;
+  let height = end.y - begin.y;
+  const ratio = Math.abs(width / height);
+  if (ratio > aspectRatio) {
+    width = Math.sign(width) * Math.abs(height * aspectRatio);
+  } else if (ratio < aspectRatio) {
+    height = Math.sign(height) * Math.abs(width / aspectRatio);
+  }
+  end.x = begin.x + width;
+  end.y = begin.y + height;
+}
+function applyMinMaxProps(rect, chartArea, points, { min, max, prop }) {
+  rect[min] = clamp(Math.min(points.begin[prop], points.end[prop]), chartArea[min], chartArea[max]);
+  rect[max] = clamp(Math.max(points.begin[prop], points.end[prop]), chartArea[min], chartArea[max]);
+}
+function getRelativePoints(chart, pointEvents, maintainAspectRatio) {
+  const points = {
+    begin: getPointPosition(pointEvents.dragStart, chart),
+    end: getPointPosition(pointEvents.dragEnd, chart)
+  };
+  if (maintainAspectRatio) {
+    const aspectRatio = chart.chartArea.width / chart.chartArea.height;
+    applyAspectRatio(points, aspectRatio);
+  }
+  return points;
+}
+function computeDragRect(chart, mode, pointEvents, maintainAspectRatio) {
+  const xEnabled = directionEnabled(mode, "x", chart);
+  const yEnabled = directionEnabled(mode, "y", chart);
+  const { top, left, right, bottom, width: chartWidth, height: chartHeight } = chart.chartArea;
+  const rect = { top, left, right, bottom };
+  const points = getRelativePoints(chart, pointEvents, maintainAspectRatio && xEnabled && yEnabled);
+  if (xEnabled) {
+    applyMinMaxProps(rect, chart.chartArea, points, { min: "left", max: "right", prop: "x" });
+  }
+  if (yEnabled) {
+    applyMinMaxProps(rect, chart.chartArea, points, { min: "top", max: "bottom", prop: "y" });
+  }
+  const width = rect.right - rect.left;
+  const height = rect.bottom - rect.top;
+  return {
+    ...rect,
+    width,
+    height,
+    zoomX: xEnabled && width ? 1 + (chartWidth - width) / chartWidth : 1,
+    zoomY: yEnabled && height ? 1 + (chartHeight - height) / chartHeight : 1
+  };
+}
+function mouseUp(chart, event) {
+  const state = getState(chart);
+  if (!state.dragStart) {
+    return;
+  }
+  removeHandler(chart, "mousemove");
+  const { mode, onZoomComplete, drag: { threshold = 0, maintainAspectRatio } } = state.options.zoom;
+  const rect = computeDragRect(chart, mode, { dragStart: state.dragStart, dragEnd: event }, maintainAspectRatio);
+  const distanceX = directionEnabled(mode, "x", chart) ? rect.width : 0;
+  const distanceY = directionEnabled(mode, "y", chart) ? rect.height : 0;
+  const distance = Math.sqrt(distanceX * distanceX + distanceY * distanceY);
+  state.dragStart = state.dragEnd = null;
+  if (distance <= threshold) {
+    state.dragging = false;
+    chart.update("none");
+    return;
+  }
+  zoomRect(chart, { x: rect.left, y: rect.top }, { x: rect.right, y: rect.bottom }, "zoom", "drag");
+  state.dragging = false;
+  state.filterNextClick = true;
+  callback(onZoomComplete, [{ chart }]);
+}
+function wheelPreconditions(chart, event, zoomOptions) {
+  if (keyNotPressed(getModifierKey(zoomOptions.wheel), event)) {
+    callback(zoomOptions.onZoomRejected, [{ chart, event }]);
+    return;
+  }
+  if (zoomStart(chart, event, zoomOptions) === false) {
+    return;
+  }
+  if (event.cancelable) {
+    event.preventDefault();
+  }
+  if (event.deltaY === void 0) {
+    return;
+  }
+  return true;
+}
+function wheel(chart, event) {
+  const { handlers: { onZoomComplete }, options: { zoom: zoomOptions } } = getState(chart);
+  if (!wheelPreconditions(chart, event, zoomOptions)) {
+    return;
+  }
+  const rect = event.target.getBoundingClientRect();
+  const speed = zoomOptions.wheel.speed;
+  const percentage = event.deltaY >= 0 ? 2 - 1 / (1 - speed) : 1 + speed;
+  const amount = {
+    x: percentage,
+    y: percentage,
+    focalPoint: {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    }
+  };
+  zoom(chart, amount, "zoom", "wheel");
+  callback(onZoomComplete, [{ chart }]);
+}
+function addDebouncedHandler(chart, name, handler, delay) {
+  if (handler) {
+    getState(chart).handlers[name] = debounce(() => callback(handler, [{ chart }]), delay);
+  }
+}
+function addListeners(chart, options) {
+  const canvas = chart.canvas;
+  const { wheel: wheelOptions, drag: dragOptions, onZoomComplete } = options.zoom;
+  if (wheelOptions.enabled) {
+    addHandler(chart, canvas, "wheel", wheel);
+    addDebouncedHandler(chart, "onZoomComplete", onZoomComplete, 250);
+  } else {
+    removeHandler(chart, "wheel");
+  }
+  if (dragOptions.enabled) {
+    addHandler(chart, canvas, "mousedown", mouseDown);
+    addHandler(chart, canvas.ownerDocument, "mouseup", mouseUp);
+  } else {
+    removeHandler(chart, "mousedown");
+    removeHandler(chart, "mousemove");
+    removeHandler(chart, "mouseup");
+    removeHandler(chart, "keydown");
+  }
+}
+function removeListeners(chart) {
+  removeHandler(chart, "mousedown");
+  removeHandler(chart, "mousemove");
+  removeHandler(chart, "mouseup");
+  removeHandler(chart, "wheel");
+  removeHandler(chart, "click");
+  removeHandler(chart, "keydown");
+}
+function createEnabler(chart, state) {
+  return function(recognizer, event) {
+    const { pan: panOptions, zoom: zoomOptions = {} } = state.options;
+    if (!panOptions || !panOptions.enabled) {
+      return false;
+    }
+    const srcEvent = event && event.srcEvent;
+    if (!srcEvent) {
+      return true;
+    }
+    if (!state.panning && event.pointerType === "mouse" && (keyNotPressed(getModifierKey(panOptions), srcEvent) || keyPressed(getModifierKey(zoomOptions.drag), srcEvent))) {
+      callback(panOptions.onPanRejected, [{ chart, event }]);
+      return false;
+    }
+    return true;
+  };
+}
+function pinchAxes(p0, p1) {
+  const pinchX = Math.abs(p0.clientX - p1.clientX);
+  const pinchY = Math.abs(p0.clientY - p1.clientY);
+  const p2 = pinchX / pinchY;
+  let x2, y2;
+  if (p2 > 0.3 && p2 < 1.7) {
+    x2 = y2 = true;
+  } else if (pinchX > pinchY) {
+    x2 = true;
+  } else {
+    y2 = true;
+  }
+  return { x: x2, y: y2 };
+}
+function handlePinch(chart, state, e) {
+  if (state.scale) {
+    const { center, pointers } = e;
+    const zoomPercent = 1 / state.scale * e.scale;
+    const rect = e.target.getBoundingClientRect();
+    const pinch = pinchAxes(pointers[0], pointers[1]);
+    const mode = state.options.zoom.mode;
+    const amount = {
+      x: pinch.x && directionEnabled(mode, "x", chart) ? zoomPercent : 1,
+      y: pinch.y && directionEnabled(mode, "y", chart) ? zoomPercent : 1,
+      focalPoint: {
+        x: center.x - rect.left,
+        y: center.y - rect.top
+      }
+    };
+    zoom(chart, amount, "zoom", "pinch");
+    state.scale = e.scale;
+  }
+}
+function startPinch(chart, state, event) {
+  if (state.options.zoom.pinch.enabled) {
+    const point = getRelativePosition(event, chart);
+    if (callback(state.options.zoom.onZoomStart, [{ chart, event, point }]) === false) {
+      state.scale = null;
+      callback(state.options.zoom.onZoomRejected, [{ chart, event }]);
+    } else {
+      state.scale = 1;
+    }
+  }
+}
+function endPinch(chart, state, e) {
+  if (state.scale) {
+    handlePinch(chart, state, e);
+    state.scale = null;
+    callback(state.options.zoom.onZoomComplete, [{ chart }]);
+  }
+}
+function handlePan(chart, state, e) {
+  const delta = state.delta;
+  if (delta) {
+    state.panning = true;
+    pan(chart, { x: e.deltaX - delta.x, y: e.deltaY - delta.y }, state.panScales);
+    state.delta = { x: e.deltaX, y: e.deltaY };
+  }
+}
+function startPan(chart, state, event) {
+  const { enabled, onPanStart, onPanRejected } = state.options.pan;
+  if (!enabled) {
+    return;
+  }
+  const rect = event.target.getBoundingClientRect();
+  const point = {
+    x: event.center.x - rect.left,
+    y: event.center.y - rect.top
+  };
+  if (callback(onPanStart, [{ chart, event, point }]) === false) {
+    return callback(onPanRejected, [{ chart, event }]);
+  }
+  state.panScales = getEnabledScalesByPoint(state.options.pan, point, chart);
+  state.delta = { x: 0, y: 0 };
+  handlePan(chart, state, event);
+}
+function endPan(chart, state) {
+  state.delta = null;
+  if (state.panning) {
+    state.panning = false;
+    state.filterNextClick = true;
+    callback(state.options.pan.onPanComplete, [{ chart }]);
+  }
+}
+const hammers = /* @__PURE__ */ new WeakMap();
+function startHammer(chart, options) {
+  const state = getState(chart);
+  const canvas = chart.canvas;
+  const { pan: panOptions, zoom: zoomOptions } = options;
+  const mc2 = new Hammer.Manager(canvas);
+  if (zoomOptions && zoomOptions.pinch.enabled) {
+    mc2.add(new Hammer.Pinch());
+    mc2.on("pinchstart", (e) => startPinch(chart, state, e));
+    mc2.on("pinch", (e) => handlePinch(chart, state, e));
+    mc2.on("pinchend", (e) => endPinch(chart, state, e));
+  }
+  if (panOptions && panOptions.enabled) {
+    mc2.add(new Hammer.Pan({
+      threshold: panOptions.threshold,
+      enable: createEnabler(chart, state)
+    }));
+    mc2.on("panstart", (e) => startPan(chart, state, e));
+    mc2.on("panmove", (e) => handlePan(chart, state, e));
+    mc2.on("panend", () => endPan(chart, state));
+  }
+  hammers.set(chart, mc2);
+}
+function stopHammer(chart) {
+  const mc2 = hammers.get(chart);
+  if (mc2) {
+    mc2.remove("pinchstart");
+    mc2.remove("pinch");
+    mc2.remove("pinchend");
+    mc2.remove("panstart");
+    mc2.remove("pan");
+    mc2.remove("panend");
+    mc2.destroy();
+    hammers.delete(chart);
+  }
+}
+function hammerOptionsChanged(oldOptions, newOptions) {
+  var _a2, _b2, _c, _d;
+  const { pan: oldPan, zoom: oldZoom } = oldOptions;
+  const { pan: newPan, zoom: newZoom } = newOptions;
+  if (((_b2 = (_a2 = oldZoom == null ? void 0 : oldZoom.zoom) == null ? void 0 : _a2.pinch) == null ? void 0 : _b2.enabled) !== ((_d = (_c = newZoom == null ? void 0 : newZoom.zoom) == null ? void 0 : _c.pinch) == null ? void 0 : _d.enabled)) {
+    return true;
+  }
+  if ((oldPan == null ? void 0 : oldPan.enabled) !== (newPan == null ? void 0 : newPan.enabled)) {
+    return true;
+  }
+  if ((oldPan == null ? void 0 : oldPan.threshold) !== (newPan == null ? void 0 : newPan.threshold)) {
+    return true;
+  }
+  return false;
+}
+var version = "2.2.0";
+function draw(chart, caller, options) {
+  const dragOptions = options.zoom.drag;
+  const { dragStart, dragEnd } = getState(chart);
+  if (dragOptions.drawTime !== caller || !dragEnd) {
+    return;
+  }
+  const { left, top, width, height } = computeDragRect(chart, options.zoom.mode, { dragStart, dragEnd }, dragOptions.maintainAspectRatio);
+  const ctx = chart.ctx;
+  ctx.save();
+  ctx.beginPath();
+  ctx.fillStyle = dragOptions.backgroundColor || "rgba(225,225,225,0.3)";
+  ctx.fillRect(left, top, width, height);
+  if (dragOptions.borderWidth > 0) {
+    ctx.lineWidth = dragOptions.borderWidth;
+    ctx.strokeStyle = dragOptions.borderColor || "rgba(225,225,225)";
+    ctx.strokeRect(left, top, width, height);
+  }
+  ctx.restore();
+}
+var plugin = {
+  id: "zoom",
+  version,
+  defaults: {
+    pan: {
+      enabled: false,
+      mode: "xy",
+      threshold: 10,
+      modifierKey: null
+    },
+    zoom: {
+      wheel: {
+        enabled: false,
+        speed: 0.1,
+        modifierKey: null
+      },
+      drag: {
+        enabled: false,
+        drawTime: "beforeDatasetsDraw",
+        modifierKey: null
+      },
+      pinch: {
+        enabled: false
+      },
+      mode: "xy"
+    }
+  },
+  start: function(chart, _args, options) {
+    const state = getState(chart);
+    state.options = options;
+    if (Object.prototype.hasOwnProperty.call(options.zoom, "enabled")) {
+      console.warn("The option `zoom.enabled` is no longer supported. Please use `zoom.wheel.enabled`, `zoom.drag.enabled`, or `zoom.pinch.enabled`.");
+    }
+    if (Object.prototype.hasOwnProperty.call(options.zoom, "overScaleMode") || Object.prototype.hasOwnProperty.call(options.pan, "overScaleMode")) {
+      console.warn("The option `overScaleMode` is deprecated. Please use `scaleMode` instead (and update `mode` as desired).");
+    }
+    if (Hammer) {
+      startHammer(chart, options);
+    }
+    chart.pan = (delta, panScales, transition) => pan(chart, delta, panScales, transition);
+    chart.zoom = (args, transition) => zoom(chart, args, transition);
+    chart.zoomRect = (p0, p1, transition) => zoomRect(chart, p0, p1, transition);
+    chart.zoomScale = (id2, range, transition) => zoomScale(chart, id2, range, transition);
+    chart.resetZoom = (transition) => resetZoom(chart, transition);
+    chart.getZoomLevel = () => getZoomLevel(chart);
+    chart.getInitialScaleBounds = () => getInitialScaleBounds(chart);
+    chart.getZoomedScaleBounds = () => getZoomedScaleBounds(chart);
+    chart.isZoomedOrPanned = () => isZoomedOrPanned(chart);
+    chart.isZoomingOrPanning = () => isZoomingOrPanning(chart);
+  },
+  beforeEvent(chart, { event }) {
+    if (isZoomingOrPanning(chart)) {
+      return false;
+    }
+    if (event.type === "click" || event.type === "mouseup") {
+      const state = getState(chart);
+      if (state.filterNextClick) {
+        state.filterNextClick = false;
+        return false;
+      }
+    }
+  },
+  beforeUpdate: function(chart, args, options) {
+    const state = getState(chart);
+    const previousOptions = state.options;
+    state.options = options;
+    if (hammerOptionsChanged(previousOptions, options)) {
+      stopHammer(chart);
+      startHammer(chart, options);
+    }
+    addListeners(chart, options);
+  },
+  beforeDatasetsDraw(chart, _args, options) {
+    draw(chart, "beforeDatasetsDraw", options);
+  },
+  afterDatasetsDraw(chart, _args, options) {
+    draw(chart, "afterDatasetsDraw", options);
+  },
+  beforeDraw(chart, _args, options) {
+    draw(chart, "beforeDraw", options);
+  },
+  afterDraw(chart, _args, options) {
+    draw(chart, "afterDraw", options);
+  },
+  stop: function(chart) {
+    removeListeners(chart);
+    if (Hammer) {
+      stopHammer(chart);
+    }
+    removeState(chart);
+  },
+  panFunctions,
+  zoomFunctions,
+  zoomRectFunctions
+};
+Chart$1.register(TimeScale, LinearScale, PointElement, LineElement, plugin_title, plugin_tooltip, plugin_legend, plugin);
 function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
@@ -34223,7 +37086,6 @@ function useThemeVersion() {
   }, []);
   return v2;
 }
-Chart$1.register(TimeScale, LinearScale, PointElement, LineElement, plugin_title, plugin_tooltip, plugin_legend);
 function toIsoDate(xVal) {
   const dateStr = xVal.includes("_") ? xVal.split("_").pop() : xVal;
   if (/^\d{8}$/.test(dateStr)) {
@@ -34238,6 +37100,8 @@ function TimeSeriesChart() {
   const [chartData, setChartData] = reactExports.useState(null);
   const [bufferData, setBufferData] = reactExports.useState({});
   const [isLoading, setIsLoading] = reactExports.useState(false);
+  const [isZoomed, setIsZoomed] = reactExports.useState(false);
+  const chartRef = reactExports.useRef(null);
   const updateChart = reactExports.useCallback(async () => {
     if (!state.showChart || !state.currentDataset || state.timeSeriesPoints.length === 0) {
       setChartData(null);
@@ -34417,6 +37281,8 @@ function TimeSeriesChart() {
     const textColor = cssVar("--sb-text", "#dde0f0");
     const mutedColor = cssVar("--sb-muted", "#7880a8");
     const gridColor = cssVar("--sb-border", "#2c2f4a");
+    const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
+    const yLabel = (dsInfo == null ? void 0 : dsInfo.label) && (dsInfo == null ? void 0 : dsInfo.unit) ? `${dsInfo.label} (${dsInfo.unit})` : (dsInfo == null ? void 0 : dsInfo.label) || (dsInfo == null ? void 0 : dsInfo.unit) || "Displacement (m)";
     return {
       responsive: true,
       maintainAspectRatio: false,
@@ -34459,12 +37325,26 @@ function TimeSeriesChart() {
               var _a2, _b2;
               const dataset = (_a2 = chartData == null ? void 0 : chartData.datasets) == null ? void 0 : _a2[context.datasetIndex];
               if (!dataset) return "";
-              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
+              const unit = (dsInfo == null ? void 0 : dsInfo.unit) || "m";
+              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} ${unit}`;
               if (((_b2 = dataset.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 && state.showTrends) {
                 label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
               }
               return label;
             }
+          }
+        },
+        zoom: {
+          pan: {
+            enabled: true,
+            mode: "x",
+            onPanComplete: () => setIsZoomed(true)
+          },
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            mode: "x",
+            onZoomComplete: () => setIsZoomed(true)
           }
         }
       },
@@ -34477,7 +37357,7 @@ function TimeSeriesChart() {
           ticks: { color: mutedColor }
         },
         y: {
-          title: { display: true, text: "Displacement (m)", color: mutedColor },
+          title: { display: true, text: yLabel, color: mutedColor },
           suggestedMin: state.vmin,
           suggestedMax: state.vmax,
           grid: { color: gridColor },
@@ -34486,7 +37366,7 @@ function TimeSeriesChart() {
       },
       onClick: handleChartClick
     };
-  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, handleChartClick]);
+  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, state.currentDataset, state.datasetInfo, handleChartClick]);
   if (!state.showChart) return null;
   if (state.timeSeriesPoints.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-placeholder", children: [
@@ -34619,15 +37499,31 @@ function TimeSeriesChart() {
             ]
           }
         ),
+        isZoomed && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            className: "chart-btn",
+            onClick: () => {
+              var _a2;
+              (_a2 = chartRef.current) == null ? void 0 : _a2.resetZoom();
+              setIsZoomed(false);
+            },
+            title: "Reset zoom",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-magnifying-glass-minus" }),
+              " Reset"
+            ]
+          }
+        ),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", onClick: handleExportToCSV, title: "Export data to CSV", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-download" }),
           " CSV"
         ] })
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-content", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: formattedChartData, options: chartOptions }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-content", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { ref: chartRef, data: formattedChartData, options: chartOptions }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-help", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("small", { children: [
-      "Click chart points to sync map time",
+      "Scroll to zoom · Drag to pan · Click points to sync map time",
       state.bufferEnabled && Object.keys(bufferData).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
         " · Buffer: ",
         Object.values(bufferData).map((b) => b.n_pixels).join(", "),
@@ -34822,11 +37718,16 @@ function PointManagerPanel() {
 }
 function AppContent() {
   const { state, dispatch } = useAppContext();
-  const { fetchDatasets, fetchDataMode } = useApi();
+  const { fetchDatasets, fetchDataMode, fetchConfig } = useApi();
+  const [appTitle, setAppTitle] = reactExports.useState("");
   reactExports.useEffect(() => {
     const initializeApp = async () => {
       try {
-        const mode = await fetchDataMode();
+        const [config, mode] = await Promise.all([fetchConfig(), fetchDataMode()]);
+        if (config.title) {
+          setAppTitle(config.title);
+          document.title = config.title;
+        }
         dispatch({ type: "SET_DATA_MODE", payload: mode });
         const datasets = await fetchDatasets();
         dispatch({ type: "SET_DATASETS", payload: datasets });
@@ -34843,9 +37744,9 @@ function AppContent() {
       }
     };
     initializeApp();
-  }, [fetchDatasets, fetchDataMode, dispatch]);
+  }, [fetchDatasets, fetchDataMode, fetchConfig, dispatch]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "app-container", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(ControlPanel, {}),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ControlPanel, { title: appTitle }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-container", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(MapContainer, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(PointManagerPanel, {}),

--- a/src/bowser/dist/index.js
+++ b/src/bowser/dist/index.js
@@ -7051,7 +7051,6 @@ const initialState = {
   bufferSamples: 10,
   pickingEnabled: true,
   refEnabled: true,
-  showProfile: false,
   refBufferEnabled: false,
   refBufferRadius: 500,
   showRefChart: false
@@ -7201,8 +7200,6 @@ function appReducer(state, action) {
       return { ...state, pickingEnabled: !state.pickingEnabled };
     case "TOGGLE_REF_ENABLED":
       return { ...state, refEnabled: !state.refEnabled };
-    case "TOGGLE_PROFILE":
-      return { ...state, showProfile: !state.showProfile };
     case "TOGGLE_REF_BUFFER":
       return { ...state, refBufferEnabled: !state.refBufferEnabled };
     case "SET_REF_BUFFER_RADIUS":
@@ -19617,9 +19614,9 @@ function parseMaxStyle(styleValue, node, parentProperty) {
   }
   return valueInPixels;
 }
-const getComputedStyle = (element) => element.ownerDocument.defaultView.getComputedStyle(element, null);
+const getComputedStyle$1 = (element) => element.ownerDocument.defaultView.getComputedStyle(element, null);
 function getStyle(el2, property) {
-  return getComputedStyle(el2).getPropertyValue(property);
+  return getComputedStyle$1(el2).getPropertyValue(property);
 }
 const positions = [
   "top",
@@ -19665,7 +19662,7 @@ function getRelativePosition(event, chart) {
     return event;
   }
   const { canvas, currentDevicePixelRatio } = chart;
-  const style = getComputedStyle(canvas);
+  const style = getComputedStyle$1(canvas);
   const borderBox = style.boxSizing === "border-box";
   const paddings = getPositionedStyle(style, "padding");
   const borders = getPositionedStyle(style, "border", "width");
@@ -19691,7 +19688,7 @@ function getContainerSize(canvas, width, height) {
       height = canvas.clientHeight;
     } else {
       const rect = container.getBoundingClientRect();
-      const containerStyle = getComputedStyle(container);
+      const containerStyle = getComputedStyle$1(container);
       const containerBorder = getPositionedStyle(containerStyle, "border", "width");
       const containerPadding = getPositionedStyle(containerStyle, "padding");
       width = rect.width - containerPadding.width - containerBorder.width;
@@ -19709,7 +19706,7 @@ function getContainerSize(canvas, width, height) {
 }
 const round1 = (v2) => Math.round(v2 * 10) / 10;
 function getMaximumSize(canvas, bbWidth, bbHeight, aspectRatio) {
-  const style = getComputedStyle(canvas);
+  const style = getComputedStyle$1(canvas);
   const margins = getPositionedStyle(style, "margin");
   const maxWidth = parseMaxStyle(style.maxWidth, canvas, "clientWidth") || INFINITY;
   const maxHeight = parseMaxStyle(style.maxHeight, canvas, "clientHeight") || INFINITY;
@@ -29020,6 +29017,9 @@ const VERTEX_ICON = L$1.divIcon({
   html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
   iconSize: [0, 0]
 });
+function cssVar$1(name, fallback) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
 function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   const map2 = useMap();
   const { state } = useAppContext();
@@ -29030,7 +29030,8 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   const modeRef = reactExports.useRef("idle");
   const [profileData, setProfileData] = reactExports.useState(null);
   const [loading, setLoading] = reactExports.useState(false);
-  const fetchFn = reactExports.useCallback(async (pts) => {
+  const [radius, setRadius] = reactExports.useState(0);
+  const fetchFn = reactExports.useCallback(async (pts, r2) => {
     if (pts.length < 2 || !state.currentDataset) return;
     setLoading(true);
     try {
@@ -29041,10 +29042,22 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
           coords: pts.map((p2) => [p2.lng, p2.lat]),
           dataset_name: state.currentDataset,
           time_index: state.currentTimeIndex,
-          n_samples: 200
+          n_samples: 200,
+          radius: r2,
+          n_random: 5
         })
       });
-      if (res.ok) setProfileData(await res.json());
+      if (!res.ok) return;
+      const json = await res.json();
+      if (Array.isArray(json)) {
+        setProfileData({ centre: json, median: null, samples: [] });
+      } else {
+        setProfileData({
+          centre: json.centre ?? [],
+          median: json.median ?? null,
+          samples: json.samples ?? []
+        });
+      }
     } finally {
       setLoading(false);
     }
@@ -29053,6 +29066,10 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   reactExports.useEffect(() => {
     fetchRef.current = fetchFn;
   }, [fetchFn]);
+  const radiusRef = reactExports.useRef(radius);
+  reactExports.useEffect(() => {
+    radiusRef.current = radius;
+  }, [radius]);
   const updatePoly = (pts) => {
     if (polyRef.current) {
       polyRef.current.setLatLngs(pts);
@@ -29070,7 +29087,7 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       });
       m2.on("dragend", () => {
         ptsRef.current[idx] = m2.getLatLng();
-        fetchRef.current(ptsRef.current);
+        fetchRef.current(ptsRef.current, radiusRef.current);
       });
       return m2;
     });
@@ -29089,9 +29106,56 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   }, []);
   reactExports.useEffect(() => {
     if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current);
     }
   }, [state.currentTimeIndex, active]);
+  reactExports.useEffect(() => {
+    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
+      fetchRef.current(ptsRef.current, radius);
+    }
+  }, [radius, active]);
+  reactExports.useEffect(() => {
+    if (!active || radius <= 0 || ptsRef.current.length < 2) return;
+    const pts = ptsRef.current;
+    const offsetPoints = [[], []];
+    for (let i = 0; i < pts.length; i++) {
+      let bearingRad;
+      if (i < pts.length - 1) {
+        const dx = pts[i + 1].lng - pts[i].lng;
+        const dy = pts[i + 1].lat - pts[i].lat;
+        bearingRad = Math.atan2(dx, dy);
+      } else {
+        const dx = pts[i].lng - pts[i - 1].lng;
+        const dy = pts[i].lat - pts[i - 1].lat;
+        bearingRad = Math.atan2(dx, dy);
+      }
+      const lat = pts[i].lat;
+      const metersPerDegLat = 111320;
+      const metersPerDegLng = 111320 * Math.cos(lat * Math.PI / 180);
+      const perpBearing = bearingRad + Math.PI / 2;
+      const dLat = radius / metersPerDegLat * Math.cos(perpBearing);
+      const dLng = radius / metersPerDegLng * Math.sin(perpBearing);
+      offsetPoints[0].push(L$1.latLng(pts[i].lat + dLat, pts[i].lng + dLng));
+      offsetPoints[1].push(L$1.latLng(pts[i].lat - dLat, pts[i].lng - dLng));
+    }
+    const poly = L$1.polygon([...offsetPoints[0], ...offsetPoints[1].reverse()], {
+      color: "#f0a500",
+      fillColor: "#f0a500",
+      fillOpacity: 0.12,
+      weight: 1,
+      dashArray: "4 3"
+    }).addTo(map2);
+    return () => {
+      poly.remove();
+    };
+  }, [
+    active,
+    radius,
+    map2,
+    // re-run when pts change (after drawing / dragging)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    profileData
+  ]);
   reactExports.useEffect(() => {
     if (!active) {
       clearAll();
@@ -29132,7 +29196,7 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       modeRef.current = "ready";
       map2.getContainer().style.cursor = "default";
       rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current);
     };
     map2.on("click", onClick);
     map2.on("mousemove", onMouseMove);
@@ -29146,38 +29210,81 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       map2.getContainer().style.cursor = "";
     };
   }, [active, map2, clearAll]);
+  if (!active) return null;
   if (loading) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "profile-panel", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Extracting profile…" }) }) });
   }
-  if (!profileData || profileData.length === 0 || !state.showProfile) return null;
-  const chartData = {
-    labels: profileData.map((p2) => p2.dist.toFixed(0)),
-    datasets: [{
-      label: state.currentDataset,
-      data: profileData.map((p2) => p2.value),
-      borderColor: "#4d9de0",
-      backgroundColor: "rgba(77,157,224,0.15)",
-      borderWidth: 1.5,
+  const textColor = cssVar$1("--sb-text", "#dde0f0");
+  const mutedColor = cssVar$1("--sb-muted", "#7880a8");
+  const gridColor = cssVar$1("--sb-border", "#2c2f4a");
+  const hasData = profileData && (profileData.centre.length > 0 || profileData.median && profileData.median.length > 0);
+  const datasets = [];
+  if (hasData) {
+    const useBuffer = radius > 0 && profileData.median && profileData.median.length > 0;
+    if (useBuffer) {
+      profileData.samples.forEach((s, i) => {
+        datasets.push({
+          label: `sample ${i}`,
+          data: s.map((p2) => p2.value),
+          labels: s.map((p2) => p2.dist.toFixed(0)),
+          borderColor: "#4d9de028",
+          backgroundColor: "transparent",
+          borderWidth: 1,
+          pointRadius: 0,
+          fill: false,
+          tension: 0.2
+        });
+      });
+    }
+    const centre = profileData.centre;
+    datasets.push({
+      label: useBuffer ? "centre" : state.currentDataset,
+      data: centre.map((p2) => p2.value),
+      borderColor: useBuffer ? "#4d9de088" : "#4d9de0",
+      backgroundColor: useBuffer ? "transparent" : "rgba(77,157,224,0.15)",
+      borderWidth: useBuffer ? 1 : 1.5,
       pointRadius: 0,
-      fill: true,
+      fill: !useBuffer,
       tension: 0.2
-    }]
-  };
+    });
+    if (useBuffer && profileData.median) {
+      datasets.push({
+        label: "median",
+        data: profileData.median.map((p2) => p2.value),
+        borderColor: "#4d9de0",
+        backgroundColor: "transparent",
+        borderWidth: 2.5,
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2
+      });
+    }
+  }
+  const xLabels = profileData ? (profileData.centre.length > 0 ? profileData.centre : profileData.median ?? []).map((p2) => p2.dist.toFixed(0)) : [];
+  const chartData = { labels: xLabels, datasets };
   const options = {
     responsive: true,
     maintainAspectRatio: false,
     animation: { duration: 0 },
-    plugins: { legend: { display: false } },
+    plugins: {
+      legend: {
+        display: radius > 0,
+        labels: {
+          color: textColor,
+          filter: (item) => !item.text.startsWith("sample")
+        }
+      }
+    },
     scales: {
       x: {
-        title: { display: true, text: "Distance (m)", color: "#aaa" },
-        ticks: { color: "#aaa", maxTicksLimit: 8 },
-        grid: { color: "rgba(255,255,255,0.1)" }
+        title: { display: true, text: "Distance (m)", color: mutedColor },
+        ticks: { color: mutedColor, maxTicksLimit: 8 },
+        grid: { color: gridColor }
       },
       y: {
-        title: { display: true, text: state.currentDataset, color: "#aaa" },
-        ticks: { color: "#aaa" },
-        grid: { color: "rgba(255,255,255,0.1)" }
+        title: { display: true, text: state.currentDataset, color: mutedColor },
+        ticks: { color: mutedColor },
+        grid: { color: gridColor }
       }
     }
   };
@@ -29187,9 +29294,24 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
         "Profile — ",
         state.currentDataset
       ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-radius-control", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "profile-radius", style: { color: mutedColor, fontSize: "0.8em", marginRight: 4 }, children: "Radius (m):" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "input",
+          {
+            id: "profile-radius",
+            type: "number",
+            min: 0,
+            step: 100,
+            value: radius,
+            onChange: (e) => setRadius(Math.max(0, Number(e.target.value))),
+            className: "profile-radius-input"
+          }
+        )
+      ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: clearAll, title: "Clear profile", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" }) })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { height: 180, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) })
+    hasData && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { height: 180, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) })
   ] });
 }
 function RefPointChart() {
@@ -29411,7 +29533,10 @@ function RasterTileLayer() {
   const { state } = useAppContext();
   const [tileUrl, setTileUrl] = reactExports.useState(null);
   reactExports.useEffect(() => {
-    if (!state.currentDataset || !state.datasetInfo[state.currentDataset]) {
+    if (!state.currentDataset || !state.datasetInfo[state.currentDataset] || !state.dataMode) {
+      return;
+    }
+    if (state.dataMode !== "md" && state.dataMode !== "cog") {
       return;
     }
     const controller = new AbortController();
@@ -29443,7 +29568,7 @@ function RasterTileLayer() {
         const maskUrl = currentDatasetInfo.mask_file_list[timeIdx];
         const maskMinValue = currentDatasetInfo.mask_min_value;
         params.url = url;
-        if (maskUrl) params.mask = encodeURIComponent(maskUrl);
+        if (maskUrl) params.mask = maskUrl;
         if (maskMinValue !== void 0) params.mask_min_value = maskMinValue.toString();
         if (state.customMaskPath) params.custom_mask = state.customMaskPath;
         params.time_idx = timeIdx.toString();
@@ -29469,8 +29594,11 @@ function RasterTileLayer() {
         }
       }
     };
-    updateTileLayer2();
-    return () => controller.abort();
+    const debounceTimer = setTimeout(() => updateTileLayer2(), 80);
+    return () => {
+      clearTimeout(debounceTimer);
+      controller.abort();
+    };
   }, [
     state.currentDataset,
     state.currentTimeIndex,
@@ -29495,6 +29623,49 @@ function RasterTileLayer() {
     },
     tileUrl
   );
+}
+function RadiusCircles() {
+  const { state } = useAppContext();
+  const map2 = useMap();
+  reactExports.useEffect(() => {
+    const circles = [];
+    if (state.bufferEnabled && state.bufferRadius > 0) {
+      state.timeSeriesPoints.filter((p2) => p2.visible).forEach((point) => {
+        circles.push(L$1.circle([point.position[0], point.position[1]], {
+          radius: state.bufferRadius,
+          color: point.color,
+          fillColor: point.color,
+          fillOpacity: 0.08,
+          weight: 1.5,
+          dashArray: "4 3"
+        }).addTo(map2));
+      });
+    }
+    if (state.refEnabled && state.refBufferEnabled && state.refBufferRadius > 0) {
+      const [lat, lng] = state.refMarkerPosition;
+      circles.push(L$1.circle([lat, lng], {
+        radius: state.refBufferRadius,
+        color: "#e05d6a",
+        fillColor: "#e05d6a",
+        fillOpacity: 0.08,
+        weight: 1.5,
+        dashArray: "4 3"
+      }).addTo(map2));
+    }
+    return () => {
+      circles.forEach((c) => c.remove());
+    };
+  }, [
+    map2,
+    state.bufferEnabled,
+    state.bufferRadius,
+    state.refEnabled,
+    state.refBufferEnabled,
+    state.refBufferRadius,
+    state.refMarkerPosition,
+    JSON.stringify(state.timeSeriesPoints.map((p2) => ({ id: p2.id, pos: p2.position, vis: p2.visible })))
+  ]);
+  return null;
 }
 function MarkerEventHandlers() {
   const { state, dispatch } = useAppContext();
@@ -29668,6 +29839,7 @@ function MapContainer() {
             }
           ),
           /* @__PURE__ */ jsxRuntimeExports.jsx(RasterTileLayer, {}),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(RadiusCircles, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(MarkerEventHandlers, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(MapEvents, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(MousePosition, {}),
@@ -29725,6 +29897,11 @@ function Histogram() {
     dispatch({ type: "SET_VMIN", payload: parseFloat(histData.p23.toFixed(4)) });
     dispatch({ type: "SET_VMAX", payload: parseFloat(histData.p977.toFixed(4)) });
   };
+  const handleCenterZero = () => {
+    const absMax = parseFloat(Math.max(Math.abs(state.vmin), Math.abs(state.vmax)).toFixed(4));
+    dispatch({ type: "SET_VMIN", payload: -absMax });
+    dispatch({ type: "SET_VMAX", payload: absMax });
+  };
   if (!state.currentDataset || loading) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "histogram-loading", children: loading ? "Computing…" : "" });
   }
@@ -29765,7 +29942,8 @@ function Histogram() {
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleAutoScale, title: "2nd–98th percentile", children: "2–98%" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleSigmaScale, title: "±1σ (16–84%)", children: "±1σ" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleTwoSigmaScale, title: "±2σ (2.3–97.7%)", children: "±2σ" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleFullScale, title: "Full range", children: "Full" })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleFullScale, title: "Full range", children: "Full" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "hist-btn", onClick: handleCenterZero, title: "Symmetric around zero: ±max(|vmin|,|vmax|)", children: "±0" })
     ] })
   ] });
 }
@@ -29790,6 +29968,27 @@ function ControlPanel() {
   const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [draftVmin, setDraftVmin] = reactExports.useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = reactExports.useState(String(state.vmax));
+  const [lightTheme, setLightTheme] = reactExports.useState(false);
+  const [datasetRanges, setDatasetRanges] = reactExports.useState({});
+  reactExports.useEffect(() => {
+    const missing = state.layerMasks.map((m2) => m2.dataset).filter((ds) => ds && !(ds in datasetRanges));
+    const unique = [...new Set(missing)];
+    unique.forEach(async (ds) => {
+      try {
+        const res = await fetch(`/dataset_range/${encodeURIComponent(ds)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setDatasetRanges((prev) => ({ ...prev, [ds]: data }));
+        }
+      } catch {
+      }
+    });
+  }, [state.layerMasks, datasetRanges]);
+  const toggleTheme = () => {
+    const next = !lightTheme;
+    setLightTheme(next);
+    document.documentElement.setAttribute("data-theme", next ? "light" : "dark");
+  };
   reactExports.useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
   reactExports.useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
   reactExports.useEffect(() => {
@@ -29866,6 +30065,7 @@ function ControlPanel() {
   const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
   const currentTimeValue = currentDatasetInfo ? currentDatasetInfo.x_values[state.currentTimeIndex] : "";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "menu", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sidebar-theme-toggle", children: /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "theme-toggle-btn", onClick: toggleTheme, title: lightTheme ? "Switch to dark theme" : "Switch to light theme", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${lightTheme ? "fa-moon" : "fa-sun"}` }) }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-layer-group" }),
@@ -30020,59 +30220,85 @@ function ControlPanel() {
         /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-mask" }),
         " Masking"
       ] }),
-      state.layerMasks.map((mask) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "layer-mask-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", alignItems: "center", gap: 4, marginBottom: 4 }, children: [
+      state.layerMasks.map((mask) => {
+        const range = datasetRanges[mask.dataset];
+        const rMin = (range == null ? void 0 : range.p2) ?? (range == null ? void 0 : range.min) ?? 0;
+        const rMax = (range == null ? void 0 : range.p98) ?? (range == null ? void 0 : range.max) ?? 1;
+        const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
+        return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "layer-mask-row", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", alignItems: "center", gap: 4, marginBottom: 4 }, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "select",
+              {
+                className: "sidebar-select",
+                style: { flex: 1, fontSize: "0.78em" },
+                value: mask.dataset,
+                onChange: (e) => {
+                  const ds = e.target.value;
+                  const newRange = datasetRanges[ds];
+                  const defaultThreshold = newRange ? newRange.p2 ?? newRange.min : 0.5;
+                  dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
+                },
+                children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs(
+              "select",
+              {
+                className: "sidebar-select",
+                style: { width: 56, fontSize: "0.78em", padding: "2px 4px" },
+                value: mask.mode,
+                onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: e.target.value } } }),
+                children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "min", children: "≥" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "max", children: "≤" })
+                ]
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                className: "hist-btn",
+                style: { color: "var(--sb-red)", padding: "2px 6px", flexShrink: 0 },
+                onClick: () => dispatch({ type: "REMOVE_LAYER_MASK", payload: mask.id }),
+                title: "Remove mask",
+                children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" })
+              }
+            )
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { fontSize: "0.75em", color: "var(--sb-muted)" }, children: [
+              "Threshold",
+              range ? ` [${rMin.toPrecision(3)}, ${rMax.toPrecision(3)}]` : ""
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "number",
+                style: { width: 72, fontSize: "0.75em", background: "var(--sb-surface2)", border: "1px solid var(--sb-border)", borderRadius: 4, color: "var(--sb-text)", padding: "1px 4px", textAlign: "right" },
+                step,
+                value: parseFloat(mask.threshold.toPrecision(4)),
+                onChange: (e) => {
+                  const v2 = parseFloat(e.target.value);
+                  if (!isNaN(v2)) dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: v2 } } });
+                }
+              }
+            )
+          ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "select",
+            "input",
             {
-              className: "sidebar-select",
-              style: { flex: 1, fontSize: "0.78em" },
-              value: mask.dataset,
-              onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { dataset: e.target.value } } }),
-              children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs(
-            "select",
-            {
-              className: "sidebar-select",
-              style: { width: 56, fontSize: "0.78em", padding: "2px 4px" },
-              value: mask.mode,
-              onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: e.target.value } } }),
-              children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "min", children: "≥" }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "max", children: "≤" })
-              ]
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              className: "hist-btn",
-              style: { color: "var(--sb-red)", padding: "2px 6px", flexShrink: 0 },
-              onClick: () => dispatch({ type: "REMOVE_LAYER_MASK", payload: mask.id }),
-              title: "Remove mask",
-              children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" })
+              type: "range",
+              className: "sidebar-range",
+              min: rMin,
+              max: rMax,
+              step,
+              value: mask.threshold,
+              onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })
             }
           )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.75em", color: "var(--sb-muted)" }, children: "Threshold (normalised)" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: mask.threshold.toFixed(2) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: mask.threshold,
-            onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })
-          }
-        )
-      ] }, mask.id)),
+        ] }, mask.id);
+      }),
       Object.keys(state.datasetInfo).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {
@@ -30080,12 +30306,14 @@ function ControlPanel() {
           style: { width: "100%", marginTop: 4 },
           onClick: () => {
             const firstDataset = Object.keys(state.datasetInfo)[0];
+            const range = datasetRanges[firstDataset];
+            const defaultThreshold = range ? range.p2 ?? range.min : 0.5;
             dispatch({
               type: "ADD_LAYER_MASK",
               payload: {
                 id: `mask_${Date.now()}`,
                 dataset: firstDataset,
-                threshold: 0.5,
+                threshold: defaultThreshold,
                 mode: "min"
               }
             });
@@ -30269,19 +30497,6 @@ function ControlPanel() {
             /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showChart ? "fa-chart-line" : "fa-wave-square"}` }),
             state.showChart ? "Hide" : "Show",
             " Time Series"
-          ]
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: "chart-toggle-btn",
-          style: { marginTop: 4 },
-          onClick: () => dispatch({ type: "TOGGLE_PROFILE" }),
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-chart-area" }),
-            state.showProfile ? "Hide" : "Show",
-            " Profile"
           ]
         }
       ),
@@ -33996,6 +34211,18 @@ adapters._date.override({
     }
   }
 });
+function cssVar(name, fallback) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+function useThemeVersion() {
+  const [v2, setV] = reactExports.useState(0);
+  reactExports.useEffect(() => {
+    const obs = new MutationObserver(() => setV((n2) => n2 + 1));
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => obs.disconnect();
+  }, []);
+  return v2;
+}
 Chart$1.register(TimeScale, LinearScale, PointElement, LineElement, plugin_title, plugin_tooltip, plugin_legend);
 function toIsoDate(xVal) {
   const dateStr = xVal.includes("_") ? xVal.split("_").pop() : xVal;
@@ -34007,6 +34234,7 @@ function toIsoDate(xVal) {
 function TimeSeriesChart() {
   const { state, dispatch } = useAppContext();
   const { fetchMultiPointTimeSeries, fetchBufferTimeSeries } = useApi();
+  const themeVersion = useThemeVersion();
   const [chartData, setChartData] = reactExports.useState(null);
   const [bufferData, setBufferData] = reactExports.useState({});
   const [isLoading, setIsLoading] = reactExports.useState(false);
@@ -34185,74 +34413,80 @@ function TimeSeriesChart() {
     link.click();
     document.body.removeChild(link);
   }, [chartData, state.showTrends, state.currentDataset]);
-  const chartOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 300 },
-    interaction: { mode: "index", intersect: false },
-    plugins: {
-      legend: {
-        display: true,
-        position: "top",
-        labels: {
-          usePointStyle: true,
-          padding: 16,
-          color: "#ffffff",
-          generateLabels: (chart) => {
-            if (!(chartData == null ? void 0 : chartData.datasets)) return [];
-            return chart.data.datasets.map((ds, index) => ({ ds, index })).filter(
-              ({ ds }) => !ds.label.endsWith(" trend") && !ds.label.endsWith(" residual") && !ds.label.includes(" sample ") && !ds.label.endsWith(" median")
-            ).map(({ ds, index }) => {
-              var _a2, _b2;
-              return {
-                text: ds.label + (ds.label && ((_b2 = (_a2 = chartData.datasets.find((d) => d.label === ds.label)) == null ? void 0 : _a2.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 ? ` (${chartData.datasets.find((d) => d.label === ds.label).trend.mmPerYear.toFixed(1)} mm/yr)` : ""),
-                pointStyle: "circle",
-                fillStyle: ds.borderColor,
-                strokeStyle: ds.borderColor,
-                lineWidth: 2,
-                datasetIndex: index
-              };
-            });
-          }
-        }
-      },
-      tooltip: {
-        callbacks: {
-          title: (context) => {
-            var _a2;
-            return `${((_a2 = context[0]) == null ? void 0 : _a2.label) || ""}`;
-          },
-          label: (context) => {
-            var _a2, _b2;
-            const dataset = (_a2 = chartData == null ? void 0 : chartData.datasets) == null ? void 0 : _a2[context.datasetIndex];
-            if (!dataset) return "";
-            let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
-            if (((_b2 = dataset.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 && state.showTrends) {
-              label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
+  const chartOptions = reactExports.useMemo(() => {
+    const textColor = cssVar("--sb-text", "#dde0f0");
+    const mutedColor = cssVar("--sb-muted", "#7880a8");
+    const gridColor = cssVar("--sb-border", "#2c2f4a");
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 300 },
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: {
+          display: true,
+          position: "top",
+          labels: {
+            usePointStyle: true,
+            padding: 16,
+            color: textColor,
+            generateLabels: (chart) => {
+              if (!(chartData == null ? void 0 : chartData.datasets)) return [];
+              return chart.data.datasets.map((ds, index) => ({ ds, index })).filter(
+                ({ ds }) => !ds.label.endsWith(" trend") && !ds.label.endsWith(" residual") && !ds.label.includes(" sample ") && !ds.label.endsWith(" median")
+              ).map(({ ds, index }) => {
+                var _a2, _b2;
+                return {
+                  text: ds.label + (ds.label && ((_b2 = (_a2 = chartData.datasets.find((d) => d.label === ds.label)) == null ? void 0 : _a2.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 ? ` (${chartData.datasets.find((d) => d.label === ds.label).trend.mmPerYear.toFixed(1)} mm/yr)` : ""),
+                  pointStyle: "circle",
+                  fillStyle: ds.borderColor,
+                  strokeStyle: ds.borderColor,
+                  fontColor: textColor,
+                  lineWidth: 2,
+                  datasetIndex: index
+                };
+              });
             }
-            return label;
+          }
+        },
+        tooltip: {
+          callbacks: {
+            title: (context) => {
+              var _a2;
+              return `${((_a2 = context[0]) == null ? void 0 : _a2.label) || ""}`;
+            },
+            label: (context) => {
+              var _a2, _b2;
+              const dataset = (_a2 = chartData == null ? void 0 : chartData.datasets) == null ? void 0 : _a2[context.datasetIndex];
+              if (!dataset) return "";
+              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
+              if (((_b2 = dataset.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 && state.showTrends) {
+                label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
+              }
+              return label;
+            }
           }
         }
-      }
-    },
-    scales: {
-      x: {
-        type: "time",
-        time: { displayFormats: { month: "MMM yyyy", day: "MMM d", year: "yyyy" } },
-        title: { display: true, text: "Date" },
-        grid: { color: "rgba(255,255,255,0.1)" },
-        ticks: { color: "#aaa" }
       },
-      y: {
-        title: { display: true, text: "Displacement (m)" },
-        suggestedMin: state.vmin,
-        suggestedMax: state.vmax,
-        grid: { color: "rgba(255,255,255,0.1)" },
-        ticks: { color: "#aaa" }
-      }
-    },
-    onClick: handleChartClick
-  };
+      scales: {
+        x: {
+          type: "time",
+          time: { displayFormats: { month: "MMM yyyy", day: "MMM d", year: "yyyy" } },
+          title: { display: true, text: "Date", color: mutedColor },
+          grid: { color: gridColor },
+          ticks: { color: mutedColor }
+        },
+        y: {
+          title: { display: true, text: "Displacement (m)", color: mutedColor },
+          suggestedMin: state.vmin,
+          suggestedMax: state.vmax,
+          grid: { color: gridColor },
+          ticks: { color: mutedColor }
+        }
+      },
+      onClick: handleChartClick
+    };
+  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, handleChartClick]);
   if (!state.showChart) return null;
   if (state.timeSeriesPoints.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-placeholder", children: [

--- a/src/bowser/dist/index.js
+++ b/src/bowser/dist/index.js
@@ -29147,6 +29147,28 @@ function useDraggableResizable({ defaultWidth, defaultHeight, initialRight = 20,
   );
   return { panelRef, panelStyle, size, onDragMouseDown, resizeGrip };
 }
+const ProfileContext = reactExports.createContext({
+  data: null,
+  loading: false,
+  radius: 0,
+  samplingInterval: 0,
+  active: false,
+  setActive: () => {
+  },
+  setRadius: () => {
+  },
+  setSamplingInterval: () => {
+  },
+  clearAll: () => {
+  },
+  _setData: () => {
+  },
+  _setLoading: () => {
+  }
+});
+function useProfileContext() {
+  return reactExports.useContext(ProfileContext);
+}
 const VERTEX_ICON = L$1.divIcon({
   className: "",
   html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
@@ -29155,27 +29177,49 @@ const VERTEX_ICON = L$1.divIcon({
 function cssVar$1(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
-function ProfileTool({ active, onDeactivate: _onDeactivate }) {
+function ProfileProvider({ children }) {
+  const [data, setData] = reactExports.useState(null);
+  const [loading, setLoading] = reactExports.useState(false);
+  const [radius, setRadius] = reactExports.useState(0);
+  const [samplingInterval, setSamplingInterval] = reactExports.useState(0);
+  const [active, setActive] = reactExports.useState(false);
+  const clearAll = reactExports.useCallback(() => setData(null), []);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileContext.Provider, { value: {
+    data,
+    loading,
+    radius,
+    samplingInterval,
+    active,
+    setActive,
+    setRadius,
+    setSamplingInterval,
+    clearAll,
+    _setData: setData,
+    _setLoading: setLoading
+  }, children });
+}
+function ProfileToolMap() {
   const map2 = useMap();
   const { state } = useAppContext();
-  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
-    defaultWidth: 540,
-    defaultHeight: 280,
-    initialRight: 20,
-    initialBottom: 20
-  });
+  const ctx = reactExports.useContext(ProfileContext);
+  const { active, radius, samplingInterval, _setData, _setLoading, clearAll: ctxClearAll } = ctx;
   const polyRef = reactExports.useRef(null);
   const previewRef = reactExports.useRef(null);
   const markersRef = reactExports.useRef([]);
   const ptsRef = reactExports.useRef([]);
   const modeRef = reactExports.useRef("idle");
-  const [profileData, setProfileData] = reactExports.useState(null);
-  const [loading, setLoading] = reactExports.useState(false);
-  const [radius, setRadius] = reactExports.useState(0);
-  const [samplingInterval, setSamplingInterval] = reactExports.useState(0);
-  const fetchFn = reactExports.useCallback(async (pts, r2, si2) => {
+  const radiusRef = reactExports.useRef(radius);
+  const siRef = reactExports.useRef(samplingInterval);
+  reactExports.useEffect(() => {
+    radiusRef.current = radius;
+  }, [radius]);
+  reactExports.useEffect(() => {
+    siRef.current = samplingInterval;
+  }, [samplingInterval]);
+  const fetchFnRef = reactExports.useRef();
+  const fetchProfile = reactExports.useCallback(async (pts, r2, si2) => {
     if (pts.length < 2 || !state.currentDataset) return;
-    setLoading(true);
+    _setLoading(true);
     try {
       const res = await fetch("/profile", {
         method: "POST",
@@ -29193,9 +29237,9 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       if (!res.ok) return;
       const json = await res.json();
       if (Array.isArray(json)) {
-        setProfileData({ centre: json, median: null, samples: [], binned: false });
+        _setData({ centre: json, median: null, samples: [], binned: false });
       } else {
-        setProfileData({
+        _setData({
           centre: json.centre ?? [],
           median: json.median ?? null,
           samples: json.samples ?? [],
@@ -29204,27 +29248,13 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
         });
       }
     } finally {
-      setLoading(false);
+      _setLoading(false);
     }
-  }, [state.currentDataset, state.currentTimeIndex]);
-  const fetchRef = reactExports.useRef(fetchFn);
-  reactExports.useEffect(() => {
-    fetchRef.current = fetchFn;
-  }, [fetchFn]);
-  const radiusRef = reactExports.useRef(radius);
-  reactExports.useEffect(() => {
-    radiusRef.current = radius;
-  }, [radius]);
-  const samplingIntervalRef = reactExports.useRef(samplingInterval);
-  reactExports.useEffect(() => {
-    samplingIntervalRef.current = samplingInterval;
-  }, [samplingInterval]);
+  }, [state.currentDataset, state.currentTimeIndex, _setData, _setLoading]);
+  fetchFnRef.current = fetchProfile;
   const updatePoly = (pts) => {
-    if (polyRef.current) {
-      polyRef.current.setLatLngs(pts);
-    } else {
-      polyRef.current = L$1.polyline(pts, { color: "#f0a500", weight: 2.5 }).addTo(map2);
-    }
+    if (polyRef.current) polyRef.current.setLatLngs(pts);
+    else polyRef.current = L$1.polyline(pts, { color: "#f0a500", weight: 2.5 }).addTo(map2);
   };
   const rebuildMarkers = (pts) => {
     markersRef.current.forEach((m2) => m2.remove());
@@ -29235,8 +29265,9 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
         updatePoly(ptsRef.current);
       });
       m2.on("dragend", () => {
+        var _a2;
         ptsRef.current[idx] = m2.getLatLng();
-        fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
+        (_a2 = fetchFnRef.current) == null ? void 0 : _a2.call(fetchFnRef, ptsRef.current, radiusRef.current, siRef.current);
       });
       return m2;
     });
@@ -29251,44 +29282,35 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
     markersRef.current = [];
     ptsRef.current = [];
     modeRef.current = "idle";
-    setProfileData(null);
-  }, []);
+    ctxClearAll();
+  }, [ctxClearAll]);
   reactExports.useEffect(() => {
-    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
-    }
+    var _a2;
+    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2)
+      (_a2 = fetchFnRef.current) == null ? void 0 : _a2.call(fetchFnRef, ptsRef.current, radiusRef.current, siRef.current);
   }, [state.currentTimeIndex, active]);
   reactExports.useEffect(() => {
-    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radius, samplingIntervalRef.current);
-    }
+    var _a2;
+    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2)
+      (_a2 = fetchFnRef.current) == null ? void 0 : _a2.call(fetchFnRef, ptsRef.current, radius, siRef.current);
   }, [radius, active]);
   reactExports.useEffect(() => {
-    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radiusRef.current, samplingInterval);
-    }
+    var _a2;
+    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2)
+      (_a2 = fetchFnRef.current) == null ? void 0 : _a2.call(fetchFnRef, ptsRef.current, radiusRef.current, samplingInterval);
   }, [samplingInterval, active]);
   reactExports.useEffect(() => {
     if (!active || radius <= 0 || ptsRef.current.length < 2) return;
     const pts = ptsRef.current;
     const offsetPoints = [[], []];
     for (let i = 0; i < pts.length; i++) {
-      let bearingRad;
-      if (i < pts.length - 1) {
-        const dx = pts[i + 1].lng - pts[i].lng;
-        const dy = pts[i + 1].lat - pts[i].lat;
-        bearingRad = Math.atan2(dx, dy);
-      } else {
-        const dx = pts[i].lng - pts[i - 1].lng;
-        const dy = pts[i].lat - pts[i - 1].lat;
-        bearingRad = Math.atan2(dx, dy);
-      }
+      const bearingRad = i < pts.length - 1 ? Math.atan2(pts[i + 1].lng - pts[i].lng, pts[i + 1].lat - pts[i].lat) : Math.atan2(pts[i].lng - pts[i - 1].lng, pts[i].lat - pts[i - 1].lat);
       const lat = pts[i].lat;
-      const metersPerDegLat = 111320;
-      const metersPerDegLng = 111320 * Math.cos(lat * Math.PI / 180);
-      const perpBearing = bearingRad + Math.PI / 2;
-      const dLat = radius / metersPerDegLat * Math.cos(perpBearing);
-      const dLng = radius / metersPerDegLng * Math.sin(perpBearing);
+      const mPerDegLat = 111320;
+      const mPerDegLng = 111320 * Math.cos(lat * Math.PI / 180);
+      const perp = bearingRad + Math.PI / 2;
+      const dLat = radius / mPerDegLat * Math.cos(perp);
+      const dLng = radius / mPerDegLng * Math.sin(perp);
       offsetPoints[0].push(L$1.latLng(pts[i].lat + dLat, pts[i].lng + dLng));
       offsetPoints[1].push(L$1.latLng(pts[i].lat - dLat, pts[i].lng - dLng));
     }
@@ -29302,14 +29324,7 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
     return () => {
       poly.remove();
     };
-  }, [
-    active,
-    radius,
-    map2,
-    // re-run when pts change (after drawing / dragging)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    profileData
-  ]);
+  }, [active, radius, map2, ctx.data]);
   reactExports.useEffect(() => {
     if (!active) {
       clearAll();
@@ -29330,18 +29345,11 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
     const onMouseMove = (e) => {
       if (modeRef.current !== "drawing" || ptsRef.current.length === 0) return;
       const preview = [...ptsRef.current, e.latlng];
-      if (previewRef.current) {
-        previewRef.current.setLatLngs(preview);
-      } else {
-        previewRef.current = L$1.polyline(preview, {
-          color: "#f0a500",
-          weight: 2,
-          dashArray: "6 4"
-        }).addTo(map2);
-      }
+      if (previewRef.current) previewRef.current.setLatLngs(preview);
+      else previewRef.current = L$1.polyline(preview, { color: "#f0a500", weight: 2, dashArray: "6 4" }).addTo(map2);
     };
     const onDblClick = (e) => {
-      var _a2;
+      var _a2, _b2;
       L$1.DomEvent.stop(e);
       if (modeRef.current !== "drawing" || ptsRef.current.length < 2) return;
       (_a2 = previewRef.current) == null ? void 0 : _a2.remove();
@@ -29350,7 +29358,7 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       modeRef.current = "ready";
       map2.getContainer().style.cursor = "default";
       rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
+      (_b2 = fetchFnRef.current) == null ? void 0 : _b2.call(fetchFnRef, ptsRef.current, radiusRef.current, siRef.current);
     };
     map2.on("click", onClick);
     map2.on("mousemove", onMouseMove);
@@ -29364,10 +29372,30 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       map2.getContainer().style.cursor = "";
     };
   }, [active, map2, clearAll]);
+  return null;
+}
+function ProfileChart() {
+  const { state } = useAppContext();
+  const { active, data: profileData, loading, radius, samplingInterval, setRadius, setSamplingInterval, clearAll } = useProfileContext();
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 540,
+    defaultHeight: 280,
+    initialRight: 20,
+    initialBottom: 20,
+    minWidth: 200,
+    minHeight: 150
+  });
   if (!active) return null;
-  if (loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: panelRef, className: "profile-panel", style: panelStyle, onMouseDown: (e) => e.stopPropagation(), children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Extracting profile…" }) }) });
-  }
+  if (loading) return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      ref: panelRef,
+      style: { ...panelStyle, position: "fixed" },
+      className: "profile-panel",
+      onMouseDown: (e) => e.stopPropagation(),
+      children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Extracting profile…" }) })
+    }
+  );
   const textColor = cssVar$1("--sb-text", "#dde0f0");
   const mutedColor = cssVar$1("--sb-muted", "#7880a8");
   const gridColor = cssVar$1("--sb-border", "#2c2f4a");
@@ -29377,60 +29405,50 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   if (hasData) {
     const useBuffer = radius > 0 && profileData.median && profileData.median.length > 0;
     if (isBinned) {
-      profileData.samples.forEach((s, i) => {
-        datasets.push({
-          label: `sample ${i}`,
-          data: s.map((p2) => p2.value),
-          borderColor: "#4d9de028",
-          backgroundColor: "transparent",
-          borderWidth: 1,
-          pointRadius: 0,
-          fill: false,
-          tension: 0.3
-        });
+      profileData.samples.forEach((s, i) => datasets.push({
+        label: `sample ${i}`,
+        data: s.map((p2) => p2.value),
+        borderColor: "#4d9de028",
+        backgroundColor: "transparent",
+        borderWidth: 1,
+        pointRadius: 0,
+        fill: false,
+        tension: 0.3
+      }));
+      if (profileData.centre.length > 0) datasets.push({
+        label: "centre",
+        data: profileData.centre.map((p2) => p2.value),
+        borderColor: "#4d9de066",
+        backgroundColor: "transparent",
+        borderWidth: 1,
+        borderDash: [4, 3],
+        pointRadius: 0,
+        fill: false,
+        tension: 0
       });
-      if (profileData.centre.length > 0) {
-        datasets.push({
-          label: "centre",
-          data: profileData.centre.map((p2) => p2.value),
-          borderColor: "#4d9de066",
-          backgroundColor: "transparent",
-          borderWidth: 1,
-          borderDash: [4, 3],
-          pointRadius: 0,
-          fill: false,
-          tension: 0
-        });
-      }
-      if (profileData.median) {
-        datasets.push({
-          label: "median",
-          data: profileData.median.map((p2) => p2.value),
-          borderColor: "#4d9de0",
-          backgroundColor: "#4d9de0",
-          borderWidth: 0,
-          showLine: false,
-          pointStyle: "circle",
-          pointRadius: 5,
-          pointHoverRadius: 7,
-          fill: false
-        });
-      }
+      if (profileData.median) datasets.push({
+        label: "median",
+        data: profileData.median.map((p2) => p2.value),
+        borderColor: "#4d9de0",
+        backgroundColor: "#4d9de0",
+        borderWidth: 0,
+        showLine: false,
+        pointStyle: "circle",
+        pointRadius: 5,
+        pointHoverRadius: 7,
+        fill: false
+      });
     } else {
-      if (useBuffer) {
-        profileData.samples.forEach((s, i) => {
-          datasets.push({
-            label: `sample ${i}`,
-            data: s.map((p2) => p2.value),
-            borderColor: "#4d9de028",
-            backgroundColor: "transparent",
-            borderWidth: 1,
-            pointRadius: 0,
-            fill: false,
-            tension: 0.2
-          });
-        });
-      }
+      if (useBuffer) profileData.samples.forEach((s, i) => datasets.push({
+        label: `sample ${i}`,
+        data: s.map((p2) => p2.value),
+        borderColor: "#4d9de028",
+        backgroundColor: "transparent",
+        borderWidth: 1,
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2
+      }));
       const centre = profileData.centre;
       datasets.push({
         label: useBuffer ? "centre" : state.currentDataset,
@@ -29442,18 +29460,16 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
         fill: !useBuffer,
         tension: 0.2
       });
-      if (useBuffer && profileData.median) {
-        datasets.push({
-          label: "median",
-          data: profileData.median.map((p2) => p2.value),
-          borderColor: "#4d9de0",
-          backgroundColor: "transparent",
-          borderWidth: 2.5,
-          pointRadius: 0,
-          fill: false,
-          tension: 0.2
-        });
-      }
+      if (useBuffer && profileData.median) datasets.push({
+        label: "median",
+        data: profileData.median.map((p2) => p2.value),
+        borderColor: "#4d9de0",
+        backgroundColor: "transparent",
+        borderWidth: 2.5,
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2
+      });
     }
   }
   const xSourcePts = profileData ? isBinned && profileData.median ? profileData.median : profileData.centre.length > 0 ? profileData.centre : profileData.median ?? [] : [];
@@ -29464,76 +29480,65 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
     maintainAspectRatio: false,
     animation: { duration: 0 },
     plugins: {
-      legend: {
-        display: radius > 0 || isBinned,
-        labels: {
-          color: textColor,
-          filter: (item) => !item.text.startsWith("sample")
-        }
-      },
-      tooltip: {
-        callbacks: {
-          title: (ctx) => {
-            var _a2;
-            return `${((_a2 = ctx[0]) == null ? void 0 : _a2.label) ?? ""} m`;
-          }
-        }
-      }
+      legend: { display: radius > 0 || isBinned, labels: { color: textColor, filter: (item) => !item.text.startsWith("sample") } },
+      tooltip: { callbacks: { title: (ctx) => {
+        var _a2;
+        return `${((_a2 = ctx[0]) == null ? void 0 : _a2.label) ?? ""} m`;
+      } } }
     },
     scales: {
-      x: {
-        title: { display: true, text: "Distance (m)", color: mutedColor },
-        ticks: { color: mutedColor, maxTicksLimit: 8 },
-        grid: { color: gridColor }
-      },
-      y: {
-        title: { display: true, text: state.currentDataset, color: mutedColor },
-        ticks: { color: mutedColor },
-        grid: { color: gridColor }
-      }
+      x: { title: { display: true, text: "Distance (m)", color: mutedColor }, ticks: { color: mutedColor, maxTicksLimit: 8 }, grid: { color: gridColor } },
+      y: { title: { display: true, text: state.currentDataset, color: mutedColor }, ticks: { color: mutedColor }, grid: { color: gridColor } }
     }
   };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: panelRef, className: "profile-panel", style: panelStyle, onMouseDown: (e) => e.stopPropagation(), children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", onMouseDown: onDragMouseDown, style: { cursor: "grab" }, children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
-        "Profile — ",
-        state.currentDataset
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-radius-control", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "profile-sampling", style: { color: mutedColor, fontSize: "0.8em", marginRight: 4 }, children: "Sampling (m):" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            id: "profile-sampling",
-            type: "number",
-            min: 0,
-            step: 50,
-            value: samplingInterval,
-            onChange: (e) => setSamplingInterval(Math.max(0, Number(e.target.value))),
-            className: "profile-radius-input",
-            title: "Bin spacing along profile (0 = continuous dense line)"
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "profile-radius", style: { color: mutedColor, fontSize: "0.8em", marginLeft: 8, marginRight: 4 }, children: "Radius (m):" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            id: "profile-radius",
-            type: "number",
-            min: 0,
-            step: 100,
-            value: radius,
-            onChange: (e) => setRadius(Math.max(0, Number(e.target.value))),
-            className: "profile-radius-input",
-            title: "Perpendicular buffer width (0 = centre line only)"
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: clearAll, title: "Clear profile", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" }) })
-    ] }),
-    hasData && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { flex: 1, minHeight: 120, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) }),
-    resizeGrip
-  ] });
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      ref: panelRef,
+      className: "profile-panel",
+      style: { ...panelStyle, position: "fixed" },
+      onMouseDown: (e) => e.stopPropagation(),
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", onMouseDown: onDragMouseDown, style: { cursor: "grab" }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
+            "Profile — ",
+            state.currentDataset
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-radius-control", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("label", { style: { color: mutedColor, fontSize: "0.8em", marginRight: 4 }, children: "Sampling (m):" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "number",
+                min: 0,
+                step: 50,
+                value: samplingInterval,
+                onChange: (e) => setSamplingInterval(Math.max(0, Number(e.target.value))),
+                className: "profile-radius-input",
+                onMouseDown: (e) => e.stopPropagation()
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("label", { style: { color: mutedColor, fontSize: "0.8em", marginLeft: 8, marginRight: 4 }, children: "Radius (m):" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "number",
+                min: 0,
+                step: 100,
+                value: radius,
+                onChange: (e) => setRadius(Math.max(0, Number(e.target.value))),
+                className: "profile-radius-input",
+                onMouseDown: (e) => e.stopPropagation()
+              }
+            )
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: clearAll, title: "Clear profile", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" }) })
+        ] }),
+        hasData && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { flex: 1, minHeight: 120, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) }),
+        resizeGrip
+      ]
+    }
+  );
 }
 delete L$1.Icon.Default.prototype._getIconUrl;
 L$1.Icon.Default.mergeOptions({
@@ -29887,7 +29892,7 @@ function MapContainer() {
   const center = getInitialCenter();
   const hasDatasets = Object.keys(state.datasetInfo).length > 0;
   const [measureActive, setMeasureActive] = reactExports.useState(false);
-  const [profileActive, setProfileActive] = reactExports.useState(false);
+  const { active: profileActive, setActive: setProfileActive } = useProfileContext();
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-container", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-toolbar", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -29908,7 +29913,7 @@ function MapContainer() {
           className: `map-tool-btn${profileActive ? " active" : ""}`,
           title: "Draw profile line (click start, click end, double-click to extract)",
           onClick: () => {
-            setProfileActive((v2) => !v2);
+            setProfileActive(!profileActive);
             setMeasureActive(false);
           },
           children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-chart-area" })
@@ -29938,7 +29943,7 @@ function MapContainer() {
           /* @__PURE__ */ jsxRuntimeExports.jsx(MousePosition, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(ScaleBar, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(MeasureTool, { active: measureActive, onDeactivate: () => setMeasureActive(false) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileTool, { active: profileActive, onDeactivate: () => setProfileActive(false) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileToolMap, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(MapViewController, {})
         ]
       },
@@ -38757,6 +38762,7 @@ function AppContent() {
   const { state, dispatch } = useAppContext();
   const { fetchDatasets, fetchDataMode, fetchConfig } = useApi();
   const [appTitle, setAppTitle] = reactExports.useState("");
+  const [sidebarHidden, setSidebarHidden] = reactExports.useState(false);
   reactExports.useEffect(() => {
     const initializeApp = async () => {
       try {
@@ -38782,19 +38788,29 @@ function AppContent() {
     };
     initializeApp();
   }, [fetchDatasets, fetchDataMode, fetchConfig, dispatch]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "app-container", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `app-container${sidebarHidden ? " sidebar-hidden" : ""}`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(ControlPanel, { title: appTitle }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-container", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          className: "sidebar-toggle-btn",
+          onClick: () => setSidebarHidden((h) => !h),
+          title: sidebarHidden ? "Show sidebar" : "Hide sidebar",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid fa-chevron-${sidebarHidden ? "right" : "left"}` })
+        }
+      ),
       /* @__PURE__ */ jsxRuntimeExports.jsx(MapContainer, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(PointManagerPanel, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(RefPointChart, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(ColormapBar, {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileChart, {}),
       state.showChart && state.chartWindows.map((w2) => /* @__PURE__ */ jsxRuntimeExports.jsx(TimeSeriesChart, { windowId: w2.id }, w2.id))
     ] })
   ] });
 }
 function App() {
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(AppProvider, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(AppContent, {}) });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(AppProvider, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileProvider, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(AppContent, {}) }) });
 }
 client.createRoot(document.getElementById("root")).render(
   /* @__PURE__ */ jsxRuntimeExports.jsx(React.StrictMode, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(App, {}) })

--- a/src/bowser/dist/index.js
+++ b/src/bowser/dist/index.js
@@ -7041,6 +7041,7 @@ const initialState = {
   vmax: 1,
   opacity: 1,
   showChart: false,
+  chartWindows: [],
   selectedPointId: null,
   showTrends: false,
   showResiduals: false,
@@ -7055,7 +7056,12 @@ const initialState = {
   refBufferRadius: 500,
   showRefChart: false,
   isPlaying: false,
-  animationSpeed: 500
+  animationSpeed: 500,
+  markerSize: 4,
+  dateRangeStart: null,
+  dateRangeEnd: null,
+  viewBounds: null,
+  showColorbar: false
 };
 function appReducer(state, action) {
   switch (action.type) {
@@ -7214,8 +7220,36 @@ function appReducer(state, action) {
       return { ...state, isPlaying: action.payload };
     case "SET_ANIMATION_SPEED":
       return { ...state, animationSpeed: action.payload };
-    case "TOGGLE_CHART":
-      return { ...state, showChart: !state.showChart };
+    case "SET_MARKER_SIZE":
+      return { ...state, markerSize: action.payload };
+    case "SET_DATE_RANGE_START":
+      return { ...state, dateRangeStart: action.payload };
+    case "SET_DATE_RANGE_END":
+      return { ...state, dateRangeEnd: action.payload };
+    case "SET_VIEW_BOUNDS":
+      return { ...state, viewBounds: action.payload };
+    case "TOGGLE_COLORBAR":
+      return { ...state, showColorbar: !state.showColorbar };
+    case "ADD_CHART_WINDOW":
+      return { ...state, chartWindows: [...state.chartWindows, action.payload] };
+    case "REMOVE_CHART_WINDOW":
+      return { ...state, chartWindows: state.chartWindows.filter((w2) => w2.id !== action.payload) };
+    case "SET_CHART_WINDOW_DS":
+      return {
+        ...state,
+        chartWindows: state.chartWindows.map(
+          (w2) => w2.id === action.payload.id ? { ...w2, dsNames: action.payload.dsNames } : w2
+        )
+      };
+    case "TOGGLE_CHART": {
+      const opening = !state.showChart;
+      const firstWindow = { id: `chart_${Date.now()}`, dsNames: [] };
+      return {
+        ...state,
+        showChart: opening,
+        chartWindows: opening && state.chartWindows.length === 0 ? [firstWindow] : state.chartWindows
+      };
+    }
     default:
       return state;
   }
@@ -29025,6 +29059,94 @@ function createTypedChart(type, registerables) {
 }
 const Line = /* @__PURE__ */ createTypedChart("line", LineController);
 const Bar = /* @__PURE__ */ createTypedChart("bar", BarController);
+function useDraggableResizable({ defaultWidth, defaultHeight, initialRight = 20, initialBottom = 20, minWidth = 320, minHeight = 180 }) {
+  const [pos, setPos] = reactExports.useState(null);
+  const [size, setSize] = reactExports.useState({ width: defaultWidth, height: defaultHeight });
+  const panelRef = reactExports.useRef(null);
+  const dragState = reactExports.useRef(null);
+  const resizeState = reactExports.useRef(null);
+  reactExports.useEffect(() => {
+    setPos((p2) => p2 ?? {
+      left: window.innerWidth - defaultWidth - initialRight,
+      top: window.innerHeight - defaultHeight - initialBottom
+    });
+  }, []);
+  const onDragMouseDown = (e) => {
+    if (e.target.closest("button, input, select")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const cur = pos ?? { left: window.innerWidth - defaultWidth - initialRight, top: window.innerHeight - defaultHeight - initialBottom };
+    dragState.current = { startX: e.clientX, startY: e.clientY, startLeft: cur.left, startTop: cur.top };
+    const onMove = (me2) => {
+      if (!dragState.current) return;
+      setPos({
+        left: Math.max(0, Math.min(window.innerWidth - size.width, dragState.current.startLeft + me2.clientX - dragState.current.startX)),
+        top: Math.max(0, Math.min(window.innerHeight - 60, dragState.current.startTop + me2.clientY - dragState.current.startY))
+      });
+    };
+    const onUp = () => {
+      dragState.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
+  const onResizeMouseDown = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizeState.current = { startX: e.clientX, startY: e.clientY, startW: size.width, startH: size.height };
+    const onMove = (me2) => {
+      if (!resizeState.current) return;
+      setSize({
+        width: Math.max(minWidth, resizeState.current.startW + me2.clientX - resizeState.current.startX),
+        height: Math.max(minHeight, resizeState.current.startH + me2.clientY - resizeState.current.startY)
+      });
+    };
+    const onUp = () => {
+      resizeState.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
+  const resolvedPos = pos ?? { left: window.innerWidth - defaultWidth - initialRight, top: window.innerHeight - defaultHeight - initialBottom };
+  const panelStyle = {
+    left: resolvedPos.left,
+    top: resolvedPos.top,
+    width: size.width,
+    height: size.height,
+    bottom: "auto",
+    right: "auto",
+    transform: "none"
+  };
+  const resizeGrip = /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      onMouseDown: onResizeMouseDown,
+      style: {
+        position: "absolute",
+        right: 0,
+        bottom: 0,
+        width: 18,
+        height: 18,
+        cursor: "nwse-resize",
+        zIndex: 10,
+        display: "flex",
+        alignItems: "flex-end",
+        justifyContent: "flex-end",
+        padding: 3,
+        color: "var(--sb-muted)",
+        fontSize: 11,
+        userSelect: "none"
+      },
+      title: "Resize",
+      children: "⤡"
+    }
+  );
+  return { panelRef, panelStyle, size, onDragMouseDown, resizeGrip };
+}
 const VERTEX_ICON = L$1.divIcon({
   className: "",
   html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
@@ -29036,6 +29158,12 @@ function cssVar$1(name, fallback) {
 function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   const map2 = useMap();
   const { state } = useAppContext();
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 540,
+    defaultHeight: 280,
+    initialRight: 20,
+    initialBottom: 20
+  });
   const polyRef = reactExports.useRef(null);
   const previewRef = reactExports.useRef(null);
   const markersRef = reactExports.useRef([]);
@@ -29044,7 +29172,8 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   const [profileData, setProfileData] = reactExports.useState(null);
   const [loading, setLoading] = reactExports.useState(false);
   const [radius, setRadius] = reactExports.useState(0);
-  const fetchFn = reactExports.useCallback(async (pts, r2) => {
+  const [samplingInterval, setSamplingInterval] = reactExports.useState(0);
+  const fetchFn = reactExports.useCallback(async (pts, r2, si2) => {
     if (pts.length < 2 || !state.currentDataset) return;
     setLoading(true);
     try {
@@ -29057,18 +29186,21 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
           time_index: state.currentTimeIndex,
           n_samples: 200,
           radius: r2,
-          n_random: 5
+          n_random: 5,
+          sampling_interval: si2
         })
       });
       if (!res.ok) return;
       const json = await res.json();
       if (Array.isArray(json)) {
-        setProfileData({ centre: json, median: null, samples: [] });
+        setProfileData({ centre: json, median: null, samples: [], binned: false });
       } else {
         setProfileData({
           centre: json.centre ?? [],
           median: json.median ?? null,
-          samples: json.samples ?? []
+          samples: json.samples ?? [],
+          binned: json.binned ?? false,
+          bin_width: json.bin_width
         });
       }
     } finally {
@@ -29083,6 +29215,10 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   reactExports.useEffect(() => {
     radiusRef.current = radius;
   }, [radius]);
+  const samplingIntervalRef = reactExports.useRef(samplingInterval);
+  reactExports.useEffect(() => {
+    samplingIntervalRef.current = samplingInterval;
+  }, [samplingInterval]);
   const updatePoly = (pts) => {
     if (polyRef.current) {
       polyRef.current.setLatLngs(pts);
@@ -29100,7 +29236,7 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       });
       m2.on("dragend", () => {
         ptsRef.current[idx] = m2.getLatLng();
-        fetchRef.current(ptsRef.current, radiusRef.current);
+        fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
       });
       return m2;
     });
@@ -29119,14 +29255,19 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   }, []);
   reactExports.useEffect(() => {
     if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radiusRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
     }
   }, [state.currentTimeIndex, active]);
   reactExports.useEffect(() => {
     if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radius);
+      fetchRef.current(ptsRef.current, radius, samplingIntervalRef.current);
     }
   }, [radius, active]);
+  reactExports.useEffect(() => {
+    if (active && modeRef.current === "ready" && ptsRef.current.length >= 2) {
+      fetchRef.current(ptsRef.current, radiusRef.current, samplingInterval);
+    }
+  }, [samplingInterval, active]);
   reactExports.useEffect(() => {
     if (!active || radius <= 0 || ptsRef.current.length < 2) return;
     const pts = ptsRef.current;
@@ -29209,7 +29350,7 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       modeRef.current = "ready";
       map2.getContainer().style.cursor = "default";
       rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current, radiusRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
     };
     map2.on("click", onClick);
     map2.on("mousemove", onMouseMove);
@@ -29225,55 +29366,98 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
   }, [active, map2, clearAll]);
   if (!active) return null;
   if (loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "profile-panel", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Extracting profile…" }) }) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: panelRef, className: "profile-panel", style: panelStyle, onMouseDown: (e) => e.stopPropagation(), children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Extracting profile…" }) }) });
   }
   const textColor = cssVar$1("--sb-text", "#dde0f0");
   const mutedColor = cssVar$1("--sb-muted", "#7880a8");
   const gridColor = cssVar$1("--sb-border", "#2c2f4a");
   const hasData = profileData && (profileData.centre.length > 0 || profileData.median && profileData.median.length > 0);
+  const isBinned = !!((profileData == null ? void 0 : profileData.binned) && samplingInterval > 0);
   const datasets = [];
   if (hasData) {
     const useBuffer = radius > 0 && profileData.median && profileData.median.length > 0;
-    if (useBuffer) {
+    if (isBinned) {
       profileData.samples.forEach((s, i) => {
         datasets.push({
           label: `sample ${i}`,
           data: s.map((p2) => p2.value),
-          labels: s.map((p2) => p2.dist.toFixed(0)),
           borderColor: "#4d9de028",
           backgroundColor: "transparent",
           borderWidth: 1,
           pointRadius: 0,
           fill: false,
-          tension: 0.2
+          tension: 0.3
         });
       });
-    }
-    const centre = profileData.centre;
-    datasets.push({
-      label: useBuffer ? "centre" : state.currentDataset,
-      data: centre.map((p2) => p2.value),
-      borderColor: useBuffer ? "#4d9de088" : "#4d9de0",
-      backgroundColor: useBuffer ? "transparent" : "rgba(77,157,224,0.15)",
-      borderWidth: useBuffer ? 1 : 1.5,
-      pointRadius: 0,
-      fill: !useBuffer,
-      tension: 0.2
-    });
-    if (useBuffer && profileData.median) {
+      if (profileData.centre.length > 0) {
+        datasets.push({
+          label: "centre",
+          data: profileData.centre.map((p2) => p2.value),
+          borderColor: "#4d9de066",
+          backgroundColor: "transparent",
+          borderWidth: 1,
+          borderDash: [4, 3],
+          pointRadius: 0,
+          fill: false,
+          tension: 0
+        });
+      }
+      if (profileData.median) {
+        datasets.push({
+          label: "median",
+          data: profileData.median.map((p2) => p2.value),
+          borderColor: "#4d9de0",
+          backgroundColor: "#4d9de0",
+          borderWidth: 0,
+          showLine: false,
+          pointStyle: "circle",
+          pointRadius: 5,
+          pointHoverRadius: 7,
+          fill: false
+        });
+      }
+    } else {
+      if (useBuffer) {
+        profileData.samples.forEach((s, i) => {
+          datasets.push({
+            label: `sample ${i}`,
+            data: s.map((p2) => p2.value),
+            borderColor: "#4d9de028",
+            backgroundColor: "transparent",
+            borderWidth: 1,
+            pointRadius: 0,
+            fill: false,
+            tension: 0.2
+          });
+        });
+      }
+      const centre = profileData.centre;
       datasets.push({
-        label: "median",
-        data: profileData.median.map((p2) => p2.value),
-        borderColor: "#4d9de0",
-        backgroundColor: "transparent",
-        borderWidth: 2.5,
+        label: useBuffer ? "centre" : state.currentDataset,
+        data: centre.map((p2) => p2.value),
+        borderColor: useBuffer ? "#4d9de088" : "#4d9de0",
+        backgroundColor: useBuffer ? "transparent" : "rgba(77,157,224,0.15)",
+        borderWidth: useBuffer ? 1 : 1.5,
         pointRadius: 0,
-        fill: false,
+        fill: !useBuffer,
         tension: 0.2
       });
+      if (useBuffer && profileData.median) {
+        datasets.push({
+          label: "median",
+          data: profileData.median.map((p2) => p2.value),
+          borderColor: "#4d9de0",
+          backgroundColor: "transparent",
+          borderWidth: 2.5,
+          pointRadius: 0,
+          fill: false,
+          tension: 0.2
+        });
+      }
     }
   }
-  const xLabels = profileData ? (profileData.centre.length > 0 ? profileData.centre : profileData.median ?? []).map((p2) => p2.dist.toFixed(0)) : [];
+  const xSourcePts = profileData ? isBinned && profileData.median ? profileData.median : profileData.centre.length > 0 ? profileData.centre : profileData.median ?? [] : [];
+  const xLabels = xSourcePts.map((p2) => p2.dist.toFixed(0));
   const chartData = { labels: xLabels, datasets };
   const options = {
     responsive: true,
@@ -29281,10 +29465,18 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
     animation: { duration: 0 },
     plugins: {
       legend: {
-        display: radius > 0,
+        display: radius > 0 || isBinned,
         labels: {
           color: textColor,
           filter: (item) => !item.text.startsWith("sample")
+        }
+      },
+      tooltip: {
+        callbacks: {
+          title: (ctx) => {
+            var _a2;
+            return `${((_a2 = ctx[0]) == null ? void 0 : _a2.label) ?? ""} m`;
+          }
         }
       }
     },
@@ -29301,14 +29493,28 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
       }
     }
   };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-panel", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: panelRef, className: "profile-panel", style: panelStyle, onMouseDown: (e) => e.stopPropagation(), children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", onMouseDown: onDragMouseDown, style: { cursor: "grab" }, children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
         "Profile — ",
         state.currentDataset
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-radius-control", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "profile-radius", style: { color: mutedColor, fontSize: "0.8em", marginRight: 4 }, children: "Radius (m):" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "profile-sampling", style: { color: mutedColor, fontSize: "0.8em", marginRight: 4 }, children: "Sampling (m):" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "input",
+          {
+            id: "profile-sampling",
+            type: "number",
+            min: 0,
+            step: 50,
+            value: samplingInterval,
+            onChange: (e) => setSamplingInterval(Math.max(0, Number(e.target.value))),
+            className: "profile-radius-input",
+            title: "Bin spacing along profile (0 = continuous dense line)"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "profile-radius", style: { color: mutedColor, fontSize: "0.8em", marginLeft: 8, marginRight: 4 }, children: "Radius (m):" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "input",
           {
@@ -29318,179 +29524,15 @@ function ProfileTool({ active, onDeactivate: _onDeactivate }) {
             step: 100,
             value: radius,
             onChange: (e) => setRadius(Math.max(0, Number(e.target.value))),
-            className: "profile-radius-input"
+            className: "profile-radius-input",
+            title: "Perpendicular buffer width (0 = centre line only)"
           }
         )
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: clearAll, title: "Clear profile", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" }) })
     ] }),
-    hasData && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { height: 180, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) })
-  ] });
-}
-function RefPointChart() {
-  var _a2;
-  const { state } = useAppContext();
-  const { fetchBufferTimeSeries } = useApi();
-  const [bufferData, setBufferData] = reactExports.useState(null);
-  const [loading, setLoading] = reactExports.useState(false);
-  const abortRef = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    var _a3;
-    if (!state.refBufferEnabled || !state.showRefChart || !state.currentDataset) {
-      setBufferData(null);
-      return;
-    }
-    (_a3 = abortRef.current) == null ? void 0 : _a3.abort();
-    const ctrl = new AbortController();
-    abortRef.current = ctrl;
-    const [lat, lng] = state.refMarkerPosition;
-    setLoading(true);
-    fetchBufferTimeSeries(lng, lat, state.currentDataset, state.refBufferRadius, 20).then((data) => {
-      if (!ctrl.signal.aborted && data) setBufferData(data);
-    }).finally(() => {
-      if (!ctrl.signal.aborted) setLoading(false);
-    });
-    return () => ctrl.abort();
-  }, [
-    state.refBufferEnabled,
-    state.showRefChart,
-    state.currentDataset,
-    state.refMarkerPosition,
-    state.refBufferRadius
-  ]);
-  if (!state.refBufferEnabled || !state.showRefChart) return null;
-  if (loading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "profile-panel", style: { left: "50%", transform: "translateX(-50%)", bottom: 0, right: "auto", width: 500 }, children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading reference buffer…" }) }) });
-  }
-  if (!bufferData || bufferData.labels.length === 0) return null;
-  const { median, samples } = bufferData;
-  const rawLabels = (((_a2 = state.datasetInfo[state.currentDataset]) == null ? void 0 : _a2.x_values) ?? bufferData.labels).map(String);
-  const n2 = rawLabels.length;
-  const toDisplay = (l2) => {
-    const parts = l2.split("_");
-    if (parts.length === 2 && /^\d{8}$/.test(parts[1])) {
-      const d = parts[1];
-      return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
-    }
-    return l2.slice(0, 10);
-  };
-  const displayLabels = rawLabels.map(toDisplay);
-  const mean = Array(n2).fill(0);
-  const std = Array(n2).fill(0);
-  if (samples.length > 0) {
-    for (let t2 = 0; t2 < n2; t2++) {
-      const vals = samples.map((s) => s[t2]).filter((v2) => isFinite(v2));
-      if (vals.length === 0) {
-        mean[t2] = NaN;
-        std[t2] = NaN;
-        continue;
-      }
-      const m2 = vals.reduce((a, b) => a + b, 0) / vals.length;
-      mean[t2] = m2;
-      std[t2] = Math.sqrt(vals.reduce((a, b) => a + (b - m2) ** 2, 0) / vals.length);
-    }
-  }
-  const meanPlusStd = mean.map((m2, i) => isFinite(m2) ? m2 + std[i] : NaN);
-  const meanMinusStd = mean.map((m2, i) => isFinite(m2) ? m2 - std[i] : NaN);
-  const sampleDatasets = samples.slice(0, 8).map((s, i) => ({
-    label: `sample ${i + 1}`,
-    data: s,
-    borderColor: "rgba(150,180,220,0.18)",
-    backgroundColor: "transparent",
-    borderWidth: 1,
-    pointRadius: 0,
-    tension: 0.15
-  }));
-  const chartData = {
-    labels: displayLabels,
-    datasets: [
-      // +1σ bound — fills toward -1σ (dataset index 1)
-      {
-        label: "+1σ",
-        data: meanPlusStd,
-        borderColor: "rgba(77,157,224,0.4)",
-        backgroundColor: "rgba(77,157,224,0.12)",
-        borderWidth: 1,
-        borderDash: [3, 3],
-        pointRadius: 0,
-        fill: { target: 1, above: "rgba(77,157,224,0.12)" },
-        tension: 0.2
-      },
-      // -1σ bound
-      {
-        label: "-1σ",
-        data: meanMinusStd,
-        borderColor: "rgba(77,157,224,0.4)",
-        backgroundColor: "transparent",
-        borderWidth: 1,
-        borderDash: [3, 3],
-        pointRadius: 0,
-        fill: false,
-        tension: 0.2
-      },
-      // Mean
-      {
-        label: "Mean",
-        data: mean,
-        borderColor: "#4d9de0",
-        backgroundColor: "transparent",
-        borderWidth: 2,
-        pointRadius: 0,
-        tension: 0.2
-      },
-      // Median
-      {
-        label: "Median",
-        data: median,
-        borderColor: "#3ec97a",
-        backgroundColor: "transparent",
-        borderWidth: 2,
-        borderDash: [6, 4],
-        pointRadius: 0,
-        fill: false,
-        tension: 0.2
-      },
-      // Individual samples (faint, behind main lines)
-      ...sampleDatasets
-    ]
-  };
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 0 },
-    plugins: {
-      legend: {
-        display: true,
-        labels: {
-          color: "#aaa",
-          filter: (item) => ["Mean", "Median", "+1σ"].includes(item.text),
-          boxWidth: 20,
-          font: { size: 11 }
-        }
-      },
-      tooltip: { mode: "index", intersect: false }
-    },
-    scales: {
-      x: {
-        ticks: { color: "#aaa", maxTicksLimit: 8, maxRotation: 45 },
-        grid: { color: "rgba(255,255,255,0.08)" }
-      },
-      y: {
-        title: { display: true, text: state.currentDataset, color: "#aaa" },
-        ticks: { color: "#aaa" },
-        grid: { color: "rgba(255,255,255,0.08)" }
-      }
-    }
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "profile-panel", style: { right: 16, left: "auto", width: 520 }, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-header", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
-      "Ref Buffer — ",
-      bufferData.n_pixels,
-      " px, r=",
-      state.refBufferRadius,
-      " m"
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { height: 200, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) })
+    hasData && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { flex: 1, minHeight: 120, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) }),
+    resizeGrip
   ] });
 }
 delete L$1.Icon.Default.prototype._getIconUrl;
@@ -29515,6 +29557,43 @@ function MapEvents() {
           position: [e.latlng.lat, e.latlng.lng],
           name: `Point ${Date.now().toString().slice(-4)}`
         }
+      });
+    }
+  });
+  return null;
+}
+function MapViewController() {
+  const { state, dispatch } = useAppContext();
+  const map2 = useMap();
+  const flyingRef = reactExports.useRef(false);
+  reactExports.useEffect(() => {
+    if (!state.viewBounds) return;
+    const [s, w2, n2, e] = state.viewBounds;
+    flyingRef.current = true;
+    const bounds = L$1.latLngBounds([[s, w2], [n2, e]]);
+    const center = bounds.getCenter();
+    const zoom2 = map2.getBoundsZoom(bounds, true);
+    map2.setView(center, zoom2, { animate: true });
+    const onEnd = () => {
+      flyingRef.current = false;
+    };
+    map2.once("moveend", onEnd);
+    return () => {
+      map2.off("moveend", onEnd);
+    };
+  }, [state.viewBounds]);
+  useMapEvents({
+    moveend: () => {
+      if (flyingRef.current) return;
+      const b = map2.getBounds();
+      dispatch({
+        type: "SET_VIEW_BOUNDS",
+        payload: [
+          parseFloat(b.getSouth().toFixed(6)),
+          parseFloat(b.getWest().toFixed(6)),
+          parseFloat(b.getNorth().toFixed(6)),
+          parseFloat(b.getEast().toFixed(6))
+        ]
       });
     }
   });
@@ -29860,7 +29939,7 @@ function MapContainer() {
           /* @__PURE__ */ jsxRuntimeExports.jsx(ScaleBar, {}),
           /* @__PURE__ */ jsxRuntimeExports.jsx(MeasureTool, { active: measureActive, onDeactivate: () => setMeasureActive(false) }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileTool, { active: profileActive, onDeactivate: () => setProfileActive(false) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(RefPointChart, {})
+          /* @__PURE__ */ jsxRuntimeExports.jsx(MapViewController, {})
         ]
       },
       hasDatasets ? "with-data" : "no-data"
@@ -29986,6 +30065,14 @@ function ControlPanel({ title }) {
   const [lightTheme, setLightTheme] = reactExports.useState(false);
   const [draftRefLat, setDraftRefLat] = reactExports.useState(String(state.refMarkerPosition[0]));
   const [draftRefLon, setDraftRefLon] = reactExports.useState(String(state.refMarkerPosition[1]));
+  const [draftBounds, setDraftBounds] = reactExports.useState({ s: "", w: "", n: "", e: "" });
+  const boundsEditingRef = reactExports.useRef(false);
+  const [collapsed, setCollapsed] = reactExports.useState({
+    distribution: true,
+    masking: true,
+    buffer: true
+  });
+  const toggleSection = (key) => setCollapsed((c) => ({ ...c, [key]: !c[key] }));
   const [datasetRanges, setDatasetRanges] = reactExports.useState({});
   reactExports.useEffect(() => {
     const missing = state.layerMasks.map((m2) => m2.dataset).filter((ds) => ds && !(ds in datasetRanges));
@@ -30012,6 +30099,19 @@ function ControlPanel({ title }) {
     setDraftRefLat(state.refMarkerPosition[0].toFixed(6));
     setDraftRefLon(state.refMarkerPosition[1].toFixed(6));
   }, [state.refMarkerPosition]);
+  reactExports.useEffect(() => {
+    if (!state.viewBounds || boundsEditingRef.current) return;
+    const [s, w2, n2, e] = state.viewBounds;
+    setDraftBounds({ s: String(s), w: String(w2), n: String(n2), e: String(e) });
+  }, [state.viewBounds]);
+  const applyViewBounds = () => {
+    const s = parseFloat(draftBounds.s);
+    const w2 = parseFloat(draftBounds.w);
+    const n2 = parseFloat(draftBounds.n);
+    const e = parseFloat(draftBounds.e);
+    if ([s, w2, n2, e].some(isNaN)) return;
+    dispatch({ type: "SET_VIEW_BOUNDS", payload: [s, w2, n2, e] });
+  };
   reactExports.useEffect(() => {
     const datasetName = state.currentDataset;
     if (!datasetName) return;
@@ -30106,23 +30206,34 @@ function ControlPanel({ title }) {
     }, state.animationSpeed);
     return () => clearInterval(id2);
   }, [state.isPlaying, state.animationSpeed, nTimes, dispatch]);
+  const SectionHeader = ({ icon, label, collapseKey }) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: "sidebar-section-label",
+      style: collapseKey ? { cursor: "pointer", userSelect: "none" } : void 0,
+      onClick: collapseKey ? () => toggleSection(collapseKey) : void 0,
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${icon}` }),
+          " ",
+          label
+        ] }),
+        collapseKey && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "i",
+          {
+            className: `fa-solid fa-chevron-${collapsed[collapseKey] ? "down" : "up"}`,
+            style: { fontSize: "0.75em", color: "var(--sb-muted)" }
+          }
+        )
+      ]
+    }
+  );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "menu", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sidebar-theme-toggle", children: /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "theme-toggle-btn", onClick: toggleTheme, title: lightTheme ? "Switch to dark theme" : "Switch to light theme", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${lightTheme ? "fa-moon" : "fa-sun"}` }) }) }),
     title && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sidebar-title", children: title }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-layer-group" }),
-        " Layers"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "select",
-        {
-          className: "sidebar-select",
-          value: state.currentDataset,
-          onChange: (e) => handleDatasetChange(e.target.value),
-          children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
-        }
-      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-layer-group", label: "Layers" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("select", { className: "sidebar-select", value: state.currentDataset, onChange: (e) => handleDatasetChange(e.target.value), children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name)) }),
       currentDatasetInfo && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Time step" }),
@@ -30169,18 +30280,14 @@ function ControlPanel({ title }) {
               max: "2000",
               step: "100",
               value: 2100 - state.animationSpeed,
-              onChange: (e) => dispatch({ type: "SET_ANIMATION_SPEED", payload: 2100 - parseInt(e.target.value) }),
-              title: "Animation speed"
+              onChange: (e) => dispatch({ type: "SET_ANIMATION_SPEED", payload: 2100 - parseInt(e.target.value) })
             }
           )
         ] })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-palette" }),
-        " Colormap"
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-palette", label: "Visualization" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "colormap-row", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "select",
@@ -30208,14 +30315,7 @@ function ControlPanel({ title }) {
           }
         )
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "img",
-        {
-          src: `/colorbar/${state.colormap}`,
-          className: "colorbar-img",
-          alt: "Colormap"
-        }
-      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("img", { src: `/colorbar/${state.colormap}`, className: "colorbar-img", alt: "Colormap" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-row", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "Min" }),
@@ -30268,13 +30368,25 @@ function ControlPanel({ title }) {
             onChange: (e) => dispatch({ type: "SET_OPACITY", payload: parseFloat(e.target.value) })
           }
         )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", style: { marginTop: 4 }, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "Colorbar on map" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            className: `toggle-pill${state.showColorbar ? " active" : ""}`,
+            onClick: () => dispatch({ type: "TOGGLE_COLORBAR" }),
+            children: state.showColorbar ? "ON" : "OFF"
+          }
+        )
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-map" }),
-        " Basemap"
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-chart-bar", label: "Distribution" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(Histogram, {})
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-map", label: "Basemap" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "select",
         {
@@ -30286,228 +30398,107 @@ function ControlPanel({ title }) {
       )
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-chart-bar" }),
-        " Value Distribution"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(Histogram, {})
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-mask" }),
-        " Masking"
-      ] }),
-      state.layerMasks.map((mask) => {
-        const range = datasetRanges[mask.dataset];
-        const rMin = (range == null ? void 0 : range.p2) ?? (range == null ? void 0 : range.min) ?? 0;
-        const rMax = (range == null ? void 0 : range.p98) ?? (range == null ? void 0 : range.max) ?? 1;
-        const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
-        return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "layer-mask-row", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", alignItems: "center", gap: 4, marginBottom: 4 }, children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "select",
-              {
-                className: "sidebar-select",
-                style: { flex: 1, fontSize: "0.78em" },
-                value: mask.dataset,
-                onChange: (e) => {
-                  const ds = e.target.value;
-                  const newRange = datasetRanges[ds];
-                  const defaultThreshold = newRange ? (mask.mode === "max" ? newRange.p98 ?? newRange.max : newRange.p2 ?? newRange.min) ?? 0.5 : 0.5;
-                  dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
-                },
-                children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs(
-              "select",
-              {
-                className: "sidebar-select",
-                style: { width: 56, fontSize: "0.78em", padding: "2px 4px" },
-                value: mask.mode,
-                onChange: (e) => {
-                  const newMode = e.target.value;
-                  const r2 = datasetRanges[mask.dataset];
-                  const newThreshold = r2 ? (newMode === "max" ? r2.p98 ?? r2.max : r2.p2 ?? r2.min) ?? mask.threshold : mask.threshold;
-                  dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: newMode, threshold: newThreshold } } });
-                },
-                children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "min", children: "≥" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "max", children: "≤" })
-                ]
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                className: "hist-btn",
-                style: { color: "var(--sb-red)", padding: "2px 6px", flexShrink: 0 },
-                onClick: () => dispatch({ type: "REMOVE_LAYER_MASK", payload: mask.id }),
-                title: "Remove mask",
-                children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" })
-              }
-            )
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { fontSize: "0.75em", color: "var(--sb-muted)" }, children: [
-              "Threshold",
-              range ? ` [${rMin.toPrecision(3)}, ${rMax.toPrecision(3)}]` : ""
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "input",
-              {
-                type: "number",
-                style: { width: 72, fontSize: "0.75em", background: "var(--sb-surface2)", border: "1px solid var(--sb-border)", borderRadius: 4, color: "var(--sb-text)", padding: "1px 4px", textAlign: "right" },
-                step,
-                value: parseFloat(mask.threshold.toPrecision(4)),
-                onChange: (e) => {
-                  const v2 = parseFloat(e.target.value);
-                  if (!isNaN(v2)) dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: v2 } } });
-                }
-              }
-            )
-          ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-expand", label: "View Extent" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-row", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "N" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             "input",
             {
-              type: "range",
-              className: "sidebar-range",
-              min: rMin,
-              max: rMax,
-              step,
-              value: mask.threshold,
-              onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })
-            }
-          )
-        ] }, mask.id);
-      }),
-      Object.keys(state.datasetInfo).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: "hist-btn",
-          style: { width: "100%", marginTop: 4 },
-          onClick: () => {
-            const firstDataset = Object.keys(state.datasetInfo)[0];
-            const range = datasetRanges[firstDataset];
-            const defaultThreshold = range ? range.p2 ?? range.min : 0.5;
-            dispatch({
-              type: "ADD_LAYER_MASK",
-              payload: {
-                id: `mask_${Date.now()}`,
-                dataset: firstDataset,
-                threshold: defaultThreshold,
-                mode: "min"
-              }
-            });
-          },
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-plus", style: { marginRight: 5 } }),
-            "Add layer mask"
-          ]
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-row", style: { marginTop: 8 }, children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", style: { marginBottom: 4 }, children: "Custom mask (GeoTIFF)" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-controls", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "hist-btn", style: { cursor: "pointer", textAlign: "center" }, children: [
-            "Upload",
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "input",
-              {
-                type: "file",
-                accept: ".tif,.tiff",
-                style: { display: "none" },
-                onChange: async (e) => {
-                  var _a3;
-                  const f2 = (_a3 = e.target.files) == null ? void 0 : _a3[0];
-                  if (!f2) return;
-                  const form = new FormData();
-                  form.append("file", f2);
-                  const res = await fetch("/upload_mask", { method: "POST", body: form });
-                  if (res.ok) {
-                    const data = await res.json();
-                    dispatch({ type: "SET_CUSTOM_MASK_PATH", payload: data.path });
-                  }
-                }
-              }
-            )
-          ] }),
-          state.customMaskPath && /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              className: "hist-btn",
-              style: { color: "var(--sb-red)" },
-              onClick: () => dispatch({ type: "SET_CUSTOM_MASK_PATH", payload: null }),
-              children: "Clear"
+              className: "sidebar-input",
+              type: "text",
+              inputMode: "decimal",
+              value: draftBounds.n,
+              onFocus: () => {
+                boundsEditingRef.current = true;
+              },
+              onChange: (e) => setDraftBounds((b) => ({ ...b, n: e.target.value })),
+              onBlur: () => {
+                boundsEditingRef.current = false;
+              },
+              onKeyDown: (e) => e.key === "Enter" && applyViewBounds()
             }
           )
         ] }),
-        state.customMaskPath && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { fontSize: "0.72em", color: "var(--sb-muted)", wordBreak: "break-all", marginTop: 2 }, children: state.customMaskPath.split("/").pop() })
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-circle-dot" }),
-        " Point Buffer Sampling"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "Enable buffer mode" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            className: `toggle-pill${state.bufferEnabled ? " active" : ""}`,
-            onClick: () => dispatch({ type: "TOGGLE_BUFFER" }),
-            children: state.bufferEnabled ? "ON" : "OFF"
-          }
-        )
-      ] }),
-      state.bufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Radius" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
-              state.bufferRadius,
-              " m"
-            ] })
-          ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "S" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             "input",
             {
-              type: "range",
-              className: "sidebar-range",
-              min: "50",
-              max: "5000",
-              step: "50",
-              value: state.bufferRadius,
-              onChange: (e) => dispatch({ type: "SET_BUFFER_RADIUS", payload: parseInt(e.target.value) })
+              className: "sidebar-input",
+              type: "text",
+              inputMode: "decimal",
+              value: draftBounds.s,
+              onFocus: () => {
+                boundsEditingRef.current = true;
+              },
+              onChange: (e) => setDraftBounds((b) => ({ ...b, s: e.target.value })),
+              onBlur: () => {
+                boundsEditingRef.current = false;
+              },
+              onKeyDown: (e) => e.key === "Enter" && applyViewBounds()
+            }
+          )
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-row", style: { marginTop: 4 }, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "W" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              className: "sidebar-input",
+              type: "text",
+              inputMode: "decimal",
+              value: draftBounds.w,
+              onFocus: () => {
+                boundsEditingRef.current = true;
+              },
+              onChange: (e) => setDraftBounds((b) => ({ ...b, w: e.target.value })),
+              onBlur: () => {
+                boundsEditingRef.current = false;
+              },
+              onKeyDown: (e) => e.key === "Enter" && applyViewBounds()
             }
           )
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Samples shown" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.bufferSamples })
-          ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "E" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             "input",
             {
-              type: "range",
-              className: "sidebar-range",
-              min: "0",
-              max: "50",
-              step: "1",
-              value: state.bufferSamples,
-              onChange: (e) => dispatch({ type: "SET_BUFFER_SAMPLES", payload: parseInt(e.target.value) })
+              className: "sidebar-input",
+              type: "text",
+              inputMode: "decimal",
+              value: draftBounds.e,
+              onFocus: () => {
+                boundsEditingRef.current = true;
+              },
+              onChange: (e) => setDraftBounds((b) => ({ ...b, e: e.target.value })),
+              onBlur: () => {
+                boundsEditingRef.current = false;
+              },
+              onKeyDown: (e) => e.key === "Enter" && applyViewBounds()
             }
           )
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", gap: 6, marginTop: 6 }, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", style: { flex: 1 }, onClick: applyViewBounds, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-location-crosshairs" }),
+          " Apply"
+        ] }),
+        state.currentDataset && state.datasetInfo[state.currentDataset] && /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", style: { flex: 1 }, onClick: () => {
+          const b = state.datasetInfo[state.currentDataset].latlon_bounds;
+          dispatch({ type: "SET_VIEW_BOUNDS", payload: [b[1], b[0], b[3], b[2]] });
+        }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-arrows-to-circle" }),
+          " Dataset"
         ] })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section-label", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-crosshairs" }),
-        " Reference Point"
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-crosshairs", label: "Reference Point" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-row", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "minmax-field", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", children: "Lat" }),
@@ -30551,7 +30542,7 @@ function ControlPanel({ title }) {
           }
         )
       ] }),
-      state.refBufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
+      state.refBufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Radius" }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
@@ -30564,14 +30555,218 @@ function ControlPanel({ title }) {
           {
             type: "range",
             className: "sidebar-range",
-            min: "50",
+            min: "5",
             max: "5000",
-            step: "50",
+            step: "5",
             value: state.refBufferRadius,
             onChange: (e) => dispatch({ type: "SET_REF_BUFFER_RADIUS", payload: parseInt(e.target.value) })
           }
         )
-      ] }) })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-mask", label: "Masking", collapseKey: "masking" }),
+      !collapsed.masking && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        state.layerMasks.map((mask) => {
+          const range = datasetRanges[mask.dataset];
+          const rMin = (range == null ? void 0 : range.p2) ?? (range == null ? void 0 : range.min) ?? 0;
+          const rMax = (range == null ? void 0 : range.p98) ?? (range == null ? void 0 : range.max) ?? 1;
+          const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
+          return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "layer-mask-row", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", alignItems: "center", gap: 4, marginBottom: 4 }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "select",
+                {
+                  className: "sidebar-select",
+                  style: { flex: 1, fontSize: "0.78em" },
+                  value: mask.dataset,
+                  onChange: (e) => {
+                    const ds = e.target.value;
+                    const newRange = datasetRanges[ds];
+                    const defaultThreshold = newRange ? (mask.mode === "max" ? newRange.p98 ?? newRange.max : newRange.p2 ?? newRange.min) ?? 0.5 : 0.5;
+                    dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
+                  },
+                  children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "select",
+                {
+                  className: "sidebar-select",
+                  style: { width: 56, fontSize: "0.78em", padding: "2px 4px" },
+                  value: mask.mode,
+                  onChange: (e) => {
+                    const newMode = e.target.value;
+                    const r2 = datasetRanges[mask.dataset];
+                    const newThreshold = r2 ? (newMode === "max" ? r2.p98 ?? r2.max : r2.p2 ?? r2.min) ?? mask.threshold : mask.threshold;
+                    dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: newMode, threshold: newThreshold } } });
+                  },
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "min", children: "≥" }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "max", children: "≤" })
+                  ]
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  className: "hist-btn",
+                  style: { color: "var(--sb-red)", padding: "2px 6px", flexShrink: 0 },
+                  onClick: () => dispatch({ type: "REMOVE_LAYER_MASK", payload: mask.id }),
+                  children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" })
+                }
+              )
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { fontSize: "0.75em", color: "var(--sb-muted)" }, children: [
+                "Threshold",
+                range ? ` [${rMin.toPrecision(3)}, ${rMax.toPrecision(3)}]` : ""
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "number",
+                  style: { width: 72, fontSize: "0.75em", background: "var(--sb-surface2)", border: "1px solid var(--sb-border)", borderRadius: 4, color: "var(--sb-text)", padding: "1px 4px", textAlign: "right" },
+                  step,
+                  value: parseFloat(mask.threshold.toPrecision(4)),
+                  onChange: (e) => {
+                    const v2 = parseFloat(e.target.value);
+                    if (!isNaN(v2)) dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: v2 } } });
+                  }
+                }
+              )
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "range",
+                className: "sidebar-range",
+                min: rMin,
+                max: rMax,
+                step,
+                value: mask.threshold,
+                onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })
+              }
+            )
+          ] }, mask.id);
+        }),
+        Object.keys(state.datasetInfo).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            className: "hist-btn",
+            style: { width: "100%", marginTop: 4 },
+            onClick: () => {
+              const firstDataset = Object.keys(state.datasetInfo)[0];
+              const range = datasetRanges[firstDataset];
+              dispatch({ type: "ADD_LAYER_MASK", payload: {
+                id: `mask_${Date.now()}`,
+                dataset: firstDataset,
+                threshold: range ? range.p2 ?? range.min : 0.5,
+                mode: "min"
+              } });
+            },
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-plus", style: { marginRight: 5 } }),
+              "Add layer mask"
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-row", style: { marginTop: 8 }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", style: { marginBottom: 4 }, children: "Custom mask (GeoTIFF)" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-controls", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "hist-btn", style: { cursor: "pointer", textAlign: "center" }, children: [
+              "Upload",
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "file",
+                  accept: ".tif,.tiff",
+                  style: { display: "none" },
+                  onChange: async (e) => {
+                    var _a3;
+                    const f2 = (_a3 = e.target.files) == null ? void 0 : _a3[0];
+                    if (!f2) return;
+                    const form = new FormData();
+                    form.append("file", f2);
+                    const res = await fetch("/upload_mask", { method: "POST", body: form });
+                    if (res.ok) {
+                      const data = await res.json();
+                      dispatch({ type: "SET_CUSTOM_MASK_PATH", payload: data.path });
+                    }
+                  }
+                }
+              )
+            ] }),
+            state.customMaskPath && /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                className: "hist-btn",
+                style: { color: "var(--sb-red)" },
+                onClick: () => dispatch({ type: "SET_CUSTOM_MASK_PATH", payload: null }),
+                children: "Clear"
+              }
+            )
+          ] }),
+          state.customMaskPath && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { fontSize: "0.72em", color: "var(--sb-muted)", wordBreak: "break-all", marginTop: 2 }, children: state.customMaskPath.split("/").pop() })
+        ] })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-section", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeader, { icon: "fa-circle-dot", label: "Point Buffer", collapseKey: "buffer" }),
+      !collapsed.buffer && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "Enable buffer mode" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              className: `toggle-pill${state.bufferEnabled ? " active" : ""}`,
+              onClick: () => dispatch({ type: "TOGGLE_BUFFER" }),
+              children: state.bufferEnabled ? "ON" : "OFF"
+            }
+          )
+        ] }),
+        state.bufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Radius" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
+                state.bufferRadius,
+                " m"
+              ] })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "range",
+                className: "sidebar-range",
+                min: "5",
+                max: "5000",
+                step: "5",
+                value: state.bufferRadius,
+                onChange: (e) => dispatch({ type: "SET_BUFFER_RADIUS", payload: parseInt(e.target.value) })
+              }
+            )
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Samples shown" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.bufferSamples })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "range",
+                className: "sidebar-range",
+                min: "0",
+                max: "50",
+                step: "1",
+                value: state.bufferSamples,
+                onChange: (e) => dispatch({ type: "SET_BUFFER_SAMPLES", payload: parseInt(e.target.value) })
+              }
+            )
+          ] })
+        ] })
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sidebar-footer", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -30602,18 +30797,11 @@ function ControlPanel({ title }) {
           ]
         }
       ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          className: "chart-toggle-btn",
-          onClick: () => dispatch({ type: "TOGGLE_CHART" }),
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showChart ? "fa-chart-line" : "fa-wave-square"}` }),
-            state.showChart ? "Hide" : "Show",
-            " Time Series"
-          ]
-        }
-      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-toggle-btn", onClick: () => dispatch({ type: "TOGGLE_CHART" }), children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showChart ? "fa-chart-line" : "fa-wave-square"}` }),
+        state.showChart ? "Hide" : "Show",
+        " Time Series"
+      ] }),
       state.refBufferEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {
@@ -37073,6 +37261,33 @@ var plugin = {
   zoomFunctions,
   zoomRectFunctions
 };
+const linkedLegendPlugin = {
+  id: "linkedLegend",
+  afterInit(chart) {
+    var _a2, _b2;
+    if (chart._linkedLegendPatched) return;
+    chart._linkedLegendPatched = true;
+    const origClick = (_b2 = (_a2 = chart.options.plugins) == null ? void 0 : _a2.legend) == null ? void 0 : _b2.onClick;
+    chart.options.plugins.legend.onClick = function(e, legendItem, legend) {
+      if (origClick) origClick.call(this, e, legendItem, legend);
+      else Chart$1.defaults.plugins.legend.onClick.call(this, e, legendItem, legend);
+      const clickedDs = chart.data.datasets[legendItem.datasetIndex];
+      if (!clickedDs) return;
+      const baseLabel = clickedDs._baseLabel;
+      if (!baseLabel) return;
+      const hidden = !chart.isDatasetVisible(legendItem.datasetIndex);
+      chart.data.datasets.forEach((ds, i) => {
+        if (i === legendItem.datasetIndex) return;
+        if (ds._baseLabel === baseLabel) {
+          const meta = chart.getDatasetMeta(i);
+          meta.hidden = hidden;
+        }
+      });
+      chart.update();
+    };
+  }
+};
+Chart$1.register(linkedLegendPlugin);
 Chart$1.register(TimeScale, LinearScale, PointElement, LineElement, plugin_title, plugin_tooltip, plugin_legend, plugin);
 function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
@@ -37093,73 +37308,96 @@ function toIsoDate(xVal) {
   }
   return xVal;
 }
-function TimeSeriesChart() {
+function TimeSeriesChart({ windowId }) {
   const { state, dispatch } = useAppContext();
+  const window_ = state.chartWindows.find((w2) => w2.id === windowId);
   const { fetchMultiPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const themeVersion = useThemeVersion();
-  const [chartData, setChartData] = reactExports.useState(null);
+  const [chartDataMap, setChartDataMap] = reactExports.useState({});
   const [bufferData, setBufferData] = reactExports.useState({});
   const [isLoading, setIsLoading] = reactExports.useState(false);
   const [isZoomed, setIsZoomed] = reactExports.useState(false);
+  const [dsOffsets, setDsOffsets] = reactExports.useState({});
+  const [dsColorOverrides, setDsColorOverrides] = reactExports.useState({});
+  const [dsYLimits, setDsYLimits] = reactExports.useState({});
   const chartRef = reactExports.useRef(null);
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: Math.min(560, window.innerWidth * 0.38),
+    defaultHeight: 420
+  });
+  const winDsNames = (window_ == null ? void 0 : window_.dsNames) ?? [];
+  const activeDatasetsForChart = winDsNames.length > 0 ? winDsNames : state.currentDataset ? [state.currentDataset] : [];
   const updateChart = reactExports.useCallback(async () => {
     if (!state.showChart || !state.currentDataset || state.timeSeriesPoints.length === 0) {
-      setChartData(null);
+      setChartDataMap({});
       return;
     }
     setIsLoading(true);
-    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
     const visiblePoints = state.timeSeriesPoints.filter((p2) => p2.visible);
     if (visiblePoints.length === 0) {
-      setChartData(null);
+      setChartDataMap({});
       setIsLoading(false);
       return;
     }
+    const timeDatasets = activeDatasetsForChart.filter((ds) => {
+      const info = state.datasetInfo[ds];
+      return info && Array.isArray(info.x_values) && info.x_values.length > 0;
+    });
+    if (timeDatasets.length === 0) {
+      setChartDataMap({});
+      setIsLoading(false);
+      return;
+    }
+    const apiPoints = visiblePoints.map((point) => ({
+      id: point.id,
+      lat: point.position[0],
+      lon: point.position[1],
+      color: point.color,
+      name: point.name
+    }));
     try {
-      const apiPoints = visiblePoints.map((point) => ({
-        id: point.id,
-        lat: point.position[0],
-        lon: point.position[1],
-        color: point.color,
-        name: point.name
-      }));
-      let refLon, refLat;
-      if ((currentDatasetInfo == null ? void 0 : currentDatasetInfo.uses_spatial_ref) && state.refEnabled) {
-        [refLat, refLon] = state.refMarkerPosition;
-      }
-      const tsData = await fetchMultiPointTimeSeries(
-        apiPoints,
-        state.currentDataset,
-        refLon,
-        refLat,
-        state.showTrends,
-        state.layerMasks,
-        state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
+      const results = await Promise.all(
+        timeDatasets.map(async (dsName) => {
+          const dsInfo = state.datasetInfo[dsName];
+          let refLon, refLat;
+          if ((dsInfo == null ? void 0 : dsInfo.uses_spatial_ref) && state.refEnabled) {
+            [refLat, refLon] = state.refMarkerPosition;
+          }
+          const tsData = await fetchMultiPointTimeSeries(
+            apiPoints,
+            dsName,
+            refLon,
+            refLat,
+            state.showTrends,
+            state.layerMasks,
+            state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
+          );
+          return { dsName, tsData };
+        })
       );
-      if (tsData) {
-        setChartData(tsData);
-        if (state.showTrends && tsData.datasets) {
-          setTimeout(() => {
-            tsData.datasets.forEach((dataset) => {
-              if (dataset.trend) {
-                dispatch({
-                  type: "SET_POINT_TREND_DATA",
-                  payload: {
-                    pointId: dataset.pointId,
-                    dataset: state.currentDataset,
-                    trend: {
-                      slope: dataset.trend.slope,
-                      intercept: dataset.trend.intercept,
-                      rSquared: dataset.trend.rSquared,
-                      mmPerYear: dataset.trend.mmPerYear
+      const newMap = {};
+      results.forEach(({ dsName, tsData }) => {
+        if (tsData) {
+          newMap[dsName] = tsData;
+          if (state.showTrends) {
+            setTimeout(() => {
+              tsData.datasets.forEach((dataset) => {
+                if (dataset.trend) {
+                  dispatch({
+                    type: "SET_POINT_TREND_DATA",
+                    payload: {
+                      pointId: dataset.pointId,
+                      dataset: dsName,
+                      trend: dataset.trend
                     }
-                  }
-                });
-              }
-            });
-          }, 0);
+                  });
+                }
+              });
+            }, 0);
+          }
         }
-      }
+      });
+      setChartDataMap(newMap);
     } catch (error) {
       console.error("Error updating chart:", error);
     } finally {
@@ -37168,6 +37406,7 @@ function TimeSeriesChart() {
   }, [
     state.showChart,
     state.currentDataset,
+    JSON.stringify(activeDatasetsForChart),
     JSON.stringify(state.timeSeriesPoints.map((p2) => ({ id: p2.id, position: p2.position, visible: p2.visible }))),
     state.refMarkerPosition,
     state.refEnabled,
@@ -37189,30 +37428,40 @@ function TimeSeriesChart() {
       setBufferData({});
       return;
     }
-    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
-    let refLon, refLat;
-    if ((currentDatasetInfo == null ? void 0 : currentDatasetInfo.uses_spatial_ref) && state.refEnabled) {
-      [refLat, refLon] = state.refMarkerPosition;
+    const timeDatasets = activeDatasetsForChart.filter((ds) => {
+      const info = state.datasetInfo[ds];
+      return info && Array.isArray(info.x_values) && info.x_values.length > 0;
+    });
+    if (timeDatasets.length === 0) {
+      setBufferData({});
+      return;
     }
     Promise.all(
-      visiblePoints.map(async (p2) => {
-        const result = await fetchBufferTimeSeries(
-          p2.position[1],
-          p2.position[0],
-          state.currentDataset,
-          state.bufferRadius,
-          state.bufferSamples,
-          refLon,
-          refLat,
-          state.layerMasks,
-          state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
-        );
-        return { id: p2.id, result };
+      timeDatasets.flatMap((dsName) => {
+        const dsInfo = state.datasetInfo[dsName];
+        let refLon, refLat;
+        if ((dsInfo == null ? void 0 : dsInfo.uses_spatial_ref) && state.refEnabled) {
+          [refLat, refLon] = state.refMarkerPosition;
+        }
+        return visiblePoints.map(async (p2) => {
+          const result = await fetchBufferTimeSeries(
+            p2.position[1],
+            p2.position[0],
+            dsName,
+            state.bufferRadius,
+            state.bufferSamples,
+            refLon,
+            refLat,
+            state.layerMasks,
+            state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
+          );
+          return { key: `${dsName}::${p2.id}`, result };
+        });
       })
     ).then((results) => {
       const newData = {};
-      results.forEach(({ id: id2, result }) => {
-        if (result) newData[id2] = result;
+      results.forEach(({ key, result }) => {
+        if (result) newData[key] = result;
       });
       setBufferData(newData);
     });
@@ -37220,6 +37469,7 @@ function TimeSeriesChart() {
     state.bufferEnabled,
     state.showChart,
     state.currentDataset,
+    JSON.stringify(activeDatasetsForChart),
     state.bufferRadius,
     state.bufferSamples,
     state.refEnabled,
@@ -37230,59 +37480,84 @@ function TimeSeriesChart() {
     state.refMarkerPosition,
     fetchBufferTimeSeries
   ]);
+  const firstDs = Object.values(chartDataMap)[0] ?? null;
   const handleChartClick = reactExports.useCallback((_event, elements) => {
-    if (elements.length === 0 || !chartData) return;
+    if (elements.length === 0 || !firstDs) return;
     const dataIndex = elements[0].index;
-    if (dataIndex !== void 0 && dataIndex < chartData.labels.length) {
+    if (dataIndex !== void 0 && dataIndex < firstDs.labels.length) {
       dispatch({ type: "SET_TIME_INDEX", payload: dataIndex });
     }
-  }, [chartData, dispatch]);
+  }, [firstDs, dispatch]);
   const handleExportToCSV = reactExports.useCallback(() => {
-    if (!chartData || !chartData.datasets || chartData.datasets.length === 0) return;
-    const headers = ["Time", ...chartData.datasets.map((d) => d.label)];
-    const rows = [];
-    chartData.labels.forEach((label, idx) => {
-      const row = [label];
-      chartData.datasets.forEach((dataset) => {
-        const dataPoint = dataset.data[idx];
-        row.push(dataPoint ? dataPoint.y.toString() : "");
+    if (!firstDs) return;
+    const allDatasets = Object.entries(chartDataMap).flatMap(
+      ([dsName, cd2]) => cd2.datasets.map((d) => ({ ...d, _dsName: dsName }))
+    );
+    if (allDatasets.length === 0) return;
+    const multiDs2 = activeDatasetsForChart.length > 1;
+    const headers = ["Time", ...allDatasets.map((d) => multiDs2 ? `${d._dsName} — ${d.label}` : d.label)];
+    const byLabel = {};
+    allDatasets.forEach((d) => {
+      const key = multiDs2 ? `${d._dsName}::${d.label}` : d.label;
+      d.data.forEach((pt) => {
+        var _a2;
+        (byLabel[_a2 = pt.x] ?? (byLabel[_a2] = {}))[key] = pt.y;
       });
-      rows.push(row);
     });
-    const trendRows = [];
-    if (state.showTrends && chartData.datasets.some((d) => d.trend)) {
-      trendRows.push([""]);
-      trendRows.push(["Point", "Rate (mm/year)", "R²", "Slope", "Intercept"]);
-      chartData.datasets.forEach((dataset) => {
-        if (dataset.trend) {
-          trendRows.push([
-            dataset.label,
-            dataset.trend.mmPerYear.toFixed(6),
-            dataset.trend.rSquared.toFixed(6),
-            dataset.trend.slope.toFixed(6),
-            dataset.trend.intercept.toFixed(6)
-          ]);
-        }
+    const allTimes = [...new Set(allDatasets.flatMap((d) => d.data.map((pt) => pt.x)))].sort();
+    const rows = allTimes.map((t2) => {
+      const row = [t2];
+      allDatasets.forEach((d) => {
+        var _a2, _b2;
+        const key = multiDs2 ? `${d._dsName}::${d.label}` : d.label;
+        row.push(((_b2 = (_a2 = byLabel[t2]) == null ? void 0 : _a2[key]) == null ? void 0 : _b2.toString()) ?? "");
       });
-    }
-    const csvContent = [headers, ...rows, ...trendRows].map((r2) => r2.join(",")).join("\n");
+      return row;
+    });
+    const csvContent = [headers, ...rows].map((r2) => r2.join(",")).join("\n");
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
     const link = document.createElement("a");
-    const url = URL.createObjectURL(blob);
-    const timestamp = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-").slice(0, -5);
-    link.setAttribute("href", url);
-    link.setAttribute("download", `time-series-${state.currentDataset}-${timestamp}.csv`);
+    link.setAttribute("href", URL.createObjectURL(blob));
+    link.setAttribute("download", `time-series-${state.currentDataset}-${(/* @__PURE__ */ new Date()).toISOString().slice(0, 16).replace(/[:.]/g, "-")}.csv`);
     link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-  }, [chartData, state.showTrends, state.currentDataset]);
+  }, [chartDataMap, firstDs, activeDatasetsForChart, state.currentDataset]);
+  const activeChartDs = Object.keys(chartDataMap);
   const chartOptions = reactExports.useMemo(() => {
     const textColor = cssVar("--sb-text", "#dde0f0");
     const mutedColor = cssVar("--sb-muted", "#7880a8");
     const gridColor = cssVar("--sb-border", "#2c2f4a");
-    const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
-    const yLabel = (dsInfo == null ? void 0 : dsInfo.label) && (dsInfo == null ? void 0 : dsInfo.unit) ? `${dsInfo.label} (${dsInfo.unit})` : (dsInfo == null ? void 0 : dsInfo.label) || (dsInfo == null ? void 0 : dsInfo.unit) || "Displacement (m)";
+    const scales = {
+      x: {
+        type: "time",
+        time: { displayFormats: { month: "MMM yyyy", day: "MMM d", year: "yyyy" } },
+        title: { display: true, text: "Date", color: mutedColor },
+        grid: { color: gridColor },
+        ticks: { color: mutedColor }
+      }
+    };
+    activeChartDs.forEach((ds, i) => {
+      const info = state.datasetInfo[ds];
+      const yLabel = (info == null ? void 0 : info.label) && (info == null ? void 0 : info.unit) ? `${info.label} (${info.unit})` : (info == null ? void 0 : info.label) || (info == null ? void 0 : info.unit) || ds;
+      const axisColor = dsColorOverrides[ds] ?? (i === 0 ? mutedColor : mutedColor);
+      const offset = dsOffsets[ds] ?? 0;
+      const lim2 = dsYLimits[ds];
+      const userMin = (lim2 == null ? void 0 : lim2.min) !== "" && (lim2 == null ? void 0 : lim2.min) !== void 0 ? parseFloat(lim2.min) : NaN;
+      const userMax = (lim2 == null ? void 0 : lim2.max) !== "" && (lim2 == null ? void 0 : lim2.max) !== void 0 ? parseFloat(lim2.max) : NaN;
+      const axisScale = {
+        position: i === 0 ? "left" : "right",
+        title: { display: true, text: yLabel, color: axisColor, font: { size: 10 } },
+        grid: { color: i === 0 ? gridColor : "transparent" },
+        ticks: { color: axisColor, font: { size: 10 } }
+      };
+      if (!isNaN(userMin)) axisScale.min = userMin + offset;
+      if (!isNaN(userMax)) axisScale.max = userMax + offset;
+      if (isNaN(userMin) && offset !== 0) axisScale.suggestedMin = void 0;
+      if (isNaN(userMax) && offset !== 0) axisScale.suggestedMax = void 0;
+      scales[`y${i}`] = axisScale;
+    });
     return {
       responsive: true,
       maintainAspectRatio: false,
@@ -37297,19 +37572,29 @@ function TimeSeriesChart() {
             padding: 16,
             color: textColor,
             generateLabels: (chart) => {
-              if (!(chartData == null ? void 0 : chartData.datasets)) return [];
-              return chart.data.datasets.map((ds, index) => ({ ds, index })).filter(
-                ({ ds }) => !ds.label.endsWith(" trend") && !ds.label.endsWith(" residual") && !ds.label.includes(" sample ") && !ds.label.endsWith(" median")
-              ).map(({ ds, index }) => {
-                var _a2, _b2;
+              const isBuffer = chart.data.datasets.some((ds) => {
+                var _a2;
+                return (_a2 = ds.label) == null ? void 0 : _a2.endsWith(" median");
+              });
+              return chart.data.datasets.map((ds, index) => ({ ds, index })).filter(({ ds }) => {
+                if (ds.label.includes(" sample ")) return false;
+                if (ds.label.endsWith(" trend")) return false;
+                if (ds.label.endsWith(" residual")) return false;
+                if (isBuffer) return ds.label.endsWith(" median");
+                return !ds.label.endsWith(" median");
+              }).map(({ ds, index }) => {
+                const baseLabel = ds._baseLabel || ds.label;
+                const trendMmPerYear = ds._trendMmPerYear;
+                const displayText = baseLabel + (trendMmPerYear !== void 0 && state.showTrends ? ` (${trendMmPerYear.toFixed(1)} mm/yr)` : "");
                 return {
-                  text: ds.label + (ds.label && ((_b2 = (_a2 = chartData.datasets.find((d) => d.label === ds.label)) == null ? void 0 : _a2.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 ? ` (${chartData.datasets.find((d) => d.label === ds.label).trend.mmPerYear.toFixed(1)} mm/yr)` : ""),
+                  text: displayText,
                   pointStyle: "circle",
                   fillStyle: ds.borderColor,
                   strokeStyle: ds.borderColor,
                   fontColor: textColor,
                   lineWidth: 2,
-                  datasetIndex: index
+                  datasetIndex: index,
+                  hidden: !chart.isDatasetVisible(index)
                 };
               });
             }
@@ -37322,24 +37607,18 @@ function TimeSeriesChart() {
               return `${((_a2 = context[0]) == null ? void 0 : _a2.label) || ""}`;
             },
             label: (context) => {
-              var _a2, _b2;
-              const dataset = (_a2 = chartData == null ? void 0 : chartData.datasets) == null ? void 0 : _a2[context.datasetIndex];
-              if (!dataset) return "";
-              const unit = (dsInfo == null ? void 0 : dsInfo.unit) || "m";
-              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} ${unit}`;
-              if (((_b2 = dataset.trend) == null ? void 0 : _b2.mmPerYear) !== void 0 && state.showTrends) {
-                label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
-              }
+              const ds = context.chart.data.datasets[context.datasetIndex];
+              if (!ds) return "";
+              const unit = ds._unit || "m";
+              let label = `${ds._baseLabel || ds.label}: ${context.parsed.y.toFixed(4)} ${unit}`;
+              const mmPy = ds._trendMmPerYear;
+              if (mmPy !== void 0 && state.showTrends) label += ` (${mmPy.toFixed(1)} mm/yr)`;
               return label;
             }
           }
         },
         zoom: {
-          pan: {
-            enabled: true,
-            mode: "x",
-            onPanComplete: () => setIsZoomed(true)
-          },
+          pan: { enabled: true, mode: "x", onPanComplete: () => setIsZoomed(true) },
           zoom: {
             wheel: { enabled: true },
             pinch: { enabled: true },
@@ -37348,179 +37627,456 @@ function TimeSeriesChart() {
           }
         }
       },
-      scales: {
-        x: {
-          type: "time",
-          time: { displayFormats: { month: "MMM yyyy", day: "MMM d", year: "yyyy" } },
-          title: { display: true, text: "Date", color: mutedColor },
-          grid: { color: gridColor },
-          ticks: { color: mutedColor }
-        },
-        y: {
-          title: { display: true, text: yLabel, color: mutedColor },
-          suggestedMin: state.vmin,
-          suggestedMax: state.vmax,
-          grid: { color: gridColor },
-          ticks: { color: mutedColor }
-        }
-      },
+      scales,
       onClick: handleChartClick
     };
-  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, state.currentDataset, state.datasetInfo, handleChartClick]);
+  }, [themeVersion, state.showTrends, state.vmin, state.vmax, state.datasetInfo, state.bufferEnabled, handleChartClick, JSON.stringify(activeChartDs), JSON.stringify(dsOffsets), JSON.stringify(dsColorOverrides), JSON.stringify(dsYLimits), JSON.stringify(Object.fromEntries(Object.entries(chartDataMap).map(([k2, v2]) => [k2, v2.datasets.flatMap((d) => d.data.map((pt) => pt.y))])))]);
   if (!state.showChart) return null;
+  const allDsNames = Object.keys(state.datasetInfo);
+  const setWinDs = (dsNames) => dispatch({ type: "SET_CHART_WINDOW_DS", payload: { id: windowId, dsNames } });
+  const addWinDs = (ds) => {
+    if (!winDsNames.includes(ds)) setWinDs([...winDsNames, ds]);
+  };
+  const removeWinDs = (ds) => setWinDs(winDsNames.filter((d) => d !== ds));
+  const spawnNewChart = () => dispatch({
+    type: "ADD_CHART_WINDOW",
+    payload: { id: `chart_${Date.now()}`, dsNames: [] }
+  });
+  const closeThis = () => dispatch({ type: "REMOVE_CHART_WINDOW", payload: windowId });
+  const headerContent = /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", onMouseDown: onDragMouseDown, style: { cursor: "grab" }, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { style: { margin: 0, fontSize: "0.9em" }, children: "Time Series" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-controls", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", onClick: () => dispatch({ type: "TOGGLE_TRENDS" }), title: "Toggle trend analysis", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showTrends ? "fa-chart-line" : "fa-chart-simple"}` }),
+          state.showTrends ? "Trends ✓" : "Trends"
+        ] }),
+        state.showTrends && /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", onClick: () => dispatch({ type: "TOGGLE_RESIDUALS" }), title: "Show residuals", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-wave-square" }),
+          state.showResiduals ? "Resid ✓" : "Resid"
+        ] }),
+        isZoomed && /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: () => {
+          var _a2;
+          (_a2 = chartRef.current) == null ? void 0 : _a2.resetZoom();
+          setIsZoomed(false);
+        }, title: "Reset zoom", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-magnifying-glass-minus" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", onClick: handleExportToCSV, title: "Export CSV", children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-download" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", title: "New chart window", onClick: spawnNewChart, children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-plus" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { className: "chart-btn", style: { color: "var(--sb-red)" }, title: "Close this chart", onClick: closeThis, children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" }) })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-sliders", style: { marginBottom: 4, paddingBottom: 4, flexWrap: "wrap" }, children: [
+      winDsNames.length === 0 ? state.currentDataset ? /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        padding: "1px 6px",
+        background: "var(--sb-surface2)",
+        border: "1px solid var(--sb-border)",
+        borderRadius: 10,
+        fontSize: "0.72em",
+        color: "var(--sb-text)",
+        flexShrink: 0
+      }, children: [
+        state.currentDataset,
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: () => setWinDs(allDsNames.filter((d) => d !== state.currentDataset)), style: {
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: 0,
+          color: "var(--sb-muted)",
+          fontSize: "0.9em",
+          lineHeight: 1
+        }, title: `Remove ${state.currentDataset}`, children: "✕" })
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.75em", color: "var(--sb-muted)" }, children: "No layer selected" }) : winDsNames.map((ds) => /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        padding: "1px 6px",
+        background: "var(--sb-surface2)",
+        border: "1px solid var(--sb-border)",
+        borderRadius: 10,
+        fontSize: "0.72em",
+        color: "var(--sb-text)",
+        flexShrink: 0
+      }, children: [
+        ds,
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: () => removeWinDs(ds), style: {
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: 0,
+          color: "var(--sb-muted)",
+          fontSize: "0.9em",
+          lineHeight: 1
+        }, title: `Remove ${ds}`, children: "✕" })
+      ] }, ds)),
+      (() => {
+        const excluded = winDsNames.length === 0 ? [...winDsNames, state.currentDataset].filter(Boolean) : winDsNames;
+        const available = allDsNames.filter((ds) => !excluded.includes(ds));
+        return available.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
+          {
+            className: "sidebar-select",
+            style: { fontSize: "0.72em", padding: "1px 4px", height: 22, flex: "0 0 auto", maxWidth: 130 },
+            value: "",
+            onChange: (e) => {
+              if (e.target.value) {
+                addWinDs(e.target.value);
+                e.currentTarget.value = "";
+              }
+            },
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "", children: "＋ layer…" }),
+              available.map((ds) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: ds, children: ds }, ds))
+            ]
+          }
+        ) : null;
+      })(),
+      winDsNames.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          className: "chart-btn",
+          style: { fontSize: "0.7em", padding: "1px 5px" },
+          onClick: () => setWinDs([]),
+          title: "Reset to map layer",
+          children: "↺ reset"
+        }
+      )
+    ] })
+  ] });
   if (state.timeSeriesPoints.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-placeholder", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No points selected." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("small", { children: "Click on the map to add points." }) })
-    ] }) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "chart-container", ref: panelRef, style: panelStyle, children: [
+      headerContent,
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-placeholder", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No points selected." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("small", { children: "Click on the map to add points." }) })
+      ] }),
+      resizeGrip
+    ] });
   }
   if (isLoading) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading…" }) }) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "chart-container", ref: panelRef, style: panelStyle, children: [
+      headerContent,
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading…" }) }),
+      resizeGrip
+    ] });
   }
-  if (!chartData || !chartData.datasets || chartData.datasets.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "chart-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No data for selected points." }) }) });
-  }
-  const isoLabels = chartData.labels.map(toIsoDate);
-  const day0 = isoLabels.length > 0 ? new Date(isoLabels[0]).getTime() / 864e5 : 0;
-  const isoToDay = (iso) => new Date(iso).getTime() / 864e5 - day0;
-  const datasetList = [];
-  chartData.datasets.forEach((dataset) => {
-    const isoData = dataset.data.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y }));
-    datasetList.push({
-      label: dataset.label,
-      data: isoData,
-      borderColor: dataset.borderColor,
-      backgroundColor: dataset.backgroundColor,
-      borderWidth: 2,
-      pointRadius: 4,
-      pointHoverRadius: 6,
-      tension: 0.1,
-      fill: false
+  if (Object.keys(chartDataMap).length === 0) {
+    const allNoTime = activeDatasetsForChart.every((ds) => {
+      const info = state.datasetInfo[ds];
+      return info && Array.isArray(info.x_values) && info.x_values.length === 0;
     });
-    if (state.showTrends && dataset.trend && isoData.length > 1) {
-      const { slope, intercept } = dataset.trend;
-      const trendData = isoData.map((pt) => ({
-        x: pt.x,
-        y: slope * isoToDay(pt.x) + intercept
-      }));
-      datasetList.push({
-        label: `${dataset.label} trend`,
-        data: trendData,
-        borderColor: dataset.borderColor,
-        backgroundColor: "transparent",
-        borderWidth: 1.5,
-        borderDash: [6, 4],
-        pointRadius: 0,
-        pointHoverRadius: 0,
-        tension: 0,
-        fill: false
-      });
-      if (state.showResiduals) {
-        const residualData = isoData.map((pt) => ({
-          x: pt.x,
-          y: pt.y - (slope * isoToDay(pt.x) + intercept)
-        }));
-        datasetList.push({
-          label: `${dataset.label} residual`,
-          data: residualData,
-          borderColor: dataset.borderColor,
-          backgroundColor: dataset.backgroundColor,
-          borderWidth: 1,
-          borderDash: [2, 3],
-          pointRadius: 2,
-          pointHoverRadius: 4,
-          tension: 0,
-          fill: false,
-          borderDashOffset: 0
-        });
-      }
-    }
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "chart-container", ref: panelRef, style: panelStyle, children: [
+      headerContent,
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: allNoTime ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Selected layer has no time dimension." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("small", { children: "Switch to a time-series dataset to view the chart." }) })
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "No data for selected points." }) }),
+      resizeGrip
+    ] });
+  }
+  const multiDs = activeDatasetsForChart.length > 1;
+  const dateStart = state.dateRangeStart ? new Date(state.dateRangeStart).getTime() : -Infinity;
+  const dateEnd = state.dateRangeEnd ? new Date(state.dateRangeEnd).getTime() : Infinity;
+  const allIsoLabels = [...new Set(
+    Object.values(chartDataMap).flatMap((cd2) => cd2.labels.map(toIsoDate))
+  )].sort();
+  const isoLabels = allIsoLabels.filter((d) => {
+    const t2 = new Date(d).getTime();
+    return t2 >= dateStart && t2 <= dateEnd;
   });
-  if (state.bufferEnabled) {
-    chartData.datasets.forEach((dataset) => {
-      const buf = bufferData[dataset.pointId];
-      if (!buf) return;
-      const color2 = dataset.borderColor;
-      buf.samples.forEach((sample2, i) => {
+  const day0 = allIsoLabels.length > 0 ? new Date(allIsoLabels[0]).getTime() / 864e5 : 0;
+  const isoToDay = (iso) => new Date(iso).getTime() / 864e5 - day0;
+  const ms = state.markerSize;
+  const datasetList = [];
+  Object.entries(chartDataMap).forEach(([dsName, cd2]) => {
+    const dsInfo = state.datasetInfo[dsName];
+    const unit = dsInfo == null ? void 0 : dsInfo.unit;
+    const colorOverride = dsColorOverrides[dsName] ?? null;
+    const axisIdx = activeChartDs.indexOf(dsName);
+    const yAxisID = `y${axisIdx}`;
+    cd2.datasets.forEach((dataset) => {
+      var _a2;
+      const baseLabel = multiDs ? `${dataset.label} [${dsName}]` : dataset.label;
+      const borderColor = colorOverride ?? dataset.borderColor;
+      const backgroundColor = colorOverride ? colorOverride + "20" : dataset.backgroundColor;
+      if (state.bufferEnabled) {
+        const buf = bufferData[`${dsName}::${dataset.pointId}`];
+        if (!buf) return;
+        buf.samples.forEach((sample2, i) => {
+          datasetList.push({
+            label: `${baseLabel} sample ${i}`,
+            _baseLabel: baseLabel,
+            _unit: unit,
+            yAxisID,
+            data: sample2.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })).filter((pt) => {
+              const t2 = new Date(pt.x).getTime();
+              return t2 >= dateStart && t2 <= dateEnd;
+            }),
+            borderColor: borderColor + "28",
+            backgroundColor: "transparent",
+            borderWidth: 1,
+            pointRadius: 0,
+            pointHoverRadius: 0,
+            tension: 0.1,
+            fill: false
+          });
+        });
+        const medianData = buf.median.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })).filter((pt) => {
+          const t2 = new Date(pt.x).getTime();
+          return t2 >= dateStart && t2 <= dateEnd;
+        });
         datasetList.push({
-          label: `${dataset.label} sample ${i}`,
-          data: sample2.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })),
-          borderColor: color2 + "28",
-          backgroundColor: "transparent",
-          borderWidth: 1,
-          pointRadius: 0,
-          pointHoverRadius: 0,
+          label: `${baseLabel} median`,
+          _baseLabel: baseLabel,
+          _unit: unit,
+          yAxisID,
+          data: medianData,
+          borderColor,
+          backgroundColor: borderColor,
+          borderWidth: 0,
+          showLine: false,
+          pointStyle: "circle",
+          pointRadius: ms,
+          pointHoverRadius: ms + 2,
+          fill: false
+        });
+      } else {
+        const isoData = dataset.data.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })).filter((pt) => {
+          const t2 = new Date(pt.x).getTime();
+          return t2 >= dateStart && t2 <= dateEnd;
+        });
+        datasetList.push({
+          label: baseLabel,
+          _baseLabel: baseLabel,
+          _unit: unit,
+          _trendMmPerYear: (_a2 = dataset.trend) == null ? void 0 : _a2.mmPerYear,
+          yAxisID,
+          data: isoData,
+          borderColor,
+          backgroundColor,
+          borderWidth: 2,
+          pointRadius: ms,
+          pointHoverRadius: ms + 2,
           tension: 0.1,
           fill: false
         });
-      });
-      datasetList.push({
-        label: `${dataset.label} median`,
-        data: buf.median.map((pt) => ({ x: toIsoDate(pt.x), y: pt.y })),
-        borderColor: color2,
-        backgroundColor: "transparent",
-        borderWidth: 3,
-        borderDash: [4, 3],
-        pointRadius: 0,
-        pointHoverRadius: 0,
-        tension: 0.1,
-        fill: false
-      });
+        if (state.showTrends && dataset.trend && isoData.length > 1) {
+          const { slope, intercept, mmPerYear } = dataset.trend;
+          datasetList.push({
+            label: `${baseLabel} trend`,
+            _baseLabel: baseLabel,
+            _unit: unit,
+            _trendMmPerYear: mmPerYear,
+            yAxisID,
+            data: isoData.map((pt) => ({ x: pt.x, y: slope * isoToDay(pt.x) + intercept })),
+            borderColor,
+            backgroundColor: "transparent",
+            borderWidth: 1.5,
+            borderDash: [6, 4],
+            pointRadius: 0,
+            pointHoverRadius: 0,
+            tension: 0,
+            fill: false
+          });
+          if (state.showResiduals) {
+            datasetList.push({
+              label: `${baseLabel} residual`,
+              _baseLabel: baseLabel,
+              _unit: unit,
+              yAxisID,
+              data: isoData.map((pt) => ({ x: pt.x, y: pt.y - (slope * isoToDay(pt.x) + intercept) })),
+              borderColor,
+              backgroundColor,
+              borderWidth: 1,
+              borderDash: [2, 3],
+              pointRadius: ms > 2 ? ms - 1 : 2,
+              pointHoverRadius: ms + 1,
+              tension: 0,
+              fill: false
+            });
+          }
+        }
+      }
     });
-  }
+  });
   const formattedChartData = { labels: isoLabels, datasets: datasetList };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "chart-container", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-header", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { children: "Time Series" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-controls", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
+  const minDate = allIsoLabels[0] ?? "";
+  const maxDate = allIsoLabels[allIsoLabels.length - 1] ?? "";
+  const sliderStart = state.dateRangeStart ?? minDate;
+  const sliderEnd = state.dateRangeEnd ?? maxDate;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "chart-container", ref: panelRef, style: panelStyle, children: [
+    headerContent,
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-sliders", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "chart-slider-label", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Marker" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "input",
           {
-            className: "chart-btn",
-            onClick: () => dispatch({ type: "TOGGLE_TRENDS" }),
-            title: "Toggle trend analysis",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showTrends ? "fa-chart-line" : "fa-chart-simple"}` }),
-              state.showTrends ? "Hide" : "Show",
-              " Trends"
-            ]
+            type: "range",
+            min: 1,
+            max: 12,
+            step: 1,
+            value: state.markerSize,
+            onChange: (e) => dispatch({ type: "SET_MARKER_SIZE", payload: Number(e.target.value) })
           }
         ),
-        state.showTrends && /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
-          {
-            className: "chart-btn",
-            onClick: () => dispatch({ type: "TOGGLE_RESIDUALS" }),
-            title: "Show residuals (data minus trend)",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid ${state.showResiduals ? "fa-wave-square" : "fa-chart-scatter"}` }),
-              state.showResiduals ? "Hide" : "Show",
-              " Residuals"
-            ]
-          }
-        ),
-        isZoomed && /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
-          {
-            className: "chart-btn",
-            onClick: () => {
-              var _a2;
-              (_a2 = chartRef.current) == null ? void 0 : _a2.resetZoom();
-              setIsZoomed(false);
-            },
-            title: "Reset zoom",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-magnifying-glass-minus" }),
-              " Reset"
-            ]
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { className: "chart-btn", onClick: handleExportToCSV, title: "Export data to CSV", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-download" }),
-          " CSV"
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+          state.markerSize,
+          "px"
         ] })
+      ] }),
+      allIsoLabels.length > 1 && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "chart-slider-label", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "From" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "date",
+              min: minDate,
+              max: sliderEnd || maxDate,
+              value: sliderStart,
+              onChange: (e) => dispatch({ type: "SET_DATE_RANGE_START", payload: e.target.value || null })
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "chart-slider-label", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "To" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "date",
+              min: sliderStart || minDate,
+              max: maxDate,
+              value: sliderEnd,
+              onChange: (e) => dispatch({ type: "SET_DATE_RANGE_END", payload: e.target.value || null })
+            }
+          )
+        ] }),
+        (state.dateRangeStart || state.dateRangeEnd) && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            className: "chart-btn",
+            title: "Reset date range",
+            onClick: () => {
+              dispatch({ type: "SET_DATE_RANGE_START", payload: null });
+              dispatch({ type: "SET_DATE_RANGE_END", payload: null });
+            },
+            children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" })
+          }
+        )
       ] })
     ] }),
+    activeChartDs.map((ds, i) => {
+      var _a2, _b2, _c;
+      const off = dsOffsets[ds] ?? 0;
+      const baseColor = ((_b2 = (_a2 = chartDataMap[ds]) == null ? void 0 : _a2.datasets[0]) == null ? void 0 : _b2.borderColor) ?? "#7880a8";
+      const color2 = dsColorOverrides[ds] ?? baseColor;
+      const info = state.datasetInfo[ds];
+      const unit = (info == null ? void 0 : info.unit) || "";
+      const allY = ((_c = chartDataMap[ds]) == null ? void 0 : _c.datasets.flatMap((d) => d.data.map((pt) => pt.y))) ?? [];
+      const dataSpan = allY.length > 1 ? Math.max(...allY) - Math.min(...allY) : 1;
+      const sliderRange = Math.max(dataSpan * 2, 1e-3);
+      const step = parseFloat((sliderRange / 500).toPrecision(2));
+      const lim2 = dsYLimits[ds] ?? { min: "", max: "" };
+      const hasLimit = lim2.min !== "" || lim2.max !== "";
+      const inputStyle = { width: 58, fontSize: "0.72em", background: "var(--sb-surface2)", border: "1px solid var(--sb-border)", borderRadius: 4, color: "var(--sb-text)", padding: "1px 4px", textAlign: "right", flexShrink: 0 };
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "chart-sliders", style: { borderTop: i === 0 ? void 0 : "none", paddingTop: i === 0 ? void 0 : 0, flexWrap: "wrap", rowGap: 2 }, children: [
+        multiDs && /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "chart-slider-label", style: { flex: "1 1 100%" }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "color",
+              value: color2.length === 7 ? color2 : baseColor,
+              style: { width: 20, height: 20, padding: 0, border: "none", background: "none", cursor: "pointer", flexShrink: 0 },
+              title: "Change layer color",
+              onChange: (e) => setDsColorOverrides((prev) => ({ ...prev, [ds]: e.target.value }))
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { color: color2, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 80 }, title: ds, children: ds }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { fontSize: "0.72em", color: "var(--sb-muted)", flexShrink: 0 }, children: [
+            "y",
+            i,
+            " off"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "range",
+              min: -sliderRange,
+              max: sliderRange,
+              step,
+              value: off,
+              style: { flex: 1 },
+              onChange: (e) => setDsOffsets((prev) => ({ ...prev, [ds]: Number(e.target.value) }))
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "number",
+              step,
+              value: parseFloat(off.toPrecision(4)),
+              style: { ...inputStyle },
+              onChange: (e) => {
+                const v2 = parseFloat(e.target.value);
+                if (!isNaN(v2)) setDsOffsets((prev) => ({ ...prev, [ds]: v2 }));
+              }
+            }
+          ),
+          off !== 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              className: "chart-btn",
+              style: { padding: "1px 6px", flexShrink: 0 },
+              onClick: () => setDsOffsets((prev) => ({ ...prev, [ds]: 0 })),
+              title: "Reset offset",
+              children: "✕"
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "chart-slider-label", style: { flex: "1 1 100%", gap: 4 }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { fontSize: "0.72em", color: "var(--sb-muted)", flexShrink: 0 }, children: [
+            "y",
+            i,
+            " min"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "number",
+              placeholder: "auto",
+              value: lim2.min,
+              style: { ...inputStyle, flex: 1 },
+              onChange: (e) => setDsYLimits((prev) => ({ ...prev, [ds]: { ...lim2, min: e.target.value } }))
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.72em", color: "var(--sb-muted)", flexShrink: 0 }, children: "max" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "input",
+            {
+              type: "number",
+              placeholder: "auto",
+              value: lim2.max,
+              style: { ...inputStyle, flex: 1 },
+              onChange: (e) => setDsYLimits((prev) => ({ ...prev, [ds]: { ...lim2, max: e.target.value } }))
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.7em", color: "var(--sb-muted)", flexShrink: 0 }, children: unit }),
+          hasLimit && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              className: "chart-btn",
+              style: { padding: "1px 6px", flexShrink: 0 },
+              onClick: () => setDsYLimits((prev) => ({ ...prev, [ds]: { min: "", max: "" } })),
+              title: "Reset y limits",
+              children: "✕"
+            }
+          )
+        ] })
+      ] }, ds);
+    }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-content", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { ref: chartRef, data: formattedChartData, options: chartOptions }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-help", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("small", { children: [
       "Scroll to zoom · Drag to pan · Click points to sync map time",
@@ -37529,7 +38085,8 @@ function TimeSeriesChart() {
         Object.values(bufferData).map((b) => b.n_pixels).join(", "),
         " px"
       ] })
-    ] }) })
+    ] }) }),
+    resizeGrip
   ] });
 }
 function PointManagerPanel() {
@@ -37716,6 +38273,486 @@ function PointManagerPanel() {
     ] }) })
   ] });
 }
+function RefPointChart() {
+  var _a2;
+  const { state } = useAppContext();
+  const { fetchBufferTimeSeries } = useApi();
+  const [bufferData, setBufferData] = reactExports.useState(null);
+  const [loading, setLoading] = reactExports.useState(false);
+  const abortRef = reactExports.useRef(null);
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 520,
+    defaultHeight: 280,
+    initialRight: 16,
+    initialBottom: 20
+  });
+  reactExports.useEffect(() => {
+    var _a3;
+    if (!state.refBufferEnabled || !state.showRefChart || !state.currentDataset) {
+      setBufferData(null);
+      return;
+    }
+    (_a3 = abortRef.current) == null ? void 0 : _a3.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    const [lat, lng] = state.refMarkerPosition;
+    setLoading(true);
+    fetchBufferTimeSeries(lng, lat, state.currentDataset, state.refBufferRadius, 20).then((data) => {
+      if (!ctrl.signal.aborted && data) setBufferData(data);
+    }).finally(() => {
+      if (!ctrl.signal.aborted) setLoading(false);
+    });
+    return () => ctrl.abort();
+  }, [
+    state.refBufferEnabled,
+    state.showRefChart,
+    state.currentDataset,
+    state.refMarkerPosition,
+    state.refBufferRadius
+  ]);
+  if (!state.refBufferEnabled || !state.showRefChart) return null;
+  if (loading) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: panelRef, className: "profile-panel", style: panelStyle, onMouseDown: (e) => e.stopPropagation(), children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-placeholder", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Loading reference buffer…" }) }) });
+  }
+  if (!bufferData || bufferData.labels.length === 0) return null;
+  const { median, samples } = bufferData;
+  const rawLabels = (((_a2 = state.datasetInfo[state.currentDataset]) == null ? void 0 : _a2.x_values) ?? bufferData.labels).map(String);
+  const n2 = rawLabels.length;
+  const toDisplay = (l2) => {
+    const parts = l2.split("_");
+    if (parts.length === 2 && /^\d{8}$/.test(parts[1])) {
+      const d = parts[1];
+      return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
+    }
+    return l2.slice(0, 10);
+  };
+  const displayLabels = rawLabels.map(toDisplay);
+  const mean = Array(n2).fill(0);
+  const std = Array(n2).fill(0);
+  if (samples.length > 0) {
+    for (let t2 = 0; t2 < n2; t2++) {
+      const vals = samples.map((s) => s[t2]).filter((v2) => isFinite(v2));
+      if (vals.length === 0) {
+        mean[t2] = NaN;
+        std[t2] = NaN;
+        continue;
+      }
+      const m2 = vals.reduce((a, b) => a + b, 0) / vals.length;
+      mean[t2] = m2;
+      std[t2] = Math.sqrt(vals.reduce((a, b) => a + (b - m2) ** 2, 0) / vals.length);
+    }
+  }
+  const meanPlusStd = mean.map((m2, i) => isFinite(m2) ? m2 + std[i] : NaN);
+  const meanMinusStd = mean.map((m2, i) => isFinite(m2) ? m2 - std[i] : NaN);
+  const sampleDatasets = samples.slice(0, 8).map((s, i) => ({
+    label: `sample ${i + 1}`,
+    data: s,
+    borderColor: "rgba(150,180,220,0.18)",
+    backgroundColor: "transparent",
+    borderWidth: 1,
+    pointRadius: 0,
+    tension: 0.15
+  }));
+  const chartData = {
+    labels: displayLabels,
+    datasets: [
+      // +1σ bound — fills toward -1σ (dataset index 1)
+      {
+        label: "+1σ",
+        data: meanPlusStd,
+        borderColor: "rgba(77,157,224,0.4)",
+        backgroundColor: "rgba(77,157,224,0.12)",
+        borderWidth: 1,
+        borderDash: [3, 3],
+        pointRadius: 0,
+        fill: { target: 1, above: "rgba(77,157,224,0.12)" },
+        tension: 0.2
+      },
+      // -1σ bound
+      {
+        label: "-1σ",
+        data: meanMinusStd,
+        borderColor: "rgba(77,157,224,0.4)",
+        backgroundColor: "transparent",
+        borderWidth: 1,
+        borderDash: [3, 3],
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2
+      },
+      // Mean
+      {
+        label: "Mean",
+        data: mean,
+        borderColor: "#4d9de0",
+        backgroundColor: "transparent",
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.2
+      },
+      // Median
+      {
+        label: "Median",
+        data: median,
+        borderColor: "#3ec97a",
+        backgroundColor: "transparent",
+        borderWidth: 2,
+        borderDash: [6, 4],
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2
+      },
+      // Individual samples (faint, behind main lines)
+      ...sampleDatasets
+    ]
+  };
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 0 },
+    plugins: {
+      legend: {
+        display: true,
+        labels: {
+          color: "#aaa",
+          filter: (item) => ["Mean", "Median", "+1σ"].includes(item.text),
+          boxWidth: 20,
+          font: { size: 11 }
+        }
+      },
+      tooltip: { mode: "index", intersect: false }
+    },
+    scales: {
+      x: {
+        ticks: { color: "#aaa", maxTicksLimit: 8, maxRotation: 45 },
+        grid: { color: "rgba(255,255,255,0.08)" }
+      },
+      y: {
+        title: { display: true, text: state.currentDataset, color: "#aaa" },
+        ticks: { color: "#aaa" },
+        grid: { color: "rgba(255,255,255,0.08)" }
+      }
+    }
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: panelRef, className: "profile-panel", style: panelStyle, onMouseDown: (e) => e.stopPropagation(), children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "chart-header", onMouseDown: onDragMouseDown, style: { cursor: "grab" }, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("h4", { children: [
+      "Ref Buffer — ",
+      bufferData.n_pixels,
+      " px, r=",
+      state.refBufferRadius,
+      " m"
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { flex: 1, minHeight: 120, position: "relative" }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Line, { data: chartData, options }) }),
+    resizeGrip
+  ] });
+}
+function ColormapBar() {
+  const { state, dispatch } = useAppContext();
+  const [horizontal, setHorizontal] = reactExports.useState(false);
+  const [barFrac, setBarFrac] = reactExports.useState(0.4);
+  const [showBarSlider, setShowBarSlider] = reactExports.useState(false);
+  const [customLabel, setCustomLabel] = reactExports.useState(null);
+  const [customUnit, setCustomUnit] = reactExports.useState(null);
+  const { panelRef, panelStyle, size, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 300,
+    defaultHeight: 160,
+    initialRight: 70,
+    initialBottom: 40,
+    minWidth: 100,
+    minHeight: 80
+  });
+  if (!state.showColorbar) return null;
+  const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
+  const autoUnit = (dsInfo == null ? void 0 : dsInfo.unit) ?? "";
+  const unit = customUnit ?? autoUnit;
+  const autoLabel = (dsInfo == null ? void 0 : dsInfo.label) ?? state.currentDataset ?? "";
+  const label = customLabel ?? autoLabel;
+  const fmt = (v2) => {
+    const abs = Math.abs(v2);
+    if (abs === 0) return "0";
+    if (abs >= 1e4 || abs < 0.01 && abs > 0) return v2.toExponential(2);
+    return parseFloat(v2.toPrecision(4)).toString();
+  };
+  const mid = (state.vmin + state.vmax) / 2;
+  const HEADER_H = 26;
+  const PAD = Math.max(4, Math.min(10, Math.round(Math.min(size.width, size.height) * 0.04)));
+  const bodyW = size.width - PAD * 2;
+  const bodyH = size.height - HEADER_H - PAD * 2;
+  const baseFontPx = Math.max(9, Math.min(14, Math.round(Math.min(bodyW, bodyH) * 0.09)));
+  const numStyle = {
+    fontSize: baseFontPx,
+    color: "var(--sb-text)",
+    fontVariantNumeric: "tabular-nums",
+    whiteSpace: "nowrap",
+    flexShrink: 0,
+    lineHeight: 1.3
+  };
+  const midStyle = {
+    ...numStyle,
+    fontSize: baseFontPx * 0.88
+  };
+  const unitStyle = {
+    ...numStyle,
+    fontSize: baseFontPx * 0.8,
+    color: "var(--sb-muted)"
+  };
+  const barThickH = Math.max(8, Math.round(bodyH * barFrac));
+  const barThickV = Math.max(8, Math.round(bodyW * barFrac));
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      ref: panelRef,
+      style: {
+        ...panelStyle,
+        position: "fixed",
+        background: "var(--sb-surface)",
+        border: "1px solid var(--sb-border)",
+        borderRadius: 10,
+        boxShadow: "0 4px 20px rgba(0,0,0,0.4)",
+        backdropFilter: "blur(8px)",
+        zIndex: 3200,
+        display: "flex",
+        flexDirection: "column",
+        userSelect: "none",
+        minWidth: 100,
+        minHeight: 80
+      },
+      onMouseDown: (e) => e.stopPropagation(),
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            onMouseDown: onDragMouseDown,
+            style: {
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "4px 8px",
+              height: HEADER_H,
+              cursor: "grab",
+              borderBottom: "1px solid var(--sb-border)",
+              flexShrink: 0,
+              gap: 4,
+              boxSizing: "border-box"
+            },
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { flex: 1, minWidth: 0, fontSize: "0.7em", color: "var(--sb-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: "colorbar" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", gap: 3, alignItems: "center", flexShrink: 0 }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "button",
+                  {
+                    onMouseDown: (e) => e.stopPropagation(),
+                    onClick: () => setHorizontal((h) => !h),
+                    title: horizontal ? "Switch to vertical" : "Switch to horizontal",
+                    style: { background: "none", border: "1px solid var(--sb-border)", borderRadius: 4, color: "var(--sb-text)", cursor: "pointer", padding: "1px 6px", fontSize: "0.75em", lineHeight: 1.4 },
+                    children: horizontal ? "⇕" : "⇔"
+                  }
+                ),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "button",
+                  {
+                    onMouseDown: (e) => e.stopPropagation(),
+                    onClick: () => dispatch({ type: "TOGGLE_COLORBAR" }),
+                    title: "Close colorbar",
+                    style: { background: "none", border: "none", color: "var(--sb-muted)", cursor: "pointer", padding: "1px 5px", fontSize: "0.85em", lineHeight: 1 },
+                    children: "✕"
+                  }
+                )
+              ] })
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { flex: 1, padding: PAD, boxSizing: "border-box", display: "flex", flexDirection: "column", gap: PAD * 0.5, overflow: "hidden" }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                value: label,
+                onMouseDown: (e) => e.stopPropagation(),
+                onChange: (e) => setCustomLabel(e.target.value),
+                onBlur: (e) => {
+                  if (!e.target.value.trim()) setCustomLabel(null);
+                },
+                title: "Click to edit label",
+                style: {
+                  flex: 1,
+                  minWidth: 0,
+                  background: "none",
+                  border: "none",
+                  outline: "none",
+                  fontSize: baseFontPx * 0.85,
+                  color: "var(--sb-muted)",
+                  cursor: "text",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap"
+                }
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                value: unit,
+                onMouseDown: (e) => e.stopPropagation(),
+                onChange: (e) => setCustomUnit(e.target.value),
+                onBlur: (e) => {
+                  if (e.target.value === autoUnit) setCustomUnit(null);
+                },
+                placeholder: "unit",
+                title: "Click to edit unit",
+                style: {
+                  width: 32,
+                  flexShrink: 0,
+                  background: "none",
+                  border: "none",
+                  outline: "none",
+                  fontSize: baseFontPx * 0.85,
+                  color: "var(--sb-muted)",
+                  cursor: "text",
+                  textAlign: "right"
+                }
+              }
+            )
+          ] }),
+          horizontal ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "img",
+              {
+                src: `/colorbar/${state.colormap}`,
+                alt: "colorbar",
+                style: {
+                  width: "100%",
+                  height: barThickH,
+                  objectFit: "fill",
+                  borderRadius: 3,
+                  imageRendering: "pixelated",
+                  display: "block",
+                  flexShrink: 0
+                }
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "flex-start" }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: numStyle, children: fmt(state.vmin) }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: midStyle, children: fmt(mid) }),
+                unit && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: unitStyle, children: unit })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: numStyle, children: fmt(state.vmax) })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { marginTop: "auto", flexShrink: 0 }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "button",
+                {
+                  onMouseDown: (e) => e.stopPropagation(),
+                  onClick: () => setShowBarSlider((s) => !s),
+                  style: { background: "none", border: "none", cursor: "pointer", padding: 0, color: "var(--sb-muted)", fontSize: baseFontPx * 0.8, display: "flex", alignItems: "center", gap: 3 },
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid fa-chevron-${showBarSlider ? "up" : "down"}`, style: { fontSize: "0.7em" } }),
+                    "bar height"
+                  ]
+                }
+              ),
+              showBarSlider && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "range",
+                  min: 0.1,
+                  max: 0.9,
+                  step: 0.02,
+                  value: barFrac,
+                  style: { width: "100%", marginTop: 2 },
+                  onMouseDown: (e) => e.stopPropagation(),
+                  onChange: (e) => setBarFrac(Number(e.target.value))
+                }
+              )
+            ] })
+          ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { flex: 1, display: "flex", flexDirection: "row", gap: PAD, minHeight: 0 }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: {
+                position: "relative",
+                width: barThickV,
+                flexShrink: 0,
+                alignSelf: "stretch",
+                overflow: "hidden",
+                borderRadius: 3
+              }, children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "img",
+                {
+                  src: `/colorbar/${state.colormap}`,
+                  alt: "colorbar",
+                  style: {
+                    position: "absolute",
+                    width: bodyH - 30,
+                    height: barThickV,
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%) rotate(-90deg)",
+                    objectFit: "fill",
+                    imageRendering: "pixelated"
+                  }
+                }
+              ) }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: {
+                position: "relative",
+                alignSelf: "stretch",
+                minWidth: 0,
+                flex: 1
+              }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { ...numStyle, position: "absolute", top: 0, left: 0 }, children: fmt(state.vmax) }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: {
+                  ...midStyle,
+                  position: "absolute",
+                  top: "50%",
+                  left: 0,
+                  transform: "translateY(-50%)",
+                  whiteSpace: "nowrap"
+                }, children: fmt(mid) }),
+                unit && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: {
+                  ...unitStyle,
+                  position: "absolute",
+                  top: "50%",
+                  right: 0,
+                  transform: "translateY(-50%) rotate(-90deg)",
+                  whiteSpace: "nowrap",
+                  display: "inline-block"
+                }, children: unit }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { ...numStyle, position: "absolute", bottom: 0, left: 0 }, children: fmt(state.vmin) })
+              ] })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { flexShrink: 0 }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "button",
+                {
+                  onMouseDown: (e) => e.stopPropagation(),
+                  onClick: () => setShowBarSlider((s) => !s),
+                  style: { background: "none", border: "none", cursor: "pointer", padding: 0, color: "var(--sb-muted)", fontSize: baseFontPx * 0.8, display: "flex", alignItems: "center", gap: 3 },
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: `fa-solid fa-chevron-${showBarSlider ? "up" : "down"}`, style: { fontSize: "0.7em" } }),
+                    "bar width"
+                  ]
+                }
+              ),
+              showBarSlider && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "range",
+                  min: 0.1,
+                  max: 0.9,
+                  step: 0.02,
+                  value: barFrac,
+                  style: { width: "100%", marginTop: 2 },
+                  onMouseDown: (e) => e.stopPropagation(),
+                  onChange: (e) => setBarFrac(Number(e.target.value))
+                }
+              )
+            ] })
+          ] })
+        ] }),
+        resizeGrip
+      ]
+    }
+  );
+}
 function AppContent() {
   const { state, dispatch } = useAppContext();
   const { fetchDatasets, fetchDataMode, fetchConfig } = useApi();
@@ -37750,7 +38787,9 @@ function AppContent() {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "map-container", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(MapContainer, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(PointManagerPanel, {}),
-      state.showChart && /* @__PURE__ */ jsxRuntimeExports.jsx(TimeSeriesChart, {})
+      /* @__PURE__ */ jsxRuntimeExports.jsx(RefPointChart, {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ColormapBar, {}),
+      state.showChart && state.chartWindows.map((w2) => /* @__PURE__ */ jsxRuntimeExports.jsx(TimeSeriesChart, { windowId: w2.id }, w2.id))
     ] })
   ] });
 }

--- a/src/bowser/dist/index.js
+++ b/src/bowser/dist/index.js
@@ -7044,13 +7044,11 @@ const initialState = {
   selectedPointId: null,
   showTrends: false,
   showResiduals: false,
-  coherenceThreshold: 0,
-  phaseSimilarityThreshold: 0,
+  layerMasks: [],
   customMaskPath: null,
   bufferEnabled: false,
   bufferRadius: 500,
   bufferSamples: 10,
-  invResidThreshold: 0,
   pickingEnabled: true,
   refEnabled: true,
   showProfile: false,
@@ -7180,10 +7178,17 @@ function appReducer(state, action) {
       return { ...state, opacity: action.payload };
     case "TOGGLE_RESIDUALS":
       return { ...state, showResiduals: !state.showResiduals };
-    case "SET_COHERENCE_THRESHOLD":
-      return { ...state, coherenceThreshold: action.payload };
-    case "SET_PHASE_SIMILARITY_THRESHOLD":
-      return { ...state, phaseSimilarityThreshold: action.payload };
+    case "ADD_LAYER_MASK":
+      return { ...state, layerMasks: [...state.layerMasks, action.payload] };
+    case "REMOVE_LAYER_MASK":
+      return { ...state, layerMasks: state.layerMasks.filter((m2) => m2.id !== action.payload) };
+    case "UPDATE_LAYER_MASK":
+      return {
+        ...state,
+        layerMasks: state.layerMasks.map(
+          (m2) => m2.id === action.payload.id ? { ...m2, ...action.payload.updates } : m2
+        )
+      };
     case "SET_CUSTOM_MASK_PATH":
       return { ...state, customMaskPath: action.payload };
     case "TOGGLE_BUFFER":
@@ -7192,8 +7197,6 @@ function appReducer(state, action) {
       return { ...state, bufferRadius: action.payload };
     case "SET_BUFFER_SAMPLES":
       return { ...state, bufferSamples: action.payload };
-    case "SET_INV_RESID_THRESHOLD":
-      return { ...state, invResidThreshold: action.payload };
     case "TOGGLE_PICKING":
       return { ...state, pickingEnabled: !state.pickingEnabled };
     case "TOGGLE_REF_ENABLED":
@@ -7267,16 +7270,14 @@ function useApi() {
       return void 0;
     }
   }, []);
-  const fetchMultiPointTimeSeries = reactExports.useCallback(async (points, datasetName, refLon, refLat, calculateTrends = false, coherenceMin = 0, phaseSimilarityMin = 0, invResidMax = 0, refBufferM = 0) => {
+  const fetchMultiPointTimeSeries = reactExports.useCallback(async (points, datasetName, refLon, refLat, calculateTrends = false, layerMasks = [], refBufferM = 0) => {
     const payload = {
       points,
       dataset_name: datasetName,
       ref_lon: refLon,
       ref_lat: refLat,
       calculate_trends: calculateTrends,
-      coherence_min: coherenceMin,
-      phase_similarity_min: phaseSimilarityMin,
-      inv_resid_max: invResidMax,
+      layer_masks: layerMasks.map((m2) => ({ dataset: m2.dataset, threshold: m2.threshold, mode: m2.mode })),
       ref_buffer_m: refBufferM
     };
     try {
@@ -7320,7 +7321,7 @@ function useApi() {
       return void 0;
     }
   }, []);
-  const fetchBufferTimeSeries = reactExports.useCallback(async (lon, lat, datasetName, bufferM, nSamples, refLon, refLat, coherenceMin = 0, phaseSimilarityMin = 0, invResidMax = 0, refBufferM = 0) => {
+  const fetchBufferTimeSeries = reactExports.useCallback(async (lon, lat, datasetName, bufferM, nSamples, refLon, refLat, layerMasks = [], refBufferM = 0) => {
     try {
       const response = await fetch("/buffer_timeseries", {
         method: "POST",
@@ -7333,9 +7334,7 @@ function useApi() {
           n_samples: nSamples,
           ref_lon: refLon ?? null,
           ref_lat: refLat ?? null,
-          coherence_min: coherenceMin,
-          phase_similarity_min: phaseSimilarityMin,
-          inv_resid_max: invResidMax,
+          layer_masks: layerMasks.map((m2) => ({ dataset: m2.dataset, threshold: m2.threshold, mode: m2.mode })),
           ref_buffer_m: refBufferM
         })
       });
@@ -17256,439 +17255,46 @@ function MeasureTool({ active, onDeactivate }) {
       clearAll();
       return;
     }
-    const controller = new AbortController();
-    const signal = controller.signal;
-    const updateTileLayer2 = async () => {
-      const currentDatasetInfo = state.datasetInfo[state.currentDataset];
-      const colormap = state.colormap;
-      const vmin = state.vmin;
-      const vmax = state.vmax;
-      const maxIdx = currentDatasetInfo.x_values.length - 1;
-      const timeIdx = Math.max(0, Math.min(state.currentTimeIndex, maxIdx));
-      const params = {
-        variable: state.currentDataset,
-        time_idx: timeIdx.toString(),
-        rescale: `${vmin},${vmax}`,
-        colormap_name: colormap
-      };
-      if (currentDatasetInfo.algorithm) {
-        params.algorithm = currentDatasetInfo.algorithm;
-      }
-      if (state.refValues[state.currentDataset] && currentDatasetInfo.algorithm === "shift") {
-        const shift = state.refValues[state.currentDataset][timeIdx];
-        if (shift !== void 0) {
-          params.algorithm_params = JSON.stringify({ shift });
-        }
-      }
-      if (state.dataMode === "cog") {
-        const url = currentDatasetInfo.file_list[timeIdx];
-        const maskUrl = currentDatasetInfo.mask_file_list[timeIdx];
-        const maskMinValue = currentDatasetInfo.mask_min_value;
-        params.url = url;
-        if (maskUrl) params.mask = encodeURIComponent(maskUrl);
-        if (maskMinValue !== void 0) params.mask_min_value = maskMinValue.toString();
-      }
-      const urlParams = new URLSearchParams(params).toString();
-      const endpoint = state.dataMode === "md" ? `/md/WebMercatorQuad/tilejson.json?${urlParams}` : `/cog/WebMercatorQuad/tilejson.json?${urlParams}`;
-      try {
-        const response = await fetch(endpoint, { signal });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const tileInfo = await response.json();
-        if (!signal.aborted) setTileUrl(tileInfo.tiles[0]);
-      } catch (err) {
-        if (err.name !== "AbortError") {
-          console.error("Error fetching tile info:", err);
-        }
+    map2.getContainer().style.cursor = "crosshair";
+    const onClick = (e) => {
+      const pts = pointsRef.current;
+      pts.push(e.latlng);
+      const dot = L$1.circleMarker(e.latlng, {
+        radius: 4,
+        color: "#4d9de0",
+        fillColor: "#4d9de0",
+        fillOpacity: 1,
+        weight: 2
+      }).addTo(map2);
+      markersRef.current.push(dot);
+      if (pts.length > 1) {
+        const seg = L$1.polyline([pts[pts.length - 2], pts[pts.length - 1]], {
+          color: "#4d9de0",
+          weight: 2,
+          dashArray: "6 4"
+        }).addTo(map2);
+        linesRef.current.push(seg);
+        const total = pts.reduce((acc, p2, i) => i === 0 ? 0 : acc + pts[i - 1].distanceTo(p2), 0);
+        if (labelRef.current) labelRef.current.remove();
+        labelRef.current = L$1.popup({ closeButton: false, autoClose: false, closeOnClick: false }).setLatLng(e.latlng).setContent(`<b>${fmtDist(total)}</b>`).openOn(map2);
       }
     };
-    updateTileLayer2();
-    return () => controller.abort();
-  }, [
-    state.currentDataset,
-    state.currentTimeIndex,
-    state.datasetInfo,
-    state.dataMode,
-    state.refValues,
-    state.refMarkerPosition,
-    state.colormap,
-    state.vmin,
-    state.vmax
-  ]);
-  if (!tileUrl) return null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(
-    TileLayer,
-    {
-      url: tileUrl,
-      opacity: state.opacity,
-      maxZoom: 19
-    },
-    tileUrl
-  );
-}
-function MarkerEventHandlers() {
-  const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
-  const map2 = useMap();
-  const handleMarkerClick = (position, pointName) => {
-    const [lat, lng] = position;
-    const content = pointName ? `${pointName} (lon, lat):
-(${lng.toFixed(6)}, ${lat.toFixed(6)})` : `Reference (lon, lat):
-(${lng.toFixed(6)}, ${lat.toFixed(6)})`;
-    L$1.popup().setLatLng([lat, lng]).setContent(content).openOn(map2);
-  };
-  const handleTsMarkerDragEnd = (pointId) => (e) => {
-    const marker = e.target;
-    const position = marker.getLatLng();
-    dispatch({
-      type: "UPDATE_TIME_SERIES_POINT",
-      payload: {
-        id: pointId,
-        updates: { position: [position.lat, position.lng] }
-      }
-    });
-  };
-  const handleRefMarkerDragEnd = async (e) => {
-    const marker = e.target;
-    const position = marker.getLatLng();
-    const lat = position.lat;
-    const lng = position.lng;
-    dispatch({ type: "SET_REF_MARKER_POSITION", payload: [lat, lng] });
-    const ds = state.currentDataset;
-    const info = ds ? state.datasetInfo[ds] : null;
-    if (ds && (info == null ? void 0 : info.algorithm) === "shift") {
-      try {
-        const values = await fetchPointTimeSeries(lng, lat, ds);
-        if (values) {
-          dispatch({
-            type: "SET_REF_VALUES",
-            payload: { dataset: ds, values }
-          });
-        }
-      } catch (err) {
-        console.error("Error updating reference values after drag:", err);
-      }
-    }
-  };
-  const handleTsMarkerDoubleClick = (pointId) => () => {
-    dispatch({ type: "REMOVE_TIME_SERIES_POINT", payload: pointId });
-  };
-  const createColoredIcon = (color2, isSelected = false) => {
-    const iconSize = isSelected ? 25 : 20;
-    return L$1.divIcon({
-      html: `<div style="
-        width: ${iconSize}px;
-        height: ${iconSize}px;
-        background-color: ${color2};
-        border: ${isSelected ? "3px solid white" : "2px solid white"};
-        border-radius: 50%;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-      "></div>`,
-      iconSize: [iconSize, iconSize],
-      className: "custom-colored-marker"
-    });
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-    state.timeSeriesPoints.filter((p2) => p2.visible).map((point) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-      Marker,
-      {
-        position: point.position,
-        icon: createColoredIcon(point.color, state.selectedPointId === point.id),
-        draggable: true,
-        title: `${point.name} - Double-click to remove`,
-        eventHandlers: {
-          click: () => {
-            handleMarkerClick(point.position, point.name);
-            dispatch({ type: "SET_SELECTED_POINT", payload: point.id });
-          },
-          dragend: handleTsMarkerDragEnd(point.id),
-          dblclick: handleTsMarkerDoubleClick(point.id)
-        }
-      },
-      point.id
-    )),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      Marker,
-      {
-        position: state.refMarkerPosition,
-        icon: fontAwesomeIcon,
-        draggable: true,
-        title: "Reference Location",
-        eventHandlers: {
-          click: () => handleMarkerClick(state.refMarkerPosition),
-          dragend: handleRefMarkerDragEnd
-        }
-      }
-    )
-  ] });
-}
-function MapContainer() {
-  const { state } = useAppContext();
-  const getInitialCenter = () => {
-    if (state.currentDataset && state.datasetInfo[state.currentDataset]) {
-      const bounds = state.datasetInfo[state.currentDataset].latlon_bounds;
-      const centerLat = (bounds[1] + bounds[3]) / 2;
-      const centerLng = (bounds[0] + bounds[2]) / 2;
-      return [centerLat, centerLng];
-    }
-    const datasets = Object.values(state.datasetInfo);
-    if (datasets.length > 0) {
-      const bounds = datasets[0].latlon_bounds;
-      const centerLat = (bounds[1] + bounds[3]) / 2;
-      const centerLng = (bounds[0] + bounds[2]) / 2;
-      return [centerLat, centerLng];
-    }
-    return [0, 0];
-  };
-  const selectedBasemap = baseMaps[state.selectedBasemap] || baseMaps.esriSatellite;
-  const center = getInitialCenter();
-  const hasDatasets = Object.keys(state.datasetInfo).length > 0;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    MapContainer$1,
-    {
-      center,
-      zoom: 9,
-      style: { height: "100%", width: "100%" },
-      doubleClickZoom: false,
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          TileLayer,
-          {
-            url: selectedBasemap.url,
-            attribution: selectedBasemap.attribution,
-            maxZoom: 19
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(RasterTileLayer, {}),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(MarkerEventHandlers, {}),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(MapEvents, {}),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(MousePosition, {})
-      ]
-    },
-    hasDatasets ? "with-data" : "no-data"
-  );
-}
-const colormapOptions = [
-  { value: "rdbu_r", label: "Blue-Red" },
-  { value: "twilight", label: "Twilight (cyclic)" },
-  { value: "cfastie", label: "CFastie" },
-  { value: "rplumbo", label: "RPlumbo" },
-  { value: "schwarzwald", label: "Schwarzwald (elevation)" },
-  { value: "viridis", label: "Viridis" },
-  { value: "bugn", label: "Blue-Green" },
-  { value: "ylgn", label: "Yellow-Green" },
-  { value: "magma", label: "Magma" },
-  { value: "gist_earth", label: "Earth" },
-  { value: "ocean", label: "Ocean" },
-  { value: "terrain", label: "Terrain" }
-];
-function ControlPanel() {
-  const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
-  const [draftVmin, setDraftVmin] = reactExports.useState(String(state.vmin));
-  const [draftVmax, setDraftVmax] = reactExports.useState(String(state.vmax));
-  reactExports.useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
-  reactExports.useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
-  reactExports.useEffect(() => {
-    const datasetName = state.currentDataset;
-    if (!datasetName) return;
-    const safeNumToString = (x2) => Object.is(x2, -0) ? "-0" : String(x2);
-    localStorage.setItem(`${datasetName}-colormap_name`, state.colormap);
-    localStorage.setItem(`${datasetName}-vmin`, safeNumToString(state.vmin));
-    localStorage.setItem(`${datasetName}-vmax`, safeNumToString(state.vmax));
-  }, [state.colormap, state.vmin, state.vmax]);
-  reactExports.useEffect(() => {
-    const datasetName = state.currentDataset;
-    if (!datasetName) return;
-    const colormap = localStorage.getItem(`${datasetName}-colormap_name`);
-    const vminStr = localStorage.getItem(`${datasetName}-vmin`);
-    const vmaxStr = localStorage.getItem(`${datasetName}-vmax`);
-    if (colormap) dispatch({ type: "SET_COLORMAP", payload: colormap });
-    if (vminStr !== null) {
-      const v2 = Number(vminStr);
-      if (!Number.isNaN(v2)) dispatch({ type: "SET_VMIN", payload: v2 });
-    }
-    if (vmaxStr !== null) {
-      const v2 = Number(vmaxStr);
-      if (!Number.isNaN(v2)) dispatch({ type: "SET_VMAX", payload: v2 });
-    }
-  }, [state.currentDataset, dispatch]);
-  const handleDatasetChange = (datasetName) => {
-    dispatch({ type: "SET_CURRENT_DATASET", payload: datasetName });
-    const currentDatasetInfo2 = state.datasetInfo[datasetName];
-    if ((currentDatasetInfo2 == null ? void 0 : currentDatasetInfo2.uses_spatial_ref) && !state.refValues[datasetName]) {
-      setRefValues(datasetName);
-    }
-  };
-  const handleTimeIndexChange = (newIndex) => {
-    dispatch({ type: "SET_TIME_INDEX", payload: newIndex });
-  };
-  const handleColormapChange = (colormap) => {
-    dispatch({ type: "SET_COLORMAP", payload: colormap });
-  };
-  const commitVmin = reactExports.useCallback(() => {
-    const v2 = Number(draftVmin);
-    if (!Number.isNaN(v2)) {
-      dispatch({ type: "SET_VMIN", payload: v2 });
-    }
-  }, [draftVmin, dispatch]);
-  const commitVmax = reactExports.useCallback(() => {
-    const v2 = Number(draftVmax);
-    if (!Number.isNaN(v2)) {
-      dispatch({ type: "SET_VMAX", payload: v2 });
-    }
-  }, [draftVmax, dispatch]);
-  const handleOpacityChange = (opacity) => {
-    dispatch({ type: "SET_OPACITY", payload: opacity });
-  };
-  const handleBasemapChange = (basemapKey) => {
-    dispatch({ type: "SET_BASEMAP", payload: basemapKey });
-  };
-  const toggleChart = () => {
-    dispatch({ type: "TOGGLE_CHART" });
-  };
-  const setRefValues = async (datasetName) => {
-    const [lat, lng] = state.refMarkerPosition;
-    try {
-      const values = await fetchPointTimeSeries(lng, lat, datasetName);
-      if (values) {
-        dispatch({
-          type: "SET_REF_VALUES",
-          payload: { dataset: datasetName, values }
-        });
-      }
-    } catch (error) {
-      console.error("Error setting reference values:", error);
-    }
-  };
-  const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
-  const currentTimeValue = currentDatasetInfo ? currentDatasetInfo.x_values[state.currentTimeIndex] : "";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "menu", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "menu-content", className: "pure-form", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "menu-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-layer-group" }),
-          " Layers"
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "select-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "select",
-          {
-            value: state.currentDataset,
-            onChange: (e) => handleDatasetChange(e.target.value),
-            children: Object.keys(state.datasetInfo).map((datasetName) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: datasetName, children: datasetName }, datasetName))
-          }
-        ) })
-      ] }),
-      currentDatasetInfo && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "menu-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { htmlFor: "layer-slider", children: [
-          "Viewing Image: ",
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "layer-slider-value", children: currentTimeValue })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            id: "layer-slider",
-            className: "input",
-            type: "range",
-            min: "0",
-            max: currentDatasetInfo.x_values.length - 1,
-            step: "1",
-            value: state.currentTimeIndex,
-            onChange: (e) => handleTimeIndexChange(parseInt(e.target.value))
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "menu-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "colormap-section", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-palette" }),
-            " Color Map"
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "select-container", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "select",
-            {
-              value: state.colormap,
-              onChange: (e) => handleColormapChange(e.target.value),
-              children: colormapOptions.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: option.value, children: option.label }, option.value))
-            }
-          ) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "img",
-            {
-              id: "colormap-img",
-              src: `/colorbar/${state.colormap}`,
-              style: { maxWidth: "100%", height: "auto" },
-              alt: "Colormap"
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "minmax-data", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: "Rescale color limits" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              className: "input",
-              type: "text",
-              inputMode: "decimal",
-              value: draftVmin,
-              onChange: (e) => setDraftVmin(e.target.value),
-              onBlur: commitVmin,
-              onKeyDown: (e) => e.key === "Enter" && commitVmin()
-            }
-          ) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              className: "input",
-              type: "text",
-              inputMode: "decimal",
-              value: draftVmax,
-              onChange: (e) => setDraftVmax(e.target.value),
-              onBlur: commitVmax,
-              onKeyDown: (e) => e.key === "Enter" && commitVmax()
-            }
-          ) })
-        ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "menu-group pure-form", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { id: "opacity-slider-container", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { htmlFor: "opacity-slider", children: [
-          "Opacity: ",
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { id: "opacity-slider-value", children: state.opacity })
-        ] }) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            id: "opacity-slider",
-            className: "input",
-            type: "range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.opacity,
-            onChange: (e) => handleOpacityChange(parseFloat(e.target.value))
-          }
-        )
-      ] }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "select-container", children: [
-        "Basemap:",
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "select",
-          {
-            value: state.selectedBasemap,
-            onChange: (e) => handleBasemapChange(e.target.value),
-            children: Object.entries(baseMaps).map(([key]) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: key, children: key }, key))
-          }
-        )
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "menu-group", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "menu-chart", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "button",
-      {
-        className: "pure-button pure-button-primary",
-        onClick: toggleChart,
-        children: state.showChart ? "Hide time series" : "Show time series"
-      }
-    ) }) })
-  ] });
+    const onDblClick = (e) => {
+      L$1.DomEvent.stop(e);
+      onDeactivate();
+    };
+    map2.on("click", onClick);
+    map2.on("dblclick", onDblClick);
+    map2.doubleClickZoom.disable();
+    return () => {
+      map2.off("click", onClick);
+      map2.off("dblclick", onDblClick);
+      map2.doubleClickZoom.enable();
+      map2.getContainer().style.cursor = "";
+      clearAll();
+    };
+  }, [active, map2]);
+  return null;
 }
 /*!
  * @kurkle/color v0.3.4
@@ -29840,13 +29446,14 @@ function RasterTileLayer() {
         if (maskUrl) params.mask = encodeURIComponent(maskUrl);
         if (maskMinValue !== void 0) params.mask_min_value = maskMinValue.toString();
         if (state.customMaskPath) params.custom_mask = state.customMaskPath;
-        if (state.coherenceThreshold > 0) params.coherence_min = state.coherenceThreshold.toString();
-        if (state.phaseSimilarityThreshold > 0) params.phase_similarity_min = state.phaseSimilarityThreshold.toString();
+        params.time_idx = timeIdx.toString();
+      }
+      if (state.layerMasks.length > 0) {
+        params.layer_masks = JSON.stringify(
+          state.layerMasks.map((m2) => ({ dataset: m2.dataset, threshold: m2.threshold, mode: m2.mode }))
+        );
       }
       if (state.dataMode === "md") {
-        if (state.coherenceThreshold > 0) params.coherence_min = state.coherenceThreshold.toString();
-        if (state.phaseSimilarityThreshold > 0) params.phase_similarity_min = state.phaseSimilarityThreshold.toString();
-        if (state.invResidThreshold > 0) params.inv_resid_max = state.invResidThreshold.toString();
         if (state.customMaskPath) params.custom_mask_path = state.customMaskPath;
       }
       const urlParams = new URLSearchParams(params).toString();
@@ -29875,9 +29482,7 @@ function RasterTileLayer() {
     state.colormap,
     state.vmin,
     state.vmax,
-    state.coherenceThreshold,
-    state.phaseSimilarityThreshold,
-    state.invResidThreshold,
+    state.layerMasks,
     state.customMaskPath
   ]);
   if (!tileUrl) return null;
@@ -29893,7 +29498,7 @@ function RasterTileLayer() {
 }
 function MarkerEventHandlers() {
   const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
+  const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const map2 = useMap();
   const handleMarkerClick = (position, pointName) => {
     const [lat, lng] = position;
@@ -29914,6 +29519,7 @@ function MarkerEventHandlers() {
     });
   };
   const handleRefMarkerDragEnd = async (e) => {
+    var _a2, _b2, _c;
     const marker = e.target;
     const position = marker.getLatLng();
     const lat = position.lat;
@@ -29923,12 +29529,20 @@ function MarkerEventHandlers() {
     const info = ds ? state.datasetInfo[ds] : null;
     if (ds && (info == null ? void 0 : info.algorithm) === "shift") {
       try {
-        const values = await fetchPointTimeSeries(lng, lat, ds);
+        let values;
+        if (state.refBufferEnabled && state.refBufferRadius > 0) {
+          const result = await fetchBufferTimeSeries(lng, lat, ds, state.refBufferRadius, 0);
+          if (result == null ? void 0 : result.median) {
+            const xValues = ((_b2 = (_a2 = state.datasetInfo[ds]) == null ? void 0 : _a2.x_values) == null ? void 0 : _b2.map(String)) ?? ((_c = result.labels) == null ? void 0 : _c.map(String)) ?? [];
+            const byX = Object.fromEntries(result.median.map((pt) => [String(pt.x), pt.y]));
+            values = xValues.map((x2) => byX[x2] ?? NaN);
+          }
+        }
+        if (!values) {
+          values = await fetchPointTimeSeries(lng, lat, ds);
+        }
         if (values) {
-          dispatch({
-            type: "SET_REF_VALUES",
-            payload: { dataset: ds, values }
-          });
+          dispatch({ type: "SET_REF_VALUES", payload: { dataset: ds, values } });
         }
       } catch (err) {
         console.error("Error updating reference values after drag:", err);
@@ -30173,19 +29787,19 @@ const colormapOptions = [
 ];
 function ControlPanel() {
   const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
+  const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [draftVmin, setDraftVmin] = reactExports.useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = reactExports.useState(String(state.vmax));
   reactExports.useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
   reactExports.useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
   reactExports.useEffect(() => {
-    const ds = state.currentDataset;
-    if (!ds) return;
-    const safeStr = (x2) => Object.is(x2, -0) ? "-0" : String(x2);
-    localStorage.setItem(`${ds}-colormap_name`, state.colormap);
-    localStorage.setItem(`${ds}-vmin`, safeStr(state.vmin));
-    localStorage.setItem(`${ds}-vmax`, safeStr(state.vmax));
-  }, [state.currentDataset, state.colormap, state.vmin, state.vmax]);
+    const datasetName = state.currentDataset;
+    if (!datasetName) return;
+    const safeNumToString = (x2) => Object.is(x2, -0) ? "-0" : String(x2);
+    localStorage.setItem(`${datasetName}-colormap_name`, state.colormap);
+    localStorage.setItem(`${datasetName}-vmin`, safeNumToString(state.vmin));
+    localStorage.setItem(`${datasetName}-vmax`, safeNumToString(state.vmax));
+  }, [state.colormap, state.vmin, state.vmax]);
   reactExports.useEffect(() => {
     const ds = state.currentDataset;
     if (!ds) return;
@@ -30211,8 +29825,15 @@ function ControlPanel() {
   const handleDatasetChange = (ds) => {
     dispatch({ type: "SET_CURRENT_DATASET", payload: ds });
     const info = state.datasetInfo[ds];
-    if ((info == null ? void 0 : info.uses_spatial_ref) && !state.refValues[ds]) setRefValues(ds);
+    if (info == null ? void 0 : info.uses_spatial_ref) setRefValues(ds);
   };
+  reactExports.useEffect(() => {
+    const ds = state.currentDataset;
+    if (!ds) return;
+    const info = state.datasetInfo[ds];
+    if (!(info == null ? void 0 : info.uses_spatial_ref)) return;
+    setRefValues(ds);
+  }, [state.refBufferEnabled, state.refBufferRadius]);
   const commitVmin = reactExports.useCallback(() => {
     const v2 = Number(draftVmin);
     if (!Number.isNaN(v2)) dispatch({ type: "SET_VMIN", payload: v2 });
@@ -30222,9 +29843,21 @@ function ControlPanel() {
     if (!Number.isNaN(v2)) dispatch({ type: "SET_VMAX", payload: v2 });
   }, [draftVmax, dispatch]);
   const setRefValues = async (ds) => {
+    var _a2, _b2, _c;
     const [lat, lng] = state.refMarkerPosition;
     try {
-      const values = await fetchPointTimeSeries(lng, lat, ds);
+      let values;
+      if (state.refBufferEnabled && state.refBufferRadius > 0) {
+        const result = await fetchBufferTimeSeries(lng, lat, ds, state.refBufferRadius, 0);
+        if (result == null ? void 0 : result.median) {
+          const xValues = ((_b2 = (_a2 = state.datasetInfo[ds]) == null ? void 0 : _a2.x_values) == null ? void 0 : _b2.map(String)) ?? ((_c = result.labels) == null ? void 0 : _c.map(String)) ?? [];
+          const byX = Object.fromEntries(result.median.map((pt) => [String(pt.x), pt.y]));
+          values = xValues.map((x2) => byX[x2] ?? NaN);
+        }
+      }
+      if (!values) {
+        values = await fetchPointTimeSeries(lng, lat, ds);
+      }
       if (values) dispatch({ type: "SET_REF_VALUES", payload: { dataset: ds, values } });
     } catch (error) {
       console.error("Error setting reference values:", error);
@@ -30387,10 +30020,45 @@ function ControlPanel() {
         /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-mask" }),
         " Masking"
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
+      state.layerMasks.map((mask) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "layer-mask-row", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", alignItems: "center", gap: 4, marginBottom: 4 }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "select",
+            {
+              className: "sidebar-select",
+              style: { flex: 1, fontSize: "0.78em" },
+              value: mask.dataset,
+              onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { dataset: e.target.value } } }),
+              children: Object.keys(state.datasetInfo).map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: name, children: name }, name))
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "select",
+            {
+              className: "sidebar-select",
+              style: { width: 56, fontSize: "0.78em", padding: "2px 4px" },
+              value: mask.mode,
+              onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { mode: e.target.value } } }),
+              children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "min", children: "≥" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "max", children: "≤" })
+              ]
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              className: "hist-btn",
+              style: { color: "var(--sb-red)", padding: "2px 6px", flexShrink: 0 },
+              onClick: () => dispatch({ type: "REMOVE_LAYER_MASK", payload: mask.id }),
+              title: "Remove mask",
+              children: /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-xmark" })
+            }
+          )
+        ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Temporal coherence ≥" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.coherenceThreshold === 0 ? "off" : state.coherenceThreshold.toFixed(2) })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.75em", color: "var(--sb-muted)" }, children: "Threshold (normalised)" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: mask.threshold.toFixed(2) })
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "input",
@@ -30400,48 +30068,35 @@ function ControlPanel() {
             min: "0",
             max: "1",
             step: "0.01",
-            value: state.coherenceThreshold,
-            onChange: (e) => dispatch({ type: "SET_COHERENCE_THRESHOLD", payload: parseFloat(e.target.value) })
+            value: mask.threshold,
+            onChange: (e) => dispatch({ type: "UPDATE_LAYER_MASK", payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })
           }
         )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Phase similarity ≥" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.phaseSimilarityThreshold === 0 ? "off" : state.phaseSimilarityThreshold.toFixed(2) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.phaseSimilarityThreshold,
-            onChange: (e) => dispatch({ type: "SET_PHASE_SIMILARITY_THRESHOLD", payload: parseFloat(e.target.value) })
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-group", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "slider-label", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Inversion residuals ≤" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "slider-value", children: state.invResidThreshold === 0 ? "off" : state.invResidThreshold.toFixed(2) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "input",
-          {
-            type: "range",
-            className: "sidebar-range",
-            min: "0",
-            max: "1",
-            step: "0.01",
-            value: state.invResidThreshold,
-            onChange: (e) => dispatch({ type: "SET_INV_RESID_THRESHOLD", payload: parseFloat(e.target.value) })
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-row", children: [
+      ] }, mask.id)),
+      Object.keys(state.datasetInfo).length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          className: "hist-btn",
+          style: { width: "100%", marginTop: 4 },
+          onClick: () => {
+            const firstDataset = Object.keys(state.datasetInfo)[0];
+            dispatch({
+              type: "ADD_LAYER_MASK",
+              payload: {
+                id: `mask_${Date.now()}`,
+                dataset: firstDataset,
+                threshold: 0.5,
+                mode: "min"
+              }
+            });
+          },
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-plus", style: { marginRight: 5 } }),
+            "Add layer mask"
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-row", style: { marginTop: 8 }, children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "minmax-label", style: { marginBottom: 4 }, children: "Custom mask (GeoTIFF)" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "custom-mask-controls", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "hist-btn", style: { cursor: "pointer", textAlign: "center" }, children: [
@@ -34386,9 +34041,7 @@ function TimeSeriesChart() {
         refLon,
         refLat,
         state.showTrends,
-        state.coherenceThreshold,
-        state.phaseSimilarityThreshold,
-        state.invResidThreshold,
+        state.layerMasks,
         state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
       );
       if (tsData) {
@@ -34428,9 +34081,7 @@ function TimeSeriesChart() {
     state.refEnabled,
     state.datasetInfo,
     state.showTrends,
-    state.coherenceThreshold,
-    state.phaseSimilarityThreshold,
-    state.invResidThreshold,
+    state.layerMasks,
     fetchMultiPointTimeSeries
   ]);
   reactExports.useEffect(() => {
@@ -34461,9 +34112,7 @@ function TimeSeriesChart() {
           state.bufferSamples,
           refLon,
           refLat,
-          state.coherenceThreshold,
-          state.phaseSimilarityThreshold,
-          state.invResidThreshold,
+          state.layerMasks,
           state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0
         );
         return { id: p2.id, result };
@@ -34484,9 +34133,7 @@ function TimeSeriesChart() {
     state.refEnabled,
     state.refBufferEnabled,
     state.refBufferRadius,
-    state.coherenceThreshold,
-    state.phaseSimilarityThreshold,
-    state.invResidThreshold,
+    state.layerMasks,
     JSON.stringify(state.timeSeriesPoints.map((p2) => ({ id: p2.id, position: p2.position, visible: p2.visible }))),
     state.refMarkerPosition,
     fetchBufferTimeSeries

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -6,6 +6,13 @@ import warnings
 from pathlib import Path
 from typing import Annotated, Any, Callable, Optional
 
+# Register custom colormaps in rio_tiler BEFORE titiler.core.dependencies is
+# imported.  titiler captures cmap.list() into a Literal type annotation at
+# import time, so reversed variants (cfastie_r, etc.) must be in the registry
+# before that happens.
+from .utils import calculate_trend, desensitize_mpl_case, generate_colorbar, register_custom_colormaps
+register_custom_colormaps()
+
 import matplotlib
 import numpy as np
 import rasterio
@@ -25,7 +32,6 @@ from titiler.core.factory import TilerFactory
 from .config import settings
 from .readers import CustomReader
 from .titiler import Amplitude, JSONResponse, Phase, RasterGroup, Rewrap, Shift
-from .utils import calculate_trend, desensitize_mpl_case, generate_colorbar
 
 logger = logging.getLogger("bowser")
 warnings.filterwarnings(
@@ -238,9 +244,8 @@ def _apply_layer_masks_md(
     """Apply a list of layer mask dicts to a DataArray (MD mode).
 
     Each dict has keys: dataset (str), threshold (float), mode ('min'|'max').
-    threshold is always 0–1 normalised; it is scaled to the mask layer's
-    actual data range before comparison.
-    'min' keeps pixels >= scaled_threshold; 'max' keeps pixels <= scaled_threshold.
+    threshold is an absolute value in the mask layer's data units.
+    'min' keeps pixels >= threshold; 'max' keeps pixels <= threshold.
     """
     for m in layer_masks:
         var = m.get("dataset")
@@ -251,12 +256,10 @@ def _apply_layer_masks_md(
         mask_da = XARRAY_DATASET[var]
         if time_idx is not None and "time" in mask_da.dims:
             mask_da = mask_da.isel(time=time_idx)
-        vmin, vmax = _md_var_range(var)
-        scaled = _scale_threshold(threshold, vmin, vmax)
         if mode == "max":
-            da = da.where(mask_da <= scaled)
+            da = da.where(mask_da <= threshold)
         else:
-            da = da.where(mask_da >= scaled)
+            da = da.where(mask_da >= threshold)
     return da
 
 
@@ -590,6 +593,40 @@ async def get_colorbar(cmap_name: str):
 
 
 @app.get(
+    "/dataset_range/{dataset_name}",
+    response_class=JSONResponse,
+    responses={200: {"description": "Return min/max/p2/p98 for a dataset (first time slice)"}},
+)
+async def get_dataset_range(dataset_name: str):
+    """Return the value range of a dataset for use in mask threshold sliders."""
+    if DATA_MODE == "md":
+        if dataset_name not in XARRAY_DATASET.data_vars:
+            raise HTTPException(status_code=404, detail=f"Variable {dataset_name} not found")
+        da = XARRAY_DATASET[dataset_name]
+        arr = da.isel(time=0).values.ravel().astype(float) if "time" in da.dims else da.values.ravel().astype(float)
+    else:
+        if dataset_name not in RASTER_GROUPS:
+            raise HTTPException(status_code=404, detail=f"Dataset {dataset_name} not found")
+        rg = RASTER_GROUPS[dataset_name]
+        with rasterio.open(rg.file_list[0]) as src:
+            arr = src.read(1).ravel().astype(float)
+            nodata = src.nodata
+        if nodata is not None:
+            arr = arr[arr != nodata]
+
+    valid = arr[np.isfinite(arr)]
+    if valid.size == 0:
+        raise HTTPException(status_code=204, detail="No valid data")
+
+    return JSONResponse({
+        "min": float(valid.min()),
+        "max": float(valid.max()),
+        "p2": float(np.percentile(valid, 2)),
+        "p98": float(np.percentile(valid, 98)),
+    })
+
+
+@app.get(
     "/histogram/{dataset_name}",
     response_class=JSONResponse,
     responses={200: {"description": "Return histogram data for one time slice"}},
@@ -771,8 +808,14 @@ async def extract_profile(
     dataset_name: str = Body(..., description="Dataset name"),
     time_index: int = Body(0, description="Time index"),
     n_samples: int = Body(200, description="Number of samples along line"),
+    radius: float = Body(0.0, description="Buffer radius in metres (0 = single line)"),
+    n_random: int = Body(5, description="Number of random sample lines within buffer"),
 ):
-    """Sample raster values along a polyline and return distance + value pairs."""
+    """Sample raster values along a polyline.
+
+    When ``radius`` > 0, returns median and random sample profiles within the
+    buffer; otherwise returns the single centre-line profile.
+    """
     from pyproj import Geod  # noqa: PLC0415
 
     if len(coords) < 2:
@@ -792,16 +835,13 @@ async def extract_profile(
         raise HTTPException(status_code=422, detail="Zero-length line")
 
     sample_dists = np.linspace(0, total_dist, n_samples)
-    results: list[dict] = []
-    for sd in sample_dists:
-        seg_idx = int(np.clip(np.searchsorted(seg_dists, sd, side="right") - 1, 0, len(lons) - 2))
-        frac = (sd - seg_dists[seg_idx]) / max(seg_dists[seg_idx + 1] - seg_dists[seg_idx], 1e-9)
-        slon = lons[seg_idx] + frac * (lons[seg_idx + 1] - lons[seg_idx])
-        slat = lats[seg_idx] + frac * (lats[seg_idx + 1] - lats[seg_idx])
+
+    def _read_lonlat(slon: float, slat: float) -> float | None:
+        """Read a single value at (slon, slat); return None on failure."""
         try:
             if DATA_MODE == "md":
                 if dataset_name not in XARRAY_DATASET.data_vars:
-                    continue
+                    return None
                 da = XARRAY_DATASET[dataset_name]
                 if "time" in da.dims and time_index < da.shape[0]:
                     da = da.isel(time=time_index)
@@ -809,15 +849,84 @@ async def extract_profile(
                 val = float(da.sel(x=x_c, y=y_c, method="nearest").values)
             else:
                 if dataset_name not in RASTER_GROUPS:
-                    continue
+                    return None
                 rg = RASTER_GROUPS[dataset_name]
                 t = min(time_index, len(rg.file_list) - 1)
                 val = float(np.atleast_1d(rg._reader.readers[t].read_lonlat(slon, slat))[0])
-            if np.isfinite(val):
-                results.append({"dist": float(sd), "value": val})
+            return val if np.isfinite(val) else None
         except Exception:
-            continue
-    return JSONResponse(results)
+            return None
+
+    # ── Compute sample point positions along the line ──────────────────────────
+    # For each distance d along line, compute (slon, slat) and the perpendicular
+    # unit vector in lon/lat degrees (approximated from the local bearing).
+    sample_positions: list[tuple[float, float, float, float]] = []  # (dist, slon, slat, bearing_deg)
+    for sd in sample_dists:
+        seg_idx = int(np.clip(np.searchsorted(seg_dists, sd, side="right") - 1, 0, len(lons) - 2))
+        frac = (sd - seg_dists[seg_idx]) / max(seg_dists[seg_idx + 1] - seg_dists[seg_idx], 1e-9)
+        slon = lons[seg_idx] + frac * (lons[seg_idx + 1] - lons[seg_idx])
+        slat = lats[seg_idx] + frac * (lats[seg_idx + 1] - lats[seg_idx])
+        # Forward bearing of this segment (degrees)
+        az, _, _ = geod.inv(lons[seg_idx], lats[seg_idx], lons[seg_idx + 1], lats[seg_idx + 1])
+        sample_positions.append((float(sd), slon, slat, float(az)))
+
+    if radius <= 0:
+        # ── Simple centre-line profile ─────────────────────────────────────────
+        results: list[dict] = []
+        for sd, slon, slat, _ in sample_positions:
+            v = _read_lonlat(slon, slat)
+            if v is not None:
+                results.append({"dist": sd, "value": v})
+        return JSONResponse(results)
+
+    # ── Buffer profile: median + random samples ────────────────────────────────
+    rng = np.random.default_rng(42)
+    # Random perpendicular offsets for sample lines: shape (n_random,)
+    offsets = rng.uniform(-radius, radius, size=n_random)
+
+    # centre + random lines → shape (1+n_random, n_samples)
+    all_lines: list[list[float | None]] = [[] for _ in range(1 + n_random)]
+
+    for i, (sd, slon, slat, bearing) in enumerate(sample_positions):
+        # Centre line
+        all_lines[0].append(_read_lonlat(slon, slat))
+        # Perpendicular direction = bearing + 90°
+        perp_az = bearing + 90.0
+        for j, off in enumerate(offsets):
+            if off == 0:
+                o_lon, o_lat = slon, slat
+            else:
+                o_lon, o_lat, _ = geod.fwd(slon, slat, perp_az, off)
+            all_lines[j + 1].append(_read_lonlat(o_lon, o_lat))
+
+    # Build finite-only arrays for median computation
+    arr = np.array([[v if v is not None else np.nan for v in line] for line in all_lines])
+    median_vals = np.nanmedian(arr, axis=0)
+
+    centre_profile = [
+        {"dist": float(sample_positions[i][0]), "value": float(v)}
+        for i, v in enumerate(arr[0])
+        if np.isfinite(v)
+    ]
+    median_profile = [
+        {"dist": float(sample_positions[i][0]), "value": float(v)}
+        for i, v in enumerate(median_vals)
+        if np.isfinite(v)
+    ]
+    sample_profiles = [
+        [
+            {"dist": float(sample_positions[i][0]), "value": float(arr[j + 1, i])}
+            for i in range(len(sample_positions))
+            if np.isfinite(arr[j + 1, i])
+        ]
+        for j in range(n_random)
+    ]
+
+    return JSONResponse({
+        "centre": centre_profile,
+        "median": median_profile,
+        "samples": sample_profiles,
+    })
 
 
 # Upload directory for custom masks
@@ -910,23 +1019,10 @@ def InputDependency(
                 if not fl:
                     continue
                 f = fl[min(time_idx, len(fl) - 1)]
-                # Scale 0–1 threshold to the file's actual data range
-                try:
-                    with rasterio.open(f) as src:
-                        arr = src.read(1).astype(float)
-                        nodata = src.nodata
-                    if nodata is not None:
-                        arr = arr[arr != nodata]
-                    valid = arr[np.isfinite(arr)]
-                    if valid.size > 0:
-                        scaled = _scale_threshold(threshold, float(valid.min()), float(valid.max()))
-                    else:
-                        scaled = threshold
-                except Exception:
-                    scaled = threshold
+                # Threshold is now an absolute value — pass it directly
                 # CustomReader extra_masks keeps pixels where value > min_value ('min' mode only)
                 if mode == "min":
-                    extra_masks.append((f, scaled))
+                    extra_masks.append((f, threshold))
                 # 'max' mode not supported for COG tiles (CustomReader has no inversion)
         except (json.JSONDecodeError, Exception) as e:
             logger.warning(f"Failed to parse layer_masks: {e}")

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -211,6 +211,25 @@ async def get_variables():
     return {"variables": variables}
 
 
+def _scale_threshold(threshold: float, vmin: float, vmax: float) -> float:
+    """Map a 0–1 normalised threshold to the actual [vmin, vmax] data range."""
+    if np.isfinite(vmin) and np.isfinite(vmax) and vmax > vmin:
+        return vmin + threshold * (vmax - vmin)
+    return threshold
+
+
+# Cache dataset-level min/max so nanmin/nanmax aren't recomputed on every tile request.
+_MD_VAR_RANGE_CACHE: dict[str, tuple[float, float]] = {}
+
+
+def _md_var_range(var: str) -> tuple[float, float]:
+    """Return (nanmin, nanmax) for an MD dataset variable, cached after first call."""
+    if var not in _MD_VAR_RANGE_CACHE:
+        arr = XARRAY_DATASET[var].values
+        _MD_VAR_RANGE_CACHE[var] = (float(np.nanmin(arr)), float(np.nanmax(arr)))
+    return _MD_VAR_RANGE_CACHE[var]
+
+
 def _apply_layer_masks_md(
     da: "xr.DataArray",
     layer_masks: list[dict],
@@ -219,7 +238,9 @@ def _apply_layer_masks_md(
     """Apply a list of layer mask dicts to a DataArray (MD mode).
 
     Each dict has keys: dataset (str), threshold (float), mode ('min'|'max').
-    'min' keeps pixels >= threshold; 'max' keeps pixels <= threshold.
+    threshold is always 0–1 normalised; it is scaled to the mask layer's
+    actual data range before comparison.
+    'min' keeps pixels >= scaled_threshold; 'max' keeps pixels <= scaled_threshold.
     """
     for m in layer_masks:
         var = m.get("dataset")
@@ -230,10 +251,12 @@ def _apply_layer_masks_md(
         mask_da = XARRAY_DATASET[var]
         if time_idx is not None and "time" in mask_da.dims:
             mask_da = mask_da.isel(time=time_idx)
+        vmin, vmax = _md_var_range(var)
+        scaled = _scale_threshold(threshold, vmin, vmax)
         if mode == "max":
-            da = da.where(mask_da <= threshold)
+            da = da.where(mask_da <= scaled)
         else:
-            da = da.where(mask_da >= threshold)
+            da = da.where(mask_da >= scaled)
     return da
 
 
@@ -887,12 +910,24 @@ def InputDependency(
                 if not fl:
                     continue
                 f = fl[min(time_idx, len(fl) - 1)]
-                # For 'max' mode (keep <= threshold), we invert: mask out pixels > threshold
-                # CustomReader extra_masks keeps pixels where value > min_value, so for 'max'
-                # we can't natively invert — pass None to skip (tile-level COG 'max' not supported)
+                # Scale 0–1 threshold to the file's actual data range
+                try:
+                    with rasterio.open(f) as src:
+                        arr = src.read(1).astype(float)
+                        nodata = src.nodata
+                    if nodata is not None:
+                        arr = arr[arr != nodata]
+                    valid = arr[np.isfinite(arr)]
+                    if valid.size > 0:
+                        scaled = _scale_threshold(threshold, float(valid.min()), float(valid.max()))
+                    else:
+                        scaled = threshold
+                except Exception:
+                    scaled = threshold
+                # CustomReader extra_masks keeps pixels where value > min_value ('min' mode only)
                 if mode == "min":
-                    extra_masks.append((f, threshold))
-                # 'max' mode skipped for COG tiles (no inversion support in CustomReader)
+                    extra_masks.append((f, scaled))
+                # 'max' mode not supported for COG tiles (CustomReader has no inversion)
         except (json.JSONDecodeError, Exception) as e:
             logger.warning(f"Failed to parse layer_masks: {e}")
 

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -78,6 +78,10 @@ def load_data_sources():
             else xr.open_dataset(stack_file)
         )
         crs = CRS.from_wkt(ds.spatial_ref.crs_wkt)
+        # Collapse spatial_ref to scalar if it has a time dimension so that
+        # 2D variables (no time dim) still inherit the CRS coordinate.
+        if "time" in ds.spatial_ref.dims:
+            ds = ds.assign_coords(spatial_ref=ds.spatial_ref.isel(time=0).drop_vars("time"))
         ds.rio.write_crs(crs, inplace=True)
         transformer = Transformer.from_crs(4326, ds.rio.crs, always_xy=True)
         return "md", ds, None, transformer
@@ -138,19 +142,22 @@ def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
     for var_name, var in ds.data_vars.items():
         if "x" in var.dims and "y" in var.dims:
             use_moving_reference = (
-                "displacement" in str(var_name).lower()
-                and "short_wave" not in str(var_name).lower()
-                and not skip_spatial_reference
-            )
+                ("displacement" in str(var_name).lower() and "short_wave" not in str(var_name).lower())
+                or "velocity" in str(var_name).lower()
+            ) and not skip_spatial_reference
             available_mask_vars = [
                 v for v in ["temporal_coherence", "phase_similarity", "recommended_mask"]
                 if v in ds.data_vars
             ]
+            has_time = "time" in var.dims
+            attrs = dict(var.attrs)
             dataset_info[var_name] = {
                 "name": var_name,
-                "file_list": [
-                    f"variable:{var_name}:time:{i}" for i in range(len(ds.time))
-                ],
+                "file_list": (
+                    [f"variable:{var_name}:time:{i}" for i in range(len(ds.time))]
+                    if has_time
+                    else [f"variable:{var_name}"]
+                ),
                 "mask_file_list": [],
                 "mask_min_value": 0.1,
                 "nodata": None,
@@ -158,8 +165,10 @@ def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
                 "algorithm": "shift" if use_moving_reference else None,
                 "bounds": list(bounds),
                 "latlon_bounds": list(latlon_bounds),
-                "x_values": time_values,
+                "x_values": time_values if has_time else [],
                 "available_mask_vars": available_mask_vars,
+                "label": attrs.get("long_name", var_name),
+                "unit": attrs.get("units", ""),
             }
 
     return dataset_info
@@ -197,6 +206,12 @@ async def datasets():
 async def get_mode():
     """Return the current data mode (md or cog) for frontend routing."""
     return {"mode": DATA_MODE}
+
+
+@app.get("/config")
+async def get_config():
+    """Return app configuration for the frontend."""
+    return {"title": settings.BOWSER_TITLE}
 
 
 @app.get("/variables")
@@ -641,8 +656,11 @@ async def get_histogram(
         if dataset_name not in XARRAY_DATASET.data_vars:
             raise HTTPException(status_code=404, detail=f"Variable {dataset_name} not found")
         da = XARRAY_DATASET[dataset_name]
-        time_index = min(time_index, da.shape[0] - 1)
-        arr = da.isel(time=time_index).values.ravel().astype(float)
+        if "time" in da.dims:
+            time_index = min(time_index, da.sizes["time"] - 1)
+            arr = da.isel(time=time_index).values.ravel().astype(float)
+        else:
+            arr = da.values.ravel().astype(float)
     else:
         if dataset_name not in RASTER_GROUPS:
             raise HTTPException(status_code=404, detail=f"Dataset {dataset_name} not found")

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -1,3 +1,6 @@
+import base64
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -17,8 +20,10 @@ import matplotlib
 import numpy as np
 import rasterio
 import xarray as xr
-from fastapi import Body, FastAPI, HTTPException, Query, Response, UploadFile
+from fastapi import Body, FastAPI, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response as StarletteResponse
 from pyproj import CRS, Transformer
 from rio_tiler.io.xarray import XarrayReader
 from starlette.staticfiles import StaticFiles
@@ -64,6 +69,71 @@ app = FastAPI(
     openapi_url="/api",
     docs_url="/api.html",
 )
+
+
+def _load_htpasswd(path: str) -> dict[str, str]:
+    """Parse an htpasswd file into {username: hashed_password}."""
+    users: dict[str, str] = {}
+    for line in Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(":", 1)
+        if len(parts) == 2:
+            users[parts[0]] = parts[1]
+    return users
+
+
+def _check_password(stored: str, provided: str) -> bool:
+    """Verify a plaintext password against an htpasswd entry (SHA1 or bcrypt)."""
+    if stored.startswith("{SHA}"):
+        digest = base64.b64encode(hashlib.sha1(provided.encode()).digest()).decode()
+        return hmac.compare_digest(stored[5:], digest)
+    try:
+        import bcrypt  # optional — only needed for bcrypt hashes
+        return bcrypt.checkpw(provided.encode(), stored.encode())
+    except ImportError:
+        pass
+    # apr1/md5 not implemented — tell user to use SHA or bcrypt
+    return False
+
+
+class BasicAuthMiddleware(BaseHTTPMiddleware):
+    """HTTP Basic Auth gate — only active when BOWSER_HTPASSWD_FILE is set."""
+
+    def __init__(self, app, htpasswd_file: str) -> None:
+        super().__init__(app)
+        self.htpasswd_file = Path(htpasswd_file)
+
+    def _users(self) -> dict[str, str]:
+        return _load_htpasswd(str(self.htpasswd_file)) if self.htpasswd_file.exists() else {}
+
+    async def dispatch(self, request: Request, call_next: Any) -> StarletteResponse:
+        users = self._users()
+        if not users:
+            return await call_next(request)
+
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Basic "):
+            try:
+                decoded = base64.b64decode(auth[6:]).decode("utf-8", errors="replace")
+                username, _, password = decoded.partition(":")
+                stored = users.get(username)
+                if stored and _check_password(stored, password):
+                    return await call_next(request)
+            except Exception:
+                pass
+
+        return StarletteResponse(
+            content="Unauthorized",
+            status_code=401,
+            headers={"WWW-Authenticate": 'Basic realm="Bowser"'},
+        )
+
+
+if settings.BOWSER_HTPASSWD_FILE:
+    app.add_middleware(BasicAuthMiddleware, htpasswd_file=settings.BOWSER_HTPASSWD_FILE)
+    logger.info(f"Basic auth enabled from {settings.BOWSER_HTPASSWD_FILE}")
 
 
 def load_data_sources():
@@ -825,14 +895,22 @@ async def extract_profile(
     coords: list[list[float]] = Body(..., description="List of [lon, lat] pairs"),
     dataset_name: str = Body(..., description="Dataset name"),
     time_index: int = Body(0, description="Time index"),
-    n_samples: int = Body(200, description="Number of samples along line"),
+    n_samples: int = Body(200, description="Number of samples along line (used when sampling_interval=0)"),
     radius: float = Body(0.0, description="Buffer radius in metres (0 = single line)"),
-    n_random: int = Body(5, description="Number of random sample lines within buffer"),
+    n_random: int = Body(5, description="Number of random sample lines within buffer (legacy)"),
+    sampling_interval: float = Body(0.0, description="Bin spacing in metres along profile (0 = use n_samples). When > 0, each bin collects all pixels within ±(sampling_interval/2) of the bin centre along the profile direction and within ±radius perpendicular, then returns their median."),
 ):
     """Sample raster values along a polyline.
 
-    When ``radius`` > 0, returns median and random sample profiles within the
-    buffer; otherwise returns the single centre-line profile.
+    When ``radius`` > 0 and ``sampling_interval`` > 0, the profile is divided
+    into non-overlapping bins of width ``sampling_interval``.  Each bin
+    collects a dense grid of pixels within that along-track window and within
+    ``radius`` perpendicular to the line; the bin value is the nanmedian of
+    those pixels.  The centre-line profile uses the same bins sampled only
+    along the line centre.
+
+    When ``sampling_interval`` = 0 the legacy behaviour is used: ``n_samples``
+    evenly-spaced points with random perpendicular lines.
     """
     from pyproj import Geod  # noqa: PLC0415
 
@@ -851,8 +929,6 @@ async def extract_profile(
     total_dist = seg_dists[-1]
     if total_dist == 0:
         raise HTTPException(status_code=422, detail="Zero-length line")
-
-    sample_dists = np.linspace(0, total_dist, n_samples)
 
     def _read_lonlat(slon: float, slat: float) -> float | None:
         """Read a single value at (slon, slat); return None on failure."""
@@ -875,21 +951,103 @@ async def extract_profile(
         except Exception:
             return None
 
-    # ── Compute sample point positions along the line ──────────────────────────
-    # For each distance d along line, compute (slon, slat) and the perpendicular
-    # unit vector in lon/lat degrees (approximated from the local bearing).
-    sample_positions: list[tuple[float, float, float, float]] = []  # (dist, slon, slat, bearing_deg)
-    for sd in sample_dists:
+    def _pos_at_dist(sd: float) -> tuple[float, float, float]:
+        """Return (lon, lat, bearing_deg) at distance sd along the polyline."""
         seg_idx = int(np.clip(np.searchsorted(seg_dists, sd, side="right") - 1, 0, len(lons) - 2))
         frac = (sd - seg_dists[seg_idx]) / max(seg_dists[seg_idx + 1] - seg_dists[seg_idx], 1e-9)
         slon = lons[seg_idx] + frac * (lons[seg_idx + 1] - lons[seg_idx])
         slat = lats[seg_idx] + frac * (lats[seg_idx + 1] - lats[seg_idx])
-        # Forward bearing of this segment (degrees)
         az, _, _ = geod.inv(lons[seg_idx], lats[seg_idx], lons[seg_idx + 1], lats[seg_idx + 1])
-        sample_positions.append((float(sd), slon, slat, float(az)))
+        return float(slon), float(slat), float(az)
+
+    # ── Binned-median sampling (new mode) ─────────────────────────────────────
+    if sampling_interval > 0:
+        half = sampling_interval / 2.0
+        bin_centres = np.arange(half, total_dist, sampling_interval)
+        if len(bin_centres) == 0:
+            bin_centres = np.array([total_dist / 2.0])
+
+        # Along-track step: cap at sampling_interval so we never oversample.
+        # 5 steps per bin is enough for a smooth median; minimum 1 m.
+        along_step = max(min(sampling_interval / 5.0, sampling_interval), 1.0)
+
+        # Perpendicular: 5 steps across the full width (radius > 0 only).
+        # Minimum 1 m; 0 offset (centre line) is always included.
+        if radius > 0:
+            perp_step = max(radius / 5.0, 1.0)
+            perp_offsets_dense = np.arange(-radius, radius + perp_step * 0.5, perp_step)
+            # Remove duplicate 0 if it lands on a grid point exactly
+            perp_offsets_dense = perp_offsets_dense[np.abs(perp_offsets_dense) > 1e-3]
+        else:
+            perp_offsets_dense = np.empty(0)
+
+        # Display sample lines (for chart decoration), evenly spaced, max n_random
+        n_display = max(1, min(n_random, 5)) if radius > 0 else 0
+        perp_offsets_display = np.linspace(-radius, radius, n_display) if n_display > 0 else np.empty(0)
+
+        centre_profile: list[dict] = []
+        median_profile: list[dict] = []
+        sample_profiles_acc: list[list[dict]] = [[] for _ in range(n_display)]
+
+        for bc in bin_centres:
+            along_dists = np.arange(bc - half, bc + half + along_step * 0.5, along_step)
+            along_dists = along_dists[(along_dists >= 0) & (along_dists <= total_dist)]
+
+            # Compute centre positions once per along-track step
+            positions = [_pos_at_dist(ad) for ad in along_dists]  # (lon, lat, bearing)
+
+            # --- Centre values (no perpendicular offset) ---
+            centre_vals = [v for clon, clat, _ in positions
+                           if (v := _read_lonlat(clon, clat)) is not None]
+
+            # --- Full 2-D window (centre + perpendicular strip) ---
+            all_vals = list(centre_vals)
+            if radius > 0:
+                for clon, clat, bearing in positions:
+                    perp_az = bearing + 90.0
+                    for off in perp_offsets_dense:
+                        o_lon, o_lat, _ = geod.fwd(clon, clat, perp_az, off)
+                        v = _read_lonlat(o_lon, o_lat)
+                        if v is not None:
+                            all_vals.append(v)
+
+            if centre_vals:
+                centre_profile.append({"dist": float(bc), "value": float(np.nanmedian(centre_vals))})
+            if all_vals:
+                median_profile.append({"dist": float(bc), "value": float(np.nanmedian(all_vals))})
+
+            # --- Display sample lines (reuse cached positions) ---
+            for k, off in enumerate(perp_offsets_display):
+                svals: list[float] = []
+                for clon, clat, bearing in positions:
+                    if abs(off) < 1e-3:
+                        v = _read_lonlat(clon, clat)
+                    else:
+                        o_lon, o_lat, _ = geod.fwd(clon, clat, bearing + 90.0, off)
+                        v = _read_lonlat(o_lon, o_lat)
+                    if v is not None:
+                        svals.append(v)
+                if svals:
+                    sample_profiles_acc[k].append({"dist": float(bc), "value": float(np.nanmedian(svals))})
+
+        return JSONResponse({
+            "centre": centre_profile,
+            "median": median_profile,
+            "samples": sample_profiles_acc,
+            "binned": True,
+            "bin_width": float(sampling_interval),
+        })
+
+    # ── Legacy mode: evenly-spaced points ─────────────────────────────────────
+    sample_dists = np.linspace(0, total_dist, n_samples)
+
+    # Compute sample point positions
+    sample_positions: list[tuple[float, float, float, float]] = []
+    for sd in sample_dists:
+        slon, slat, az = _pos_at_dist(sd)
+        sample_positions.append((float(sd), slon, slat, az))
 
     if radius <= 0:
-        # ── Simple centre-line profile ─────────────────────────────────────────
         results: list[dict] = []
         for sd, slon, slat, _ in sample_positions:
             v = _read_lonlat(slon, slat)
@@ -897,18 +1055,13 @@ async def extract_profile(
                 results.append({"dist": sd, "value": v})
         return JSONResponse(results)
 
-    # ── Buffer profile: median + random samples ────────────────────────────────
+    # Legacy buffer: random perpendicular sample lines
     rng = np.random.default_rng(42)
-    # Random perpendicular offsets for sample lines: shape (n_random,)
     offsets = rng.uniform(-radius, radius, size=n_random)
 
-    # centre + random lines → shape (1+n_random, n_samples)
     all_lines: list[list[float | None]] = [[] for _ in range(1 + n_random)]
-
     for i, (sd, slon, slat, bearing) in enumerate(sample_positions):
-        # Centre line
         all_lines[0].append(_read_lonlat(slon, slat))
-        # Perpendicular direction = bearing + 90°
         perp_az = bearing + 90.0
         for j, off in enumerate(offsets):
             if off == 0:
@@ -917,7 +1070,6 @@ async def extract_profile(
                 o_lon, o_lat, _ = geod.fwd(slon, slat, perp_az, off)
             all_lines[j + 1].append(_read_lonlat(o_lon, o_lat))
 
-    # Build finite-only arrays for median computation
     arr = np.array([[v if v is not None else np.nan for v in line] for line in all_lines])
     median_vals = np.nanmedian(arr, axis=0)
 

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -867,7 +867,10 @@ async def buffer_timeseries(
     if flat.shape[1] == 0:
         raise HTTPException(status_code=404, detail="No valid pixels in buffer")
 
-    median_ts = np.nanmedian(flat, axis=1).tolist()
+    import warnings as _w  # noqa: PLC0415
+    with _w.catch_warnings():
+        _w.simplefilter("ignore", RuntimeWarning)
+        median_ts = np.nanmedian(flat, axis=1).tolist()
 
     # Random sample (up to n_samples)
     rng = np.random.default_rng(42)

--- a/src/bowser/readers.py
+++ b/src/bowser/readers.py
@@ -173,8 +173,15 @@ class RasterReader(DatasetReader):
         """Bounds of dataset in `crs` coordinates."""
         if self.keep_open:
             return self._src.bounds
-        with rio.open(self.filename, "r") as src:
-            return src.bounds
+        try:
+            with rio.open(self.filename, "r") as src:
+                return src.bounds
+        except KeyError:
+            # GDAL dtype not known to rasterio (e.g. Float16); compute from transform+shape.
+            h, w = self.shape
+            tf = self.transform
+            from rasterio.transform import array_bounds  # noqa: PLC0415
+            return array_bounds(h, w, tf)
 
     @property
     def latlon_bounds(self) -> tuple[float, float, float, float]:
@@ -198,7 +205,39 @@ class RasterReader(DatasetReader):
             dates = get_dates(filename, fmt=file_date_fmt)
         else:
             dates = None
-        with rio.open(filename, "r", **options) as src:
+        try:
+            src_ctx = rio.open(filename, "r", **options)
+        except KeyError:
+            # rasterio doesn't know this GDAL dtype (e.g. Float16 = GDAL type 15).
+            # Fall back to GDAL directly to get shape/transform, treat as float32.
+            from osgeo import gdal  # noqa: PLC0415
+            gdal.UseExceptions()
+            ds = gdal.Open(str(filename))
+            if ds is None:
+                raise OSError(f"Cannot open {filename}")
+            gt = ds.GetGeoTransform()
+            from affine import Affine  # noqa: PLC0415
+            from rasterio.crs import CRS as RioCRS  # noqa: PLC0415
+            _transform = Affine.from_gdal(*gt)
+            _crs = RioCRS.from_wkt(ds.GetProjection()) if ds.GetProjection() else None
+            _nodata = ds.GetRasterBand(band).GetNoDataValue()
+            _shape = (ds.RasterYSize, ds.RasterXSize)
+            _chunks = (256, 256)
+            ds = None
+            return cls(
+                filename=filename,
+                band=band,
+                driver="GTiff",
+                crs=_crs,
+                transform=_transform,
+                shape=_shape,
+                dtype=np.dtype("float32"),
+                nodata=_nodata,
+                keep_open=keep_open,
+                dates=dates,
+                chunks=_chunks,
+            )
+        with src_ctx as src:
             shape = (src.height, src.width)
             dtype = np.dtype(src.dtypes[band - 1])
             driver = src.driver

--- a/src/bowser/readers.py
+++ b/src/bowser/readers.py
@@ -32,6 +32,29 @@ from rio_tiler.models import BandStatistics, ImageData, Info, PointData
 from rio_tiler.types import BBox, Indexes
 from tqdm.contrib.concurrent import thread_map
 
+
+def _patch_rasterio_float16() -> None:
+    """Register GDAL Float16 (type code 15) with rasterio if missing.
+
+    GDAL 3.11+ interprets NBITS=16 on float32 GeoTIFFs as native Float16
+    (datatype code 15). Rasterio builds that lack a mapping for code 15 raise
+    ``KeyError: 15`` on open. Patch the forward/reverse dtype dicts so rasterio
+    can open these files transparently.
+    """
+    try:
+        from osgeo import gdal
+        if not hasattr(gdal, "GDT_Float16"):
+            return
+        from rasterio.dtypes import dtype_fwd, dtype_rev
+        if 15 not in dtype_fwd:
+            dtype_fwd[15] = "float16"
+            dtype_rev["float16"] = 15
+    except Exception:
+        pass
+
+
+_patch_rasterio_float16()
+
 PathOrStr = Path | str
 
 __all__ = [

--- a/src/bowser/utils.py
+++ b/src/bowser/utils.py
@@ -240,6 +240,60 @@ def generate_colorbar(cmap_name: str) -> bytes:
     return buf.read()
 
 
+def register_custom_colormaps() -> None:
+    """Register cfastie, rplumbo, schwarzwald reversed variants in rio_tiler and matplotlib.
+
+    rio_tiler ships cfastie/rplumbo/schwarzwald but not their ``_r`` (reversed)
+    counterparts.  This function reads each from rio_tiler's registry, reverses
+    the 256-entry RGBA table, and registers the result so that ``colormap_name``
+    values like ``cfastie_r`` are accepted by the titiler tile endpoint.
+
+    The same reversed colormaps are also registered in matplotlib (used for the
+    ``/colorbar/`` endpoint).
+    """
+    import matplotlib as mpl
+    import numpy as np
+    from matplotlib.colors import LinearSegmentedColormap
+
+    try:
+        from rio_tiler.colormap import cmap as rt_cmap
+    except ImportError:
+        return
+
+    _NAMES = ("cfastie", "rplumbo", "schwarzwald")
+
+    for name in _NAMES:
+        rev_name = f"{name}_r"
+        if rev_name in rt_cmap.list():
+            continue  # already present
+
+        try:
+            fwd: dict[int, tuple] = rt_cmap.get(name)
+        except Exception:
+            continue
+
+        # Build reversed 256-entry dict: value at index i → value at index 255-i
+        rev: dict[int, tuple] = {i: fwd[255 - i] for i in range(256)}
+        # rio_tiler's ColorMaps.register() returns a new object; mutate .data directly
+        rt_cmap.data[rev_name] = rev
+
+        # Also register in matplotlib for the /colorbar/ endpoint
+        rgba = np.array([list(rev[i]) for i in range(256)], dtype=np.uint8)
+        mpl_cmap = LinearSegmentedColormap.from_list(
+            rev_name, rgba[:, :3] / 255.0
+        )
+        if rev_name not in mpl.colormaps:
+            mpl.colormaps.register(mpl_cmap, name=rev_name)
+
+        # Register the forward matplotlib cmap too (in case it's missing)
+        fwd_rgba = np.array([list(fwd[i]) for i in range(256)], dtype=np.uint8)
+        mpl_fwd = LinearSegmentedColormap.from_list(
+            name, fwd_rgba[:, :3] / 255.0
+        )
+        if name not in mpl.colormaps:
+            mpl.colormaps.register(mpl_fwd, name=name)
+
+
 def desensitize_mpl_case():
     """Make `cmap` case insensitive by registering repeated cmap names."""
     import matplotlib as mpl

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,12 +7,14 @@ import TimeSeriesChart from './TimeSeriesChart';
 import PointManagerPanel from './PointManagerPanel';
 import RefPointChart from './RefPointChart';
 import ColormapBar from './ColormapBar';
+import { ProfileProvider, ProfileChart } from './ProfileTool';
 import '../style.css';
 
 function AppContent() {
   const { state, dispatch } = useAppContext();
   const { fetchDatasets, fetchDataMode, fetchConfig } = useApi();
   const [appTitle, setAppTitle] = useState('');
+  const [sidebarHidden, setSidebarHidden] = useState(false);
 
   useEffect(() => {
     const initializeApp = async () => {
@@ -49,13 +51,21 @@ function AppContent() {
   }, [fetchDatasets, fetchDataMode, fetchConfig, dispatch]);
 
   return (
-    <div className="app-container">
+    <div className={`app-container${sidebarHidden ? ' sidebar-hidden' : ''}`}>
       <ControlPanel title={appTitle} />
       <div className="map-container">
+        <button
+          className="sidebar-toggle-btn"
+          onClick={() => setSidebarHidden(h => !h)}
+          title={sidebarHidden ? 'Show sidebar' : 'Hide sidebar'}
+        >
+          <i className={`fa-solid fa-chevron-${sidebarHidden ? 'right' : 'left'}`} />
+        </button>
         <MapContainer />
         <PointManagerPanel />
         <RefPointChart />
         <ColormapBar />
+        <ProfileChart />
         {state.showChart && state.chartWindows.map(w => (
           <TimeSeriesChart key={w.id} windowId={w.id} />
         ))}
@@ -67,7 +77,9 @@ function AppContent() {
 export default function App() {
   return (
     <AppProvider>
-      <AppContent />
+      <ProfileProvider>
+        <AppContent />
+      </ProfileProvider>
     </AppProvider>
   );
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { AppProvider, useAppContext } from '../context/AppContext';
 import { useApi } from '../hooks/useApi';
 import MapContainer from './MapContainer';
@@ -9,30 +9,33 @@ import '../style.css';
 
 function AppContent() {
   const { state, dispatch } = useAppContext();
-  const { fetchDatasets, fetchDataMode } = useApi();
+  const { fetchDatasets, fetchDataMode, fetchConfig } = useApi();
+  const [appTitle, setAppTitle] = useState('');
 
   useEffect(() => {
     const initializeApp = async () => {
       try {
-        // Fetch data mode first
-        const mode = await fetchDataMode();
+        // Fetch config (title), data mode, and datasets
+        const [config, mode] = await Promise.all([fetchConfig(), fetchDataMode()]);
+
+        if (config.title) {
+          setAppTitle(config.title);
+          document.title = config.title;
+        }
+
         dispatch({ type: 'SET_DATA_MODE', payload: mode });
 
-        // Then fetch datasets
         const datasets = await fetchDatasets();
         dispatch({ type: 'SET_DATASETS', payload: datasets });
 
-        // Set initial dataset and position
         const firstDataset = Object.keys(datasets)[0];
         if (firstDataset) {
           dispatch({ type: 'SET_CURRENT_DATASET', payload: firstDataset });
 
-          // Compute center from bounds
           const bounds = datasets[firstDataset].latlon_bounds;
           const centerLat = (bounds[1] + bounds[3]) / 2;
           const centerLng = (bounds[0] + bounds[2]) / 2;
 
-          // Set reference marker position
           dispatch({ type: 'SET_REF_MARKER_POSITION', payload: [centerLat, centerLng] });
         }
       } catch (error) {
@@ -41,11 +44,11 @@ function AppContent() {
     };
 
     initializeApp();
-  }, [fetchDatasets, fetchDataMode, dispatch]);
+  }, [fetchDatasets, fetchDataMode, fetchConfig, dispatch]);
 
   return (
     <div className="app-container">
-      <ControlPanel />
+      <ControlPanel title={appTitle} />
       <div className="map-container">
         <MapContainer />
         <PointManagerPanel />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,6 +5,8 @@ import MapContainer from './MapContainer';
 import ControlPanel from './ControlPanel';
 import TimeSeriesChart from './TimeSeriesChart';
 import PointManagerPanel from './PointManagerPanel';
+import RefPointChart from './RefPointChart';
+import ColormapBar from './ColormapBar';
 import '../style.css';
 
 function AppContent() {
@@ -52,7 +54,11 @@ function AppContent() {
       <div className="map-container">
         <MapContainer />
         <PointManagerPanel />
-        {state.showChart && <TimeSeriesChart />}
+        <RefPointChart />
+        <ColormapBar />
+        {state.showChart && state.chartWindows.map(w => (
+          <TimeSeriesChart key={w.id} windowId={w.id} />
+        ))}
       </div>
     </div>
   );

--- a/src/components/ColormapBar.tsx
+++ b/src/components/ColormapBar.tsx
@@ -1,0 +1,268 @@
+import { useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+import { useDraggableResizable } from '../hooks/useDraggableResizable';
+
+export default function ColormapBar() {
+  const { state, dispatch } = useAppContext();
+  const [horizontal, setHorizontal] = useState(false);
+  const [barFrac, setBarFrac] = useState(0.4);
+  const [showBarSlider, setShowBarSlider] = useState(false);
+  const [customLabel, setCustomLabel] = useState<string | null>(null);
+  const [customUnit, setCustomUnit] = useState<string | null>(null);
+
+  const { panelRef, panelStyle, size, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth:  300,
+    defaultHeight: 160,
+    initialRight: 70,
+    initialBottom: 40,
+    minWidth: 100,
+    minHeight: 80,
+  });
+
+  if (!state.showColorbar) return null;
+
+  const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
+  const autoUnit  = dsInfo?.unit  ?? '';
+  const unit = customUnit ?? autoUnit;
+  const autoLabel = dsInfo?.label ?? state.currentDataset ?? '';
+  const label = customLabel ?? autoLabel;
+
+  const fmt = (v: number) => {
+    const abs = Math.abs(v);
+    if (abs === 0) return '0';
+    if (abs >= 10000 || (abs < 0.01 && abs > 0)) return v.toExponential(2);
+    return parseFloat(v.toPrecision(4)).toString();
+  };
+
+  const mid = (state.vmin + state.vmax) / 2;
+
+  const HEADER_H = 26;
+
+  // Adaptive padding: 2–6% of smaller dimension, clamped
+  const PAD = Math.max(4, Math.min(10, Math.round(Math.min(size.width, size.height) * 0.04)));
+
+  // Available body dimensions
+  const bodyW = size.width  - PAD * 2;
+  const bodyH = size.height - HEADER_H - PAD * 2;
+
+  // Adaptive font size: scale with panel size
+  const baseFontPx = Math.max(9, Math.min(14, Math.round(Math.min(bodyW, bodyH) * 0.09)));
+  const numStyle: React.CSSProperties = {
+    fontSize: baseFontPx,
+    color: 'var(--sb-text)',
+    fontVariantNumeric: 'tabular-nums',
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
+    lineHeight: 1.3,
+  };
+  const midStyle: React.CSSProperties = {
+    ...numStyle,
+    fontSize: baseFontPx * 0.88,
+  };
+  const unitStyle: React.CSSProperties = {
+    ...numStyle,
+    fontSize: baseFontPx * 0.8,
+    color: 'var(--sb-muted)',
+  };
+
+  // bar thickness as px derived from fraction and available space
+  const barThickH = Math.max(8, Math.round(bodyH * barFrac));
+  const barThickV = Math.max(8, Math.round(bodyW * barFrac));
+
+  return (
+    <div
+      ref={panelRef}
+      style={{
+        ...panelStyle,
+        position: 'fixed',
+        background: 'var(--sb-surface)',
+        border: '1px solid var(--sb-border)',
+        borderRadius: 10,
+        boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+        backdropFilter: 'blur(8px)',
+        zIndex: 3200,
+        display: 'flex',
+        flexDirection: 'column',
+        userSelect: 'none',
+        minWidth: 100,
+        minHeight: 80,
+      }}
+      onMouseDown={e => e.stopPropagation()}
+    >
+      {/* ── Header ── */}
+      <div
+        onMouseDown={onDragMouseDown}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '4px 8px', height: HEADER_H, cursor: 'grab',
+          borderBottom: '1px solid var(--sb-border)', flexShrink: 0, gap: 4,
+          boxSizing: 'border-box',
+        }}
+      >
+        <span style={{ flex: 1, minWidth: 0, fontSize: '0.7em', color: 'var(--sb-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          colorbar
+        </span>
+        <div style={{ display: 'flex', gap: 3, alignItems: 'center', flexShrink: 0 }}>
+          <button
+            onMouseDown={e => e.stopPropagation()}
+            onClick={() => setHorizontal(h => !h)}
+            title={horizontal ? 'Switch to vertical' : 'Switch to horizontal'}
+            style={{ background: 'none', border: '1px solid var(--sb-border)', borderRadius: 4, color: 'var(--sb-text)', cursor: 'pointer', padding: '1px 6px', fontSize: '0.75em', lineHeight: 1.4 }}
+          >
+            {horizontal ? '⇕' : '⇔'}
+          </button>
+          <button
+            onMouseDown={e => e.stopPropagation()}
+            onClick={() => dispatch({ type: 'TOGGLE_COLORBAR' })}
+            title="Close colorbar"
+            style={{ background: 'none', border: 'none', color: 'var(--sb-muted)', cursor: 'pointer', padding: '1px 5px', fontSize: '0.85em', lineHeight: 1 }}
+          >✕</button>
+        </div>
+      </div>
+
+      {/* ── Body ── */}
+      <div style={{ flex: 1, padding: PAD, boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: PAD * 0.5, overflow: 'hidden' }}>
+
+        {/* Editable label + unit row */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+          <input
+            value={label}
+            onMouseDown={e => e.stopPropagation()}
+            onChange={e => setCustomLabel(e.target.value)}
+            onBlur={e => { if (!e.target.value.trim()) setCustomLabel(null); }}
+            title="Click to edit label"
+            style={{
+              flex: 1, minWidth: 0, background: 'none', border: 'none', outline: 'none',
+              fontSize: baseFontPx * 0.85, color: 'var(--sb-muted)', cursor: 'text',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}
+          />
+          <input
+            value={unit}
+            onMouseDown={e => e.stopPropagation()}
+            onChange={e => setCustomUnit(e.target.value)}
+            onBlur={e => { if (e.target.value === autoUnit) setCustomUnit(null); }}
+            placeholder="unit"
+            title="Click to edit unit"
+            style={{
+              width: 32, flexShrink: 0, background: 'none', border: 'none', outline: 'none',
+              fontSize: baseFontPx * 0.85, color: 'var(--sb-muted)', cursor: 'text', textAlign: 'right',
+            }}
+          />
+        </div>
+
+        {horizontal ? (
+          <>
+            <img
+              src={`/colorbar/${state.colormap}`}
+              alt="colorbar"
+              style={{
+                width: '100%',
+                height: barThickH,
+                objectFit: 'fill',
+                borderRadius: 3,
+                imageRendering: 'pixelated',
+                display: 'block',
+                flexShrink: 0,
+              }}
+            />
+            {/* Labels: vmin left | mid+unit stacked center | vmax right */}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+              <span style={numStyle}>{fmt(state.vmin)}</span>
+              <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+                <span style={midStyle}>{fmt(mid)}</span>
+                {unit && <span style={unitStyle}>{unit}</span>}
+              </span>
+              <span style={numStyle}>{fmt(state.vmax)}</span>
+            </div>
+            {/* Bar height slider — collapsible */}
+            <div style={{ marginTop: 'auto', flexShrink: 0 }}>
+              <button onMouseDown={e => e.stopPropagation()} onClick={() => setShowBarSlider(s => !s)}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--sb-muted)', fontSize: baseFontPx * 0.8, display: 'flex', alignItems: 'center', gap: 3 }}>
+                <i className={`fa-solid fa-chevron-${showBarSlider ? 'up' : 'down'}`} style={{ fontSize: '0.7em' }} />
+                bar height
+              </button>
+              {showBarSlider && (
+                <input type="range" min={0.1} max={0.9} step={0.02} value={barFrac}
+                  style={{ width: '100%', marginTop: 2 }}
+                  onMouseDown={e => e.stopPropagation()}
+                  onChange={e => setBarFrac(Number(e.target.value))}
+                />
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'row', gap: PAD, minHeight: 0 }}>
+              {/* Rotated bar inside fixed-width wrapper */}
+              <div style={{
+                position: 'relative',
+                width: barThickV,
+                flexShrink: 0,
+                alignSelf: 'stretch',
+                overflow: 'hidden',
+                borderRadius: 3,
+              }}>
+                <img
+                  src={`/colorbar/${state.colormap}`}
+                  alt="colorbar"
+                  style={{
+                    position: 'absolute',
+                    width: bodyH - 30,
+                    height: barThickV,
+                    top: '50%', left: '50%',
+                    transform: 'translate(-50%, -50%) rotate(-90deg)',
+                    objectFit: 'fill',
+                    imageRendering: 'pixelated',
+                  }}
+                />
+              </div>
+              {/* Labels column: vmax top, mid rotated at center, unit (not rotated) at center right, vmin bottom */}
+              <div style={{
+                position: 'relative',
+                alignSelf: 'stretch',
+                minWidth: 0,
+                flex: 1,
+              }}>
+                <span style={{ ...numStyle, position: 'absolute', top: 0, left: 0 }}>{fmt(state.vmax)}</span>
+                {/* mid value: aligned with vmin/vmax, not rotated */}
+                <span style={{
+                  ...midStyle,
+                  position: 'absolute', top: '50%', left: 0,
+                  transform: 'translateY(-50%)',
+                  whiteSpace: 'nowrap',
+                }}>{fmt(mid)}</span>
+                {/* unit: rotated -90deg, centered in the column */}
+                {unit && <span style={{
+                  ...unitStyle,
+                  position: 'absolute', top: '50%', right: 0,
+                  transform: 'translateY(-50%) rotate(-90deg)',
+                  whiteSpace: 'nowrap',
+                  display: 'inline-block',
+                }}>{unit}</span>}
+                <span style={{ ...numStyle, position: 'absolute', bottom: 0, left: 0 }}>{fmt(state.vmin)}</span>
+              </div>
+            </div>
+            {/* Bar width slider — collapsible */}
+            <div style={{ flexShrink: 0 }}>
+              <button onMouseDown={e => e.stopPropagation()} onClick={() => setShowBarSlider(s => !s)}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--sb-muted)', fontSize: baseFontPx * 0.8, display: 'flex', alignItems: 'center', gap: 3 }}>
+                <i className={`fa-solid fa-chevron-${showBarSlider ? 'up' : 'down'}`} style={{ fontSize: '0.7em' }} />
+                bar width
+              </button>
+              {showBarSlider && (
+                <input type="range" min={0.1} max={0.9} step={0.02} value={barFrac}
+                  style={{ width: '100%', marginTop: 2 }}
+                  onMouseDown={e => e.stopPropagation()}
+                  onChange={e => setBarFrac(Number(e.target.value))}
+                />
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {resizeGrip}
+    </div>
+  );
+}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -2,35 +2,34 @@ import { useEffect, useState, useCallback } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { baseMaps } from '../basemap';
 import { useApi } from '../hooks/useApi';
+import Histogram from './Histogram';
 
 const colormapOptions = [
-  { value: 'rdbu_r', label: 'Blue-Red' },
+  { value: 'rdbu', label: 'Blue–Red' },
   { value: 'twilight', label: 'Twilight (cyclic)' },
   { value: 'cfastie', label: 'CFastie' },
   { value: 'rplumbo', label: 'RPlumbo' },
-  { value: 'schwarzwald', label: 'Schwarzwald (elevation)' },
+  { value: 'schwarzwald', label: 'Schwarzwald' },
   { value: 'viridis', label: 'Viridis' },
-  { value: 'bugn', label: 'Blue-Green' },
-  { value: 'ylgn', label: 'Yellow-Green' },
+  { value: 'bugn', label: 'Blue–Green' },
+  { value: 'ylgn', label: 'Yellow–Green' },
   { value: 'magma', label: 'Magma' },
   { value: 'gist_earth', label: 'Earth' },
   { value: 'ocean', label: 'Ocean' },
   { value: 'terrain', label: 'Terrain' },
+  { value: 'gray', label: 'Grays' },
+  { value: 'jet', label: 'Jet' },
 ];
 
 export default function ControlPanel() {
   const { state, dispatch } = useAppContext();
   const { fetchPointTimeSeries } = useApi();
-
-  // Local controlled drafts so users can type partial numbers like "-0."
   const [draftVmin, setDraftVmin] = useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = useState(String(state.vmax));
 
-  // Keep drafts in sync when state changes from outside (dataset swap, loadPreferences, etc.)
   useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
   useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
 
-  // Persist *current* state to localStorage whenever it changes
   useEffect(() => {
     const datasetName = state.currentDataset;
     if (!datasetName) return;
@@ -42,230 +41,426 @@ export default function ControlPanel() {
     localStorage.setItem(`${datasetName}-vmax`, safeNumToString(state.vmax));
   }, [state.colormap, state.vmin, state.vmax]);
 
-  // On first load / dataset change, read preferences and push into state once
   useEffect(() => {
-    const datasetName = state.currentDataset;
-    if (!datasetName) return;
-
-    const colormap = localStorage.getItem(`${datasetName}-colormap_name`);
-    const vminStr = localStorage.getItem(`${datasetName}-vmin`);
-    const vmaxStr = localStorage.getItem(`${datasetName}-vmax`);
-
+    const ds = state.currentDataset;
+    if (!ds) return;
+    const info = state.datasetInfo[ds];
+    const isPhase = info?.algorithm === 'phase' || info?.algorithm === 'rewrap';
+    const colormap = localStorage.getItem(`${ds}-colormap_name`);
+    const vminStr = localStorage.getItem(`${ds}-vmin`);
+    const vmaxStr = localStorage.getItem(`${ds}-vmax`);
     if (colormap) dispatch({ type: 'SET_COLORMAP', payload: colormap });
-
     if (vminStr !== null) {
       const v = Number(vminStr);
       if (!Number.isNaN(v)) dispatch({ type: 'SET_VMIN', payload: v });
+    } else if (isPhase) {
+      dispatch({ type: 'SET_VMIN', payload: -Math.PI });
     }
     if (vmaxStr !== null) {
       const v = Number(vmaxStr);
       if (!Number.isNaN(v)) dispatch({ type: 'SET_VMAX', payload: v });
+    } else if (isPhase) {
+      dispatch({ type: 'SET_VMAX', payload: Math.PI });
     }
   }, [state.currentDataset, dispatch]);
 
-  const handleDatasetChange = (datasetName: string) => {
-    dispatch({ type: 'SET_CURRENT_DATASET', payload: datasetName });
-
-    const currentDatasetInfo = state.datasetInfo[datasetName];
-    if (currentDatasetInfo?.uses_spatial_ref && !state.refValues[datasetName]) {
-      setRefValues(datasetName);
-    }
-  };
-
-  const handleTimeIndexChange = (newIndex: number) => {
-    dispatch({ type: 'SET_TIME_INDEX', payload: newIndex });
-  };
-
-  const handleColormapChange = (colormap: string) => {
-    dispatch({ type: 'SET_COLORMAP', payload: colormap });
+  const handleDatasetChange = (ds: string) => {
+    dispatch({ type: 'SET_CURRENT_DATASET', payload: ds });
+    const info = state.datasetInfo[ds];
+    if (info?.uses_spatial_ref && !state.refValues[ds]) setRefValues(ds);
   };
 
   const commitVmin = useCallback(() => {
     const v = Number(draftVmin);
-    if (!Number.isNaN(v)) {
-      dispatch({ type: 'SET_VMIN', payload: v });
-    }
+    if (!Number.isNaN(v)) dispatch({ type: 'SET_VMIN', payload: v });
   }, [draftVmin, dispatch]);
 
   const commitVmax = useCallback(() => {
     const v = Number(draftVmax);
-    if (!Number.isNaN(v)) {
-      dispatch({ type: 'SET_VMAX', payload: v });
-    }
+    if (!Number.isNaN(v)) dispatch({ type: 'SET_VMAX', payload: v });
   }, [draftVmax, dispatch]);
 
-  const handleOpacityChange = (opacity: number) => {
-    dispatch({ type: 'SET_OPACITY', payload: opacity });
-  };
-
-  const handleBasemapChange = (basemapKey: string) => {
-    dispatch({ type: 'SET_BASEMAP', payload: basemapKey });
-  };
-
-  const toggleChart = () => {
-    dispatch({ type: 'TOGGLE_CHART' });
-  };
-
-  const setRefValues = async (datasetName: string) => {
+  const setRefValues = async (ds: string) => {
     const [lat, lng] = state.refMarkerPosition;
     try {
-      const values = await fetchPointTimeSeries(lng, lat, datasetName);
-      if (values) {
-        dispatch({
-          type: 'SET_REF_VALUES',
-          payload: { dataset: datasetName, values }
-        });
-      }
+      const values = await fetchPointTimeSeries(lng, lat, ds);
+      if (values) dispatch({ type: 'SET_REF_VALUES', payload: { dataset: ds, values } });
     } catch (error) {
       console.error('Error setting reference values:', error);
     }
   };
 
   const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
-  const currentTimeValue = currentDatasetInfo ? currentDatasetInfo.x_values[state.currentTimeIndex] : '';
+  const currentTimeValue = currentDatasetInfo
+    ? currentDatasetInfo.x_values[state.currentTimeIndex]
+    : '';
 
   return (
     <div id="menu">
-      <div id="menu-content" className="pure-form">
-        {/* Dataset Selector */}
-        <div className="menu-group">
-          <div>
-            <i className="fa-solid fa-layer-group"></i> Layers
-          </div>
-          <div className="select-container">
-            <select
-              value={state.currentDataset}
-              onChange={(e) => handleDatasetChange(e.target.value)}
-            >
-              {Object.keys(state.datasetInfo).map((datasetName) => (
-                <option key={datasetName} value={datasetName}>
-                  {datasetName}
-                </option>
-              ))}
-            </select>
-          </div>
+      {/* ── LAYERS ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-layer-group"></i> Layers
         </div>
+        <select
+          className="sidebar-select"
+          value={state.currentDataset}
+          onChange={e => handleDatasetChange(e.target.value)}
+        >
+          {Object.keys(state.datasetInfo).map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
 
-        {/* Time Slider */}
         {currentDatasetInfo && (
-          <div className="menu-group">
-            <label htmlFor="layer-slider">
-              Viewing Image: <span id="layer-slider-value">{currentTimeValue}</span>
-            </label>
+          <div className="slider-group">
+            <div className="slider-label">
+              <span>Time step</span>
+              <span className="slider-value">{currentTimeValue}</span>
+            </div>
             <input
-              id="layer-slider"
-              className="input"
               type="range"
+              className="sidebar-range"
               min="0"
               max={currentDatasetInfo.x_values.length - 1}
               step="1"
               value={state.currentTimeIndex}
-              onChange={(e) => handleTimeIndexChange(parseInt(e.target.value))}
+              onChange={e => dispatch({ type: 'SET_TIME_INDEX', payload: parseInt(e.target.value) })}
             />
           </div>
         )}
+      </div>
 
-        {/* Colormap Section */}
-        <div className="menu-group">
-          <div id="colormap-section">
-            <div>
-              <i className="fa-solid fa-palette"></i> Color Map
-            </div>
-            <div className="select-container">
-              <select
-                value={state.colormap}
-                onChange={(e) => handleColormapChange(e.target.value)}
-              >
-                {colormapOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <img
-              id="colormap-img"
-              src={`/colorbar/${state.colormap}`}
-              style={{ maxWidth: '100%', height: 'auto' }}
-              alt="Colormap"
-            />
-          </div>
-
-          {/* Min/Max Controls */}
-          <div id="minmax-data">
-            <div>Rescale color limits</div>
-            <div>
-              <input
-                className="input"
-                type="text"
-                inputMode="decimal"
-                value={draftVmin}
-                onChange={(e) => setDraftVmin(e.target.value)}
-                onBlur={commitVmin}
-                onKeyDown={(e) => e.key === 'Enter' && commitVmin()}
-              />
-            </div>
-            <div>
-              <input
-                className="input"
-                type="text"
-                inputMode="decimal"
-                value={draftVmax}
-                onChange={(e) => setDraftVmax(e.target.value)}
-                onBlur={commitVmax}
-                onKeyDown={(e) => e.key === 'Enter' && commitVmax()}
-              />
-            </div>
-          </div>
+      {/* ── COLORMAP ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-palette"></i> Colormap
         </div>
-
-        {/* Opacity Slider */}
-        <div className="menu-group pure-form">
-          <div id="opacity-slider-container">
-            <div>
-              <label htmlFor="opacity-slider">
-                Opacity: <span id="opacity-slider-value">{state.opacity}</span>
-              </label>
-            </div>
-            <input
-              id="opacity-slider"
-              className="input"
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              value={state.opacity}
-              onChange={(e) => handleOpacityChange(parseFloat(e.target.value))}
-            />
-          </div>
-        </div>
-
-        {/* Basemap Selector */}
-        <div className="select-container">
-          Basemap:
+        <div className="colormap-row">
           <select
-            value={state.selectedBasemap}
-            onChange={(e) => handleBasemapChange(e.target.value)}
+            className="sidebar-select"
+            value={state.colormap.endsWith('_r') ? state.colormap.slice(0, -2) : state.colormap}
+            onChange={e => {
+              const base = e.target.value;
+              const inverted = state.colormap.endsWith('_r');
+              dispatch({ type: 'SET_COLORMAP', payload: inverted ? `${base}_r` : base });
+            }}
           >
-            {Object.entries(baseMaps).map(([key]) => (
-              <option key={key} value={key}>
-                {key}
-              </option>
+            {colormapOptions.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
             ))}
           </select>
+          <button
+            className={`invert-btn${state.colormap.endsWith('_r') ? ' active' : ''}`}
+            title="Invert colormap"
+            onClick={() => {
+              const cm = state.colormap;
+              dispatch({ type: 'SET_COLORMAP', payload: cm.endsWith('_r') ? cm.slice(0, -2) : `${cm}_r` });
+            }}
+          >⇅</button>
+        </div>
+        <img
+          src={`/colorbar/${state.colormap}`}
+          className="colorbar-img"
+          alt="Colormap"
+        />
+        <div className="minmax-row">
+          <div className="minmax-field">
+            <label className="minmax-label">Min</label>
+            <input
+              className="sidebar-input"
+              type="text"
+              inputMode="decimal"
+              value={draftVmin}
+              onChange={e => setDraftVmin(e.target.value)}
+              onBlur={commitVmin}
+              onKeyDown={e => e.key === 'Enter' && commitVmin()}
+            />
+          </div>
+          <div className="minmax-field">
+            <label className="minmax-label">Max</label>
+            <input
+              className="sidebar-input"
+              type="text"
+              inputMode="decimal"
+              value={draftVmax}
+              onChange={e => setDraftVmax(e.target.value)}
+              onBlur={commitVmax}
+              onKeyDown={e => e.key === 'Enter' && commitVmax()}
+            />
+          </div>
+        </div>
+
+        <div className="slider-group">
+          <div className="slider-label">
+            <span>Opacity</span>
+            <span className="slider-value">{Math.round(state.opacity * 100)}%</span>
+          </div>
+          <input
+            type="range"
+            className="sidebar-range"
+            min="0" max="1" step="0.01"
+            value={state.opacity}
+            onChange={e => dispatch({ type: 'SET_OPACITY', payload: parseFloat(e.target.value) })}
+          />
         </div>
       </div>
 
-      {/* Chart Control */}
-      <div className="menu-group">
-        <div id="menu-chart">
+      {/* ── BASEMAP ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-map"></i> Basemap
+        </div>
+        <select
+          className="sidebar-select"
+          value={state.selectedBasemap}
+          onChange={e => dispatch({ type: 'SET_BASEMAP', payload: e.target.value })}
+        >
+          {Object.keys(baseMaps).map(key => (
+            <option key={key} value={key}>{key}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* ── VALUE DISTRIBUTION ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-chart-bar"></i> Value Distribution
+        </div>
+        <Histogram />
+      </div>
+
+      {/* ── MASKING ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-mask"></i> Masking
+        </div>
+
+        {/* Layer masks list */}
+        {state.layerMasks.map(mask => (
+          <div key={mask.id} className="layer-mask-row">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
+              <select
+                className="sidebar-select"
+                style={{ flex: 1, fontSize: '0.78em' }}
+                value={mask.dataset}
+                onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { dataset: e.target.value } } })}
+              >
+                {Object.keys(state.datasetInfo).map(name => (
+                  <option key={name} value={name}>{name}</option>
+                ))}
+              </select>
+              <select
+                className="sidebar-select"
+                style={{ width: 56, fontSize: '0.78em', padding: '2px 4px' }}
+                value={mask.mode}
+                onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: e.target.value as 'min' | 'max' } } })}
+              >
+                <option value="min">≥</option>
+                <option value="max">≤</option>
+              </select>
+              <button
+                className="hist-btn"
+                style={{ color: 'var(--sb-red)', padding: '2px 6px', flexShrink: 0 }}
+                onClick={() => dispatch({ type: 'REMOVE_LAYER_MASK', payload: mask.id })}
+                title="Remove mask"
+              ><i className="fa-solid fa-xmark"></i></button>
+            </div>
+            <div className="slider-label">
+              <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>Threshold</span>
+              <span className="slider-value">{mask.threshold.toFixed(2)}</span>
+            </div>
+            <input
+              type="range" className="sidebar-range"
+              min="0" max="1" step="0.01"
+              value={mask.threshold}
+              onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })}
+            />
+          </div>
+        ))}
+
+        {/* Add mask button */}
+        {Object.keys(state.datasetInfo).length > 0 && (
           <button
-            className="pure-button pure-button-primary"
-            onClick={toggleChart}
+            className="hist-btn"
+            style={{ width: '100%', marginTop: 4 }}
+            onClick={() => {
+              const firstDataset = Object.keys(state.datasetInfo)[0];
+              dispatch({
+                type: 'ADD_LAYER_MASK',
+                payload: {
+                  id: `mask_${Date.now()}`,
+                  dataset: firstDataset,
+                  threshold: 0.5,
+                  mode: 'min',
+                },
+              });
+            }}
           >
-            {state.showChart ? 'Hide time series' : 'Show time series'}
+            <i className="fa-solid fa-plus" style={{ marginRight: 5 }}></i>Add layer mask
+          </button>
+        )}
+
+        {/* Custom mask upload */}
+        <div className="custom-mask-row" style={{ marginTop: 8 }}>
+          <label className="minmax-label" style={{ marginBottom: 4 }}>Custom mask (GeoTIFF)</label>
+          <div className="custom-mask-controls">
+            <label className="hist-btn" style={{ cursor: 'pointer', textAlign: 'center' }}>
+              Upload
+              <input
+                type="file"
+                accept=".tif,.tiff"
+                style={{ display: 'none' }}
+                onChange={async e => {
+                  const f = e.target.files?.[0];
+                  if (!f) return;
+                  const form = new FormData();
+                  form.append('file', f);
+                  const res = await fetch('/upload_mask', { method: 'POST', body: form });
+                  if (res.ok) {
+                    const data = await res.json();
+                    dispatch({ type: 'SET_CUSTOM_MASK_PATH', payload: data.path });
+                  }
+                }}
+              />
+            </label>
+            {state.customMaskPath && (
+              <button
+                className="hist-btn"
+                style={{ color: 'var(--sb-red)' }}
+                onClick={() => dispatch({ type: 'SET_CUSTOM_MASK_PATH', payload: null })}
+              >Clear</button>
+            )}
+          </div>
+          {state.customMaskPath && (
+            <div style={{ fontSize: '0.72em', color: 'var(--sb-muted)', wordBreak: 'break-all', marginTop: 2 }}>
+              {state.customMaskPath.split('/').pop()}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── BUFFER SAMPLING (time series points) ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-circle-dot"></i> Point Buffer Sampling
+        </div>
+        <div className="toggle-row">
+          <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Enable buffer mode</span>
+          <button
+            className={`toggle-pill${state.bufferEnabled ? ' active' : ''}`}
+            onClick={() => dispatch({ type: 'TOGGLE_BUFFER' })}
+          >
+            {state.bufferEnabled ? 'ON' : 'OFF'}
           </button>
         </div>
+        {state.bufferEnabled && (
+          <>
+            <div className="slider-group">
+              <div className="slider-label">
+                <span>Radius</span>
+                <span className="slider-value">{state.bufferRadius} m</span>
+              </div>
+              <input
+                type="range" className="sidebar-range"
+                min="50" max="5000" step="50"
+                value={state.bufferRadius}
+                onChange={e => dispatch({ type: 'SET_BUFFER_RADIUS', payload: parseInt(e.target.value) })}
+              />
+            </div>
+            <div className="slider-group">
+              <div className="slider-label">
+                <span>Samples shown</span>
+                <span className="slider-value">{state.bufferSamples}</span>
+              </div>
+              <input
+                type="range" className="sidebar-range"
+                min="0" max="50" step="1"
+                value={state.bufferSamples}
+                onChange={e => dispatch({ type: 'SET_BUFFER_SAMPLES', payload: parseInt(e.target.value) })}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* ── REFERENCE POINT BUFFER ── */}
+      <div className="sidebar-section">
+        <div className="sidebar-section-label">
+          <i className="fa-solid fa-crosshairs"></i> Reference Buffer
+        </div>
+        <div className="toggle-row">
+          <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Sample around ref marker</span>
+          <button
+            className={`toggle-pill${state.refBufferEnabled ? ' active' : ''}`}
+            onClick={() => dispatch({ type: 'TOGGLE_REF_BUFFER' })}
+          >
+            {state.refBufferEnabled ? 'ON' : 'OFF'}
+          </button>
+        </div>
+        {state.refBufferEnabled && (
+          <>
+            <div className="slider-group">
+              <div className="slider-label">
+                <span>Radius</span>
+                <span className="slider-value">{state.refBufferRadius} m</span>
+              </div>
+              <input
+                type="range" className="sidebar-range"
+                min="50" max="5000" step="50"
+                value={state.refBufferRadius}
+                onChange={e => dispatch({ type: 'SET_REF_BUFFER_RADIUS', payload: parseInt(e.target.value) })}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* ── CHART TOGGLES ── */}
+      <div className="sidebar-footer">
+        <button
+          className={`toggle-pill${state.pickingEnabled ? ' active' : ''}`}
+          style={{ width: '100%', marginBottom: 6, justifyContent: 'center' }}
+          onClick={() => dispatch({ type: 'TOGGLE_PICKING' })}
+          title="Toggle map-click point picking"
+        >
+          <i className="fa-solid fa-map-pin" style={{ marginRight: 6 }}></i>
+          Point Picking: {state.pickingEnabled ? 'ON' : 'OFF'}
+        </button>
+        <button
+          className={`toggle-pill${state.refEnabled ? ' active' : ''}`}
+          style={{ width: '100%', marginBottom: 6, justifyContent: 'center' }}
+          onClick={() => dispatch({ type: 'TOGGLE_REF_ENABLED' })}
+          title="Toggle spatial re-referencing"
+        >
+          <i className="fa-solid fa-crosshairs" style={{ marginRight: 6 }}></i>
+          Re-referencing: {state.refEnabled ? 'ON' : 'OFF'}
+        </button>
+        <button
+          className="chart-toggle-btn"
+          onClick={() => dispatch({ type: 'TOGGLE_CHART' })}
+        >
+          <i className={`fa-solid ${state.showChart ? 'fa-chart-line' : 'fa-wave-square'}`}></i>
+          {state.showChart ? 'Hide' : 'Show'} Time Series
+        </button>
+        <button
+          className="chart-toggle-btn"
+          style={{ marginTop: 4 }}
+          onClick={() => dispatch({ type: 'TOGGLE_PROFILE' })}
+        >
+          <i className="fa-solid fa-chart-area"></i>
+          {state.showProfile ? 'Hide' : 'Show'} Profile
+        </button>
+        {state.refBufferEnabled && (
+          <button
+            className="chart-toggle-btn"
+            style={{ marginTop: 4 }}
+            onClick={() => dispatch({ type: 'TOGGLE_REF_CHART' })}
+          >
+            <i className="fa-solid fa-crosshairs"></i>
+            {state.showRefChart ? 'Hide' : 'Show'} Ref Buffer Chart
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -26,6 +26,32 @@ export default function ControlPanel() {
   const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [draftVmin, setDraftVmin] = useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = useState(String(state.vmax));
+  const [lightTheme, setLightTheme] = useState(false);
+  // dataset range cache: { [datasetName]: { min, max, p2, p98 } }
+  const [datasetRanges, setDatasetRanges] = useState<Record<string, { min: number; max: number; p2: number; p98: number }>>({});
+
+  // Fetch range for any mask dataset not yet in cache
+  useEffect(() => {
+    const missing = state.layerMasks
+      .map(m => m.dataset)
+      .filter(ds => ds && !(ds in datasetRanges));
+    const unique = [...new Set(missing)];
+    unique.forEach(async ds => {
+      try {
+        const res = await fetch(`/dataset_range/${encodeURIComponent(ds)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setDatasetRanges(prev => ({ ...prev, [ds]: data }));
+        }
+      } catch { /* ignore */ }
+    });
+  }, [state.layerMasks, datasetRanges]);
+
+  const toggleTheme = () => {
+    const next = !lightTheme;
+    setLightTheme(next);
+    document.documentElement.setAttribute('data-theme', next ? 'light' : 'dark');
+  };
 
   useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
   useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
@@ -119,6 +145,11 @@ export default function ControlPanel() {
 
   return (
     <div id="menu">
+      <div className="sidebar-theme-toggle">
+        <button className="theme-toggle-btn" onClick={toggleTheme} title={lightTheme ? 'Switch to dark theme' : 'Switch to light theme'}>
+          <i className={`fa-solid ${lightTheme ? 'fa-moon' : 'fa-sun'}`}></i>
+        </button>
+      </div>
       {/* ── LAYERS ── */}
       <div className="sidebar-section">
         <div className="sidebar-section-label">
@@ -259,47 +290,69 @@ export default function ControlPanel() {
         </div>
 
         {/* Layer masks list */}
-        {state.layerMasks.map(mask => (
-          <div key={mask.id} className="layer-mask-row">
-            <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
-              <select
-                className="sidebar-select"
-                style={{ flex: 1, fontSize: '0.78em' }}
-                value={mask.dataset}
-                onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { dataset: e.target.value } } })}
-              >
-                {Object.keys(state.datasetInfo).map(name => (
-                  <option key={name} value={name}>{name}</option>
-                ))}
-              </select>
-              <select
-                className="sidebar-select"
-                style={{ width: 56, fontSize: '0.78em', padding: '2px 4px' }}
-                value={mask.mode}
-                onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: e.target.value as 'min' | 'max' } } })}
-              >
-                <option value="min">≥</option>
-                <option value="max">≤</option>
-              </select>
-              <button
-                className="hist-btn"
-                style={{ color: 'var(--sb-red)', padding: '2px 6px', flexShrink: 0 }}
-                onClick={() => dispatch({ type: 'REMOVE_LAYER_MASK', payload: mask.id })}
-                title="Remove mask"
-              ><i className="fa-solid fa-xmark"></i></button>
+        {state.layerMasks.map(mask => {
+          const range = datasetRanges[mask.dataset];
+          const rMin = range?.p2  ?? range?.min ?? 0;
+          const rMax = range?.p98 ?? range?.max ?? 1;
+          const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
+          return (
+            <div key={mask.id} className="layer-mask-row">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
+                <select
+                  className="sidebar-select"
+                  style={{ flex: 1, fontSize: '0.78em' }}
+                  value={mask.dataset}
+                  onChange={e => {
+                    const ds = e.target.value;
+                    const newRange = datasetRanges[ds];
+                    const defaultThreshold = newRange ? newRange.p2 ?? newRange.min : 0.5;
+                    dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
+                  }}
+                >
+                  {Object.keys(state.datasetInfo).map(name => (
+                    <option key={name} value={name}>{name}</option>
+                  ))}
+                </select>
+                <select
+                  className="sidebar-select"
+                  style={{ width: 56, fontSize: '0.78em', padding: '2px 4px' }}
+                  value={mask.mode}
+                  onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: e.target.value as 'min' | 'max' } } })}
+                >
+                  <option value="min">≥</option>
+                  <option value="max">≤</option>
+                </select>
+                <button
+                  className="hist-btn"
+                  style={{ color: 'var(--sb-red)', padding: '2px 6px', flexShrink: 0 }}
+                  onClick={() => dispatch({ type: 'REMOVE_LAYER_MASK', payload: mask.id })}
+                  title="Remove mask"
+                ><i className="fa-solid fa-xmark"></i></button>
+              </div>
+              <div className="slider-label">
+                <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>
+                  Threshold{range ? ` [${rMin.toPrecision(3)}, ${rMax.toPrecision(3)}]` : ''}
+                </span>
+                <input
+                  type="number"
+                  style={{ width: 72, fontSize: '0.75em', background: 'var(--sb-surface2)', border: '1px solid var(--sb-border)', borderRadius: 4, color: 'var(--sb-text)', padding: '1px 4px', textAlign: 'right' }}
+                  step={step}
+                  value={parseFloat(mask.threshold.toPrecision(4))}
+                  onChange={e => {
+                    const v = parseFloat(e.target.value);
+                    if (!isNaN(v)) dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: v } } });
+                  }}
+                />
+              </div>
+              <input
+                type="range" className="sidebar-range"
+                min={rMin} max={rMax} step={step}
+                value={mask.threshold}
+                onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })}
+              />
             </div>
-            <div className="slider-label">
-              <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>Threshold (normalised)</span>
-              <span className="slider-value">{mask.threshold.toFixed(2)}</span>
-            </div>
-            <input
-              type="range" className="sidebar-range"
-              min="0" max="1" step="0.01"
-              value={mask.threshold}
-              onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })}
-            />
-          </div>
-        ))}
+          );
+        })}
 
         {/* Add mask button */}
         {Object.keys(state.datasetInfo).length > 0 && (
@@ -308,12 +361,14 @@ export default function ControlPanel() {
             style={{ width: '100%', marginTop: 4 }}
             onClick={() => {
               const firstDataset = Object.keys(state.datasetInfo)[0];
+              const range = datasetRanges[firstDataset];
+              const defaultThreshold = range ? (range.p2 ?? range.min) : 0.5;
               dispatch({
                 type: 'ADD_LAYER_MASK',
                 payload: {
                   id: `mask_${Date.now()}`,
                   dataset: firstDataset,
-                  threshold: 0.5,
+                  threshold: defaultThreshold,
                   mode: 'min',
                 },
               });
@@ -464,14 +519,6 @@ export default function ControlPanel() {
         >
           <i className={`fa-solid ${state.showChart ? 'fa-chart-line' : 'fa-wave-square'}`}></i>
           {state.showChart ? 'Hide' : 'Show'} Time Series
-        </button>
-        <button
-          className="chart-toggle-btn"
-          style={{ marginTop: 4 }}
-          onClick={() => dispatch({ type: 'TOGGLE_PROFILE' })}
-        >
-          <i className="fa-solid fa-chart-area"></i>
-          {state.showProfile ? 'Hide' : 'Show'} Profile
         </button>
         {state.refBufferEnabled && (
           <button

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -23,7 +23,7 @@ const colormapOptions = [
 
 export default function ControlPanel() {
   const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
+  const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [draftVmin, setDraftVmin] = useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = useState(String(state.vmax));
 
@@ -67,8 +67,18 @@ export default function ControlPanel() {
   const handleDatasetChange = (ds: string) => {
     dispatch({ type: 'SET_CURRENT_DATASET', payload: ds });
     const info = state.datasetInfo[ds];
-    if (info?.uses_spatial_ref && !state.refValues[ds]) setRefValues(ds);
+    if (info?.uses_spatial_ref) setRefValues(ds);
   };
+
+  // Re-fetch ref values when buffer toggle or radius changes (for tile shift correction)
+  useEffect(() => {
+    const ds = state.currentDataset;
+    if (!ds) return;
+    const info = state.datasetInfo[ds];
+    if (!info?.uses_spatial_ref) return;
+    setRefValues(ds);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.refBufferEnabled, state.refBufferRadius]);
 
   const commitVmin = useCallback(() => {
     const v = Number(draftVmin);
@@ -83,7 +93,19 @@ export default function ControlPanel() {
   const setRefValues = async (ds: string) => {
     const [lat, lng] = state.refMarkerPosition;
     try {
-      const values = await fetchPointTimeSeries(lng, lat, ds);
+      let values: number[] | undefined;
+      if (state.refBufferEnabled && state.refBufferRadius > 0) {
+        const result = await fetchBufferTimeSeries(lng, lat, ds, state.refBufferRadius, 0);
+        if (result?.median) {
+          // Re-align sparse {x,y} array back to full-length index array
+          const xValues = state.datasetInfo[ds]?.x_values?.map(String) ?? result.labels?.map(String) ?? [];
+          const byX = Object.fromEntries(result.median.map((pt: { x: string; y: number }) => [String(pt.x), pt.y]));
+          values = xValues.map((x: string) => byX[x] ?? NaN);
+        }
+      }
+      if (!values) {
+        values = await fetchPointTimeSeries(lng, lat, ds);
+      }
       if (values) dispatch({ type: 'SET_REF_VALUES', payload: { dataset: ds, values } });
     } catch (error) {
       console.error('Error setting reference values:', error);
@@ -267,7 +289,7 @@ export default function ControlPanel() {
               ><i className="fa-solid fa-xmark"></i></button>
             </div>
             <div className="slider-label">
-              <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>Threshold</span>
+              <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>Threshold (normalised)</span>
               <span className="slider-value">{mask.threshold.toFixed(2)}</span>
             </div>
             <input

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { baseMaps } from '../basemap';
 import { useApi } from '../hooks/useApi';
@@ -21,12 +21,14 @@ const colormapOptions = [
   { value: 'jet', label: 'Jet' },
 ];
 
-export default function ControlPanel() {
+export default function ControlPanel({ title }: { title: string }) {
   const { state, dispatch } = useAppContext();
   const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [draftVmin, setDraftVmin] = useState(String(state.vmin));
   const [draftVmax, setDraftVmax] = useState(String(state.vmax));
   const [lightTheme, setLightTheme] = useState(false);
+  const [draftRefLat, setDraftRefLat] = useState(String(state.refMarkerPosition[0]));
+  const [draftRefLon, setDraftRefLon] = useState(String(state.refMarkerPosition[1]));
   // dataset range cache: { [datasetName]: { min, max, p2, p98 } }
   const [datasetRanges, setDatasetRanges] = useState<Record<string, { min: number; max: number; p2: number; p98: number }>>({});
 
@@ -55,6 +57,10 @@ export default function ControlPanel() {
 
   useEffect(() => setDraftVmin(String(state.vmin)), [state.vmin]);
   useEffect(() => setDraftVmax(String(state.vmax)), [state.vmax]);
+  useEffect(() => {
+    setDraftRefLat(state.refMarkerPosition[0].toFixed(6));
+    setDraftRefLon(state.refMarkerPosition[1].toFixed(6));
+  }, [state.refMarkerPosition]);
 
   useEffect(() => {
     const datasetName = state.currentDataset;
@@ -138,10 +144,34 @@ export default function ControlPanel() {
     }
   };
 
+  const commitRefPosition = useCallback(() => {
+    const lat = parseFloat(draftRefLat);
+    const lon = parseFloat(draftRefLon);
+    if (isNaN(lat) || isNaN(lon)) return;
+    dispatch({ type: 'SET_REF_MARKER_POSITION', payload: [lat, lon] });
+    const ds = state.currentDataset;
+    if (ds && state.datasetInfo[ds]?.uses_spatial_ref) setRefValues(ds);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftRefLat, draftRefLon, state.currentDataset, state.datasetInfo, dispatch]);
+
   const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
   const currentTimeValue = currentDatasetInfo
     ? currentDatasetInfo.x_values[state.currentTimeIndex]
     : '';
+
+  // Animation: auto-advance time index (lives here so it works regardless of chart visibility)
+  const nTimes = currentDatasetInfo?.x_values?.length ?? 0;
+  const timeIndexRef = useRef(state.currentTimeIndex);
+  timeIndexRef.current = state.currentTimeIndex;
+  const nTimesRef = useRef(nTimes);
+  nTimesRef.current = nTimes;
+  useEffect(() => {
+    if (!state.isPlaying || nTimes === 0) return;
+    const id = setInterval(() => {
+      dispatch({ type: 'SET_TIME_INDEX', payload: (timeIndexRef.current + 1) % nTimesRef.current });
+    }, state.animationSpeed);
+    return () => clearInterval(id);
+  }, [state.isPlaying, state.animationSpeed, nTimes, dispatch]);
 
   return (
     <div id="menu">
@@ -150,6 +180,7 @@ export default function ControlPanel() {
           <i className={`fa-solid ${lightTheme ? 'fa-moon' : 'fa-sun'}`}></i>
         </button>
       </div>
+      {title && <div className="sidebar-title">{title}</div>}
       {/* ── LAYERS ── */}
       <div className="sidebar-section">
         <div className="sidebar-section-label">
@@ -180,6 +211,32 @@ export default function ControlPanel() {
               value={state.currentTimeIndex}
               onChange={e => dispatch({ type: 'SET_TIME_INDEX', payload: parseInt(e.target.value) })}
             />
+            {currentDatasetInfo.x_values.length > 1 && (
+              <div className="anim-controls">
+                <button
+                  className={`toggle-pill anim-play-btn${state.isPlaying ? ' active' : ''}`}
+                  onClick={() => dispatch({ type: 'TOGGLE_PLAYING' })}
+                  title={state.isPlaying ? 'Pause animation' : 'Play animation'}
+                >
+                  <i className={`fa-solid ${state.isPlaying ? 'fa-pause' : 'fa-play'}`}></i>
+                  {state.isPlaying ? 'Pause' : 'Play'}
+                </button>
+                <div className="slider-label" style={{ marginTop: 4 }}>
+                  <span>Speed</span>
+                  <span className="slider-value">{(1000 / state.animationSpeed).toFixed(1)}×</span>
+                </div>
+                <input
+                  type="range"
+                  className="sidebar-range"
+                  min="100"
+                  max="2000"
+                  step="100"
+                  value={2100 - state.animationSpeed}
+                  onChange={e => dispatch({ type: 'SET_ANIMATION_SPEED', payload: 2100 - parseInt(e.target.value) })}
+                  title="Animation speed"
+                />
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -305,7 +362,10 @@ export default function ControlPanel() {
                   onChange={e => {
                     const ds = e.target.value;
                     const newRange = datasetRanges[ds];
-                    const defaultThreshold = newRange ? newRange.p2 ?? newRange.min : 0.5;
+                    // For ≥ mode default to p2 (keep above low end); for ≤ mode default to p98 (keep below high end)
+                    const defaultThreshold = newRange
+                      ? (mask.mode === 'max' ? (newRange.p98 ?? newRange.max) : (newRange.p2 ?? newRange.min)) ?? 0.5
+                      : 0.5;
                     dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
                   }}
                 >
@@ -317,7 +377,16 @@ export default function ControlPanel() {
                   className="sidebar-select"
                   style={{ width: 56, fontSize: '0.78em', padding: '2px 4px' }}
                   value={mask.mode}
-                  onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: e.target.value as 'min' | 'max' } } })}
+                  onChange={e => {
+                    const newMode = e.target.value as 'min' | 'max';
+                    const r = datasetRanges[mask.dataset];
+                    // Reset threshold to a sensible default for the new mode:
+                    // ≥ (min) → p2 (low end, keep everything above); ≤ (max) → p98 (high end, keep everything below)
+                    const newThreshold = r
+                      ? (newMode === 'max' ? (r.p98 ?? r.max) : (r.p2 ?? r.min)) ?? mask.threshold
+                      : mask.threshold;
+                    dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: newMode, threshold: newThreshold } } });
+                  }}
                 >
                   <option value="min">≥</option>
                   <option value="max">≤</option>
@@ -464,9 +533,35 @@ export default function ControlPanel() {
       {/* ── REFERENCE POINT BUFFER ── */}
       <div className="sidebar-section">
         <div className="sidebar-section-label">
-          <i className="fa-solid fa-crosshairs"></i> Reference Buffer
+          <i className="fa-solid fa-crosshairs"></i> Reference Point
         </div>
-        <div className="toggle-row">
+        <div className="minmax-row">
+          <div className="minmax-field">
+            <label className="minmax-label">Lat</label>
+            <input
+              className="sidebar-input"
+              type="text"
+              inputMode="decimal"
+              value={draftRefLat}
+              onChange={e => setDraftRefLat(e.target.value)}
+              onBlur={commitRefPosition}
+              onKeyDown={e => e.key === 'Enter' && commitRefPosition()}
+            />
+          </div>
+          <div className="minmax-field">
+            <label className="minmax-label">Lon</label>
+            <input
+              className="sidebar-input"
+              type="text"
+              inputMode="decimal"
+              value={draftRefLon}
+              onChange={e => setDraftRefLon(e.target.value)}
+              onBlur={commitRefPosition}
+              onKeyDown={e => e.key === 'Enter' && commitRefPosition()}
+            />
+          </div>
+        </div>
+        <div className="toggle-row" style={{ marginTop: 6 }}>
           <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Sample around ref marker</span>
           <button
             className={`toggle-pill${state.refBufferEnabled ? ' active' : ''}`}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -29,6 +29,14 @@ export default function ControlPanel({ title }: { title: string }) {
   const [lightTheme, setLightTheme] = useState(false);
   const [draftRefLat, setDraftRefLat] = useState(String(state.refMarkerPosition[0]));
   const [draftRefLon, setDraftRefLon] = useState(String(state.refMarkerPosition[1]));
+  const [draftBounds, setDraftBounds] = useState({ s: '', w: '', n: '', e: '' });
+  const boundsEditingRef = useRef(false);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({
+    distribution: true,
+    masking: true,
+    buffer: true,
+  });
+  const toggleSection = (key: string) => setCollapsed(c => ({ ...c, [key]: !c[key] }));
   // dataset range cache: { [datasetName]: { min, max, p2, p98 } }
   const [datasetRanges, setDatasetRanges] = useState<Record<string, { min: number; max: number; p2: number; p98: number }>>({});
 
@@ -61,6 +69,22 @@ export default function ControlPanel({ title }: { title: string }) {
     setDraftRefLat(state.refMarkerPosition[0].toFixed(6));
     setDraftRefLon(state.refMarkerPosition[1].toFixed(6));
   }, [state.refMarkerPosition]);
+
+  // Keep draft bounds in sync when map moves — but not while user is editing a field
+  useEffect(() => {
+    if (!state.viewBounds || boundsEditingRef.current) return;
+    const [s, w, n, e] = state.viewBounds;
+    setDraftBounds({ s: String(s), w: String(w), n: String(n), e: String(e) });
+  }, [state.viewBounds]);
+
+  const applyViewBounds = () => {
+    const s = parseFloat(draftBounds.s);
+    const w = parseFloat(draftBounds.w);
+    const n = parseFloat(draftBounds.n);
+    const e = parseFloat(draftBounds.e);
+    if ([s, w, n, e].some(isNaN)) return;
+    dispatch({ type: 'SET_VIEW_BOUNDS', payload: [s, w, n, e] });
+  };
 
   useEffect(() => {
     const datasetName = state.currentDataset;
@@ -173,6 +197,20 @@ export default function ControlPanel({ title }: { title: string }) {
     return () => clearInterval(id);
   }, [state.isPlaying, state.animationSpeed, nTimes, dispatch]);
 
+  const SectionHeader = ({ icon, label, collapseKey }: { icon: string; label: string; collapseKey?: string }) => (
+    <div
+      className="sidebar-section-label"
+      style={collapseKey ? { cursor: 'pointer', userSelect: 'none' } : undefined}
+      onClick={collapseKey ? () => toggleSection(collapseKey) : undefined}
+    >
+      <span><i className={`fa-solid ${icon}`}></i> {label}</span>
+      {collapseKey && (
+        <i className={`fa-solid fa-chevron-${collapsed[collapseKey] ? 'down' : 'up'}`}
+          style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }} />
+      )}
+    </div>
+  );
+
   return (
     <div id="menu">
       <div className="sidebar-theme-toggle">
@@ -181,33 +219,23 @@ export default function ControlPanel({ title }: { title: string }) {
         </button>
       </div>
       {title && <div className="sidebar-title">{title}</div>}
+
       {/* ── LAYERS ── */}
       <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-layer-group"></i> Layers
-        </div>
-        <select
-          className="sidebar-select"
-          value={state.currentDataset}
-          onChange={e => handleDatasetChange(e.target.value)}
-        >
+        <SectionHeader icon="fa-layer-group" label="Layers" />
+        <select className="sidebar-select" value={state.currentDataset} onChange={e => handleDatasetChange(e.target.value)}>
           {Object.keys(state.datasetInfo).map(name => (
             <option key={name} value={name}>{name}</option>
           ))}
         </select>
-
         {currentDatasetInfo && (
           <div className="slider-group">
             <div className="slider-label">
               <span>Time step</span>
               <span className="slider-value">{currentTimeValue}</span>
             </div>
-            <input
-              type="range"
-              className="sidebar-range"
-              min="0"
-              max={currentDatasetInfo.x_values.length - 1}
-              step="1"
+            <input type="range" className="sidebar-range"
+              min="0" max={currentDatasetInfo.x_values.length - 1} step="1"
               value={state.currentTimeIndex}
               onChange={e => dispatch({ type: 'SET_TIME_INDEX', payload: parseInt(e.target.value) })}
             />
@@ -225,15 +253,10 @@ export default function ControlPanel({ title }: { title: string }) {
                   <span>Speed</span>
                   <span className="slider-value">{(1000 / state.animationSpeed).toFixed(1)}×</span>
                 </div>
-                <input
-                  type="range"
-                  className="sidebar-range"
-                  min="100"
-                  max="2000"
-                  step="100"
+                <input type="range" className="sidebar-range"
+                  min="100" max="2000" step="100"
                   value={2100 - state.animationSpeed}
                   onChange={e => dispatch({ type: 'SET_ANIMATION_SPEED', payload: 2100 - parseInt(e.target.value) })}
-                  title="Animation speed"
                 />
               </div>
             )}
@@ -241,11 +264,9 @@ export default function ControlPanel({ title }: { title: string }) {
         )}
       </div>
 
-      {/* ── COLORMAP ── */}
+      {/* ── VISUALIZATION ── */}
       <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-palette"></i> Colormap
-        </div>
+        <SectionHeader icon="fa-palette" label="Visualization" />
         <div className="colormap-row">
           <select
             className="sidebar-select"
@@ -269,358 +290,319 @@ export default function ControlPanel({ title }: { title: string }) {
             }}
           >⇅</button>
         </div>
-        <img
-          src={`/colorbar/${state.colormap}`}
-          className="colorbar-img"
-          alt="Colormap"
-        />
+        <img src={`/colorbar/${state.colormap}`} className="colorbar-img" alt="Colormap" />
         <div className="minmax-row">
           <div className="minmax-field">
             <label className="minmax-label">Min</label>
-            <input
-              className="sidebar-input"
-              type="text"
-              inputMode="decimal"
-              value={draftVmin}
-              onChange={e => setDraftVmin(e.target.value)}
-              onBlur={commitVmin}
-              onKeyDown={e => e.key === 'Enter' && commitVmin()}
-            />
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftVmin} onChange={e => setDraftVmin(e.target.value)}
+              onBlur={commitVmin} onKeyDown={e => e.key === 'Enter' && commitVmin()} />
           </div>
           <div className="minmax-field">
             <label className="minmax-label">Max</label>
-            <input
-              className="sidebar-input"
-              type="text"
-              inputMode="decimal"
-              value={draftVmax}
-              onChange={e => setDraftVmax(e.target.value)}
-              onBlur={commitVmax}
-              onKeyDown={e => e.key === 'Enter' && commitVmax()}
-            />
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftVmax} onChange={e => setDraftVmax(e.target.value)}
+              onBlur={commitVmax} onKeyDown={e => e.key === 'Enter' && commitVmax()} />
           </div>
         </div>
-
         <div className="slider-group">
           <div className="slider-label">
             <span>Opacity</span>
             <span className="slider-value">{Math.round(state.opacity * 100)}%</span>
           </div>
-          <input
-            type="range"
-            className="sidebar-range"
-            min="0" max="1" step="0.01"
-            value={state.opacity}
-            onChange={e => dispatch({ type: 'SET_OPACITY', payload: parseFloat(e.target.value) })}
-          />
+          <input type="range" className="sidebar-range"
+            min="0" max="1" step="0.01" value={state.opacity}
+            onChange={e => dispatch({ type: 'SET_OPACITY', payload: parseFloat(e.target.value) })} />
         </div>
+        <div className="toggle-row" style={{ marginTop: 4 }}>
+          <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Colorbar on map</span>
+          <button
+            className={`toggle-pill${state.showColorbar ? ' active' : ''}`}
+            onClick={() => dispatch({ type: 'TOGGLE_COLORBAR' })}
+          >{state.showColorbar ? 'ON' : 'OFF'}</button>
+        </div>
+      </div>
+
+      {/* ── VALUE DISTRIBUTION ── */}
+      <div className="sidebar-section">
+        <SectionHeader icon="fa-chart-bar" label="Distribution" />
+        <Histogram />
       </div>
 
       {/* ── BASEMAP ── */}
       <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-map"></i> Basemap
-        </div>
-        <select
-          className="sidebar-select"
-          value={state.selectedBasemap}
-          onChange={e => dispatch({ type: 'SET_BASEMAP', payload: e.target.value })}
-        >
+        <SectionHeader icon="fa-map" label="Basemap" />
+        <select className="sidebar-select" value={state.selectedBasemap}
+          onChange={e => dispatch({ type: 'SET_BASEMAP', payload: e.target.value })}>
           {Object.keys(baseMaps).map(key => (
             <option key={key} value={key}>{key}</option>
           ))}
         </select>
       </div>
 
-      {/* ── VALUE DISTRIBUTION ── */}
+      {/* ── VIEW EXTENT ── */}
       <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-chart-bar"></i> Value Distribution
-        </div>
-        <Histogram />
-      </div>
-
-      {/* ── MASKING ── */}
-      <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-mask"></i> Masking
-        </div>
-
-        {/* Layer masks list */}
-        {state.layerMasks.map(mask => {
-          const range = datasetRanges[mask.dataset];
-          const rMin = range?.p2  ?? range?.min ?? 0;
-          const rMax = range?.p98 ?? range?.max ?? 1;
-          const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
-          return (
-            <div key={mask.id} className="layer-mask-row">
-              <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
-                <select
-                  className="sidebar-select"
-                  style={{ flex: 1, fontSize: '0.78em' }}
-                  value={mask.dataset}
-                  onChange={e => {
-                    const ds = e.target.value;
-                    const newRange = datasetRanges[ds];
-                    // For ≥ mode default to p2 (keep above low end); for ≤ mode default to p98 (keep below high end)
-                    const defaultThreshold = newRange
-                      ? (mask.mode === 'max' ? (newRange.p98 ?? newRange.max) : (newRange.p2 ?? newRange.min)) ?? 0.5
-                      : 0.5;
-                    dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
-                  }}
-                >
-                  {Object.keys(state.datasetInfo).map(name => (
-                    <option key={name} value={name}>{name}</option>
-                  ))}
-                </select>
-                <select
-                  className="sidebar-select"
-                  style={{ width: 56, fontSize: '0.78em', padding: '2px 4px' }}
-                  value={mask.mode}
-                  onChange={e => {
-                    const newMode = e.target.value as 'min' | 'max';
-                    const r = datasetRanges[mask.dataset];
-                    // Reset threshold to a sensible default for the new mode:
-                    // ≥ (min) → p2 (low end, keep everything above); ≤ (max) → p98 (high end, keep everything below)
-                    const newThreshold = r
-                      ? (newMode === 'max' ? (r.p98 ?? r.max) : (r.p2 ?? r.min)) ?? mask.threshold
-                      : mask.threshold;
-                    dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: newMode, threshold: newThreshold } } });
-                  }}
-                >
-                  <option value="min">≥</option>
-                  <option value="max">≤</option>
-                </select>
-                <button
-                  className="hist-btn"
-                  style={{ color: 'var(--sb-red)', padding: '2px 6px', flexShrink: 0 }}
-                  onClick={() => dispatch({ type: 'REMOVE_LAYER_MASK', payload: mask.id })}
-                  title="Remove mask"
-                ><i className="fa-solid fa-xmark"></i></button>
-              </div>
-              <div className="slider-label">
-                <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>
-                  Threshold{range ? ` [${rMin.toPrecision(3)}, ${rMax.toPrecision(3)}]` : ''}
-                </span>
-                <input
-                  type="number"
-                  style={{ width: 72, fontSize: '0.75em', background: 'var(--sb-surface2)', border: '1px solid var(--sb-border)', borderRadius: 4, color: 'var(--sb-text)', padding: '1px 4px', textAlign: 'right' }}
-                  step={step}
-                  value={parseFloat(mask.threshold.toPrecision(4))}
-                  onChange={e => {
-                    const v = parseFloat(e.target.value);
-                    if (!isNaN(v)) dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: v } } });
-                  }}
-                />
-              </div>
-              <input
-                type="range" className="sidebar-range"
-                min={rMin} max={rMax} step={step}
-                value={mask.threshold}
-                onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })}
-              />
-            </div>
-          );
-        })}
-
-        {/* Add mask button */}
-        {Object.keys(state.datasetInfo).length > 0 && (
-          <button
-            className="hist-btn"
-            style={{ width: '100%', marginTop: 4 }}
-            onClick={() => {
-              const firstDataset = Object.keys(state.datasetInfo)[0];
-              const range = datasetRanges[firstDataset];
-              const defaultThreshold = range ? (range.p2 ?? range.min) : 0.5;
-              dispatch({
-                type: 'ADD_LAYER_MASK',
-                payload: {
-                  id: `mask_${Date.now()}`,
-                  dataset: firstDataset,
-                  threshold: defaultThreshold,
-                  mode: 'min',
-                },
-              });
-            }}
-          >
-            <i className="fa-solid fa-plus" style={{ marginRight: 5 }}></i>Add layer mask
-          </button>
-        )}
-
-        {/* Custom mask upload */}
-        <div className="custom-mask-row" style={{ marginTop: 8 }}>
-          <label className="minmax-label" style={{ marginBottom: 4 }}>Custom mask (GeoTIFF)</label>
-          <div className="custom-mask-controls">
-            <label className="hist-btn" style={{ cursor: 'pointer', textAlign: 'center' }}>
-              Upload
-              <input
-                type="file"
-                accept=".tif,.tiff"
-                style={{ display: 'none' }}
-                onChange={async e => {
-                  const f = e.target.files?.[0];
-                  if (!f) return;
-                  const form = new FormData();
-                  form.append('file', f);
-                  const res = await fetch('/upload_mask', { method: 'POST', body: form });
-                  if (res.ok) {
-                    const data = await res.json();
-                    dispatch({ type: 'SET_CUSTOM_MASK_PATH', payload: data.path });
-                  }
-                }}
-              />
-            </label>
-            {state.customMaskPath && (
-              <button
-                className="hist-btn"
-                style={{ color: 'var(--sb-red)' }}
-                onClick={() => dispatch({ type: 'SET_CUSTOM_MASK_PATH', payload: null })}
-              >Clear</button>
-            )}
+        <SectionHeader icon="fa-expand" label="View Extent" />
+        <div className="minmax-row">
+          <div className="minmax-field">
+            <label className="minmax-label">N</label>
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftBounds.n}
+              onFocus={() => { boundsEditingRef.current = true; }}
+              onChange={e => setDraftBounds(b => ({ ...b, n: e.target.value }))}
+              onBlur={() => { boundsEditingRef.current = false; }}
+              onKeyDown={e => e.key === 'Enter' && applyViewBounds()} />
           </div>
-          {state.customMaskPath && (
-            <div style={{ fontSize: '0.72em', color: 'var(--sb-muted)', wordBreak: 'break-all', marginTop: 2 }}>
-              {state.customMaskPath.split('/').pop()}
-            </div>
+          <div className="minmax-field">
+            <label className="minmax-label">S</label>
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftBounds.s}
+              onFocus={() => { boundsEditingRef.current = true; }}
+              onChange={e => setDraftBounds(b => ({ ...b, s: e.target.value }))}
+              onBlur={() => { boundsEditingRef.current = false; }}
+              onKeyDown={e => e.key === 'Enter' && applyViewBounds()} />
+          </div>
+        </div>
+        <div className="minmax-row" style={{ marginTop: 4 }}>
+          <div className="minmax-field">
+            <label className="minmax-label">W</label>
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftBounds.w}
+              onFocus={() => { boundsEditingRef.current = true; }}
+              onChange={e => setDraftBounds(b => ({ ...b, w: e.target.value }))}
+              onBlur={() => { boundsEditingRef.current = false; }}
+              onKeyDown={e => e.key === 'Enter' && applyViewBounds()} />
+          </div>
+          <div className="minmax-field">
+            <label className="minmax-label">E</label>
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftBounds.e}
+              onFocus={() => { boundsEditingRef.current = true; }}
+              onChange={e => setDraftBounds(b => ({ ...b, e: e.target.value }))}
+              onBlur={() => { boundsEditingRef.current = false; }}
+              onKeyDown={e => e.key === 'Enter' && applyViewBounds()} />
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+          <button className="chart-btn" style={{ flex: 1 }} onClick={applyViewBounds}>
+            <i className="fa-solid fa-location-crosshairs"></i> Apply
+          </button>
+          {state.currentDataset && state.datasetInfo[state.currentDataset] && (
+            <button className="chart-btn" style={{ flex: 1 }} onClick={() => {
+              const b = state.datasetInfo[state.currentDataset].latlon_bounds;
+              dispatch({ type: 'SET_VIEW_BOUNDS', payload: [b[1], b[0], b[3], b[2]] });
+            }}>
+              <i className="fa-solid fa-arrows-to-circle"></i> Dataset
+            </button>
           )}
         </div>
       </div>
 
-      {/* ── BUFFER SAMPLING (time series points) ── */}
+      {/* ── REFERENCE POINT ── */}
       <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-circle-dot"></i> Point Buffer Sampling
-        </div>
-        <div className="toggle-row">
-          <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Enable buffer mode</span>
-          <button
-            className={`toggle-pill${state.bufferEnabled ? ' active' : ''}`}
-            onClick={() => dispatch({ type: 'TOGGLE_BUFFER' })}
-          >
-            {state.bufferEnabled ? 'ON' : 'OFF'}
-          </button>
-        </div>
-        {state.bufferEnabled && (
-          <>
-            <div className="slider-group">
-              <div className="slider-label">
-                <span>Radius</span>
-                <span className="slider-value">{state.bufferRadius} m</span>
-              </div>
-              <input
-                type="range" className="sidebar-range"
-                min="50" max="5000" step="50"
-                value={state.bufferRadius}
-                onChange={e => dispatch({ type: 'SET_BUFFER_RADIUS', payload: parseInt(e.target.value) })}
-              />
-            </div>
-            <div className="slider-group">
-              <div className="slider-label">
-                <span>Samples shown</span>
-                <span className="slider-value">{state.bufferSamples}</span>
-              </div>
-              <input
-                type="range" className="sidebar-range"
-                min="0" max="50" step="1"
-                value={state.bufferSamples}
-                onChange={e => dispatch({ type: 'SET_BUFFER_SAMPLES', payload: parseInt(e.target.value) })}
-              />
-            </div>
-          </>
-        )}
-      </div>
-
-      {/* ── REFERENCE POINT BUFFER ── */}
-      <div className="sidebar-section">
-        <div className="sidebar-section-label">
-          <i className="fa-solid fa-crosshairs"></i> Reference Point
-        </div>
+        <SectionHeader icon="fa-crosshairs" label="Reference Point" />
         <div className="minmax-row">
           <div className="minmax-field">
             <label className="minmax-label">Lat</label>
-            <input
-              className="sidebar-input"
-              type="text"
-              inputMode="decimal"
-              value={draftRefLat}
-              onChange={e => setDraftRefLat(e.target.value)}
-              onBlur={commitRefPosition}
-              onKeyDown={e => e.key === 'Enter' && commitRefPosition()}
-            />
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftRefLat} onChange={e => setDraftRefLat(e.target.value)}
+              onBlur={commitRefPosition} onKeyDown={e => e.key === 'Enter' && commitRefPosition()} />
           </div>
           <div className="minmax-field">
             <label className="minmax-label">Lon</label>
-            <input
-              className="sidebar-input"
-              type="text"
-              inputMode="decimal"
-              value={draftRefLon}
-              onChange={e => setDraftRefLon(e.target.value)}
-              onBlur={commitRefPosition}
-              onKeyDown={e => e.key === 'Enter' && commitRefPosition()}
-            />
+            <input className="sidebar-input" type="text" inputMode="decimal"
+              value={draftRefLon} onChange={e => setDraftRefLon(e.target.value)}
+              onBlur={commitRefPosition} onKeyDown={e => e.key === 'Enter' && commitRefPosition()} />
           </div>
         </div>
         <div className="toggle-row" style={{ marginTop: 6 }}>
           <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Sample around ref marker</span>
-          <button
-            className={`toggle-pill${state.refBufferEnabled ? ' active' : ''}`}
-            onClick={() => dispatch({ type: 'TOGGLE_REF_BUFFER' })}
-          >
+          <button className={`toggle-pill${state.refBufferEnabled ? ' active' : ''}`}
+            onClick={() => dispatch({ type: 'TOGGLE_REF_BUFFER' })}>
             {state.refBufferEnabled ? 'ON' : 'OFF'}
           </button>
         </div>
         {state.refBufferEnabled && (
+          <div className="slider-group">
+            <div className="slider-label">
+              <span>Radius</span>
+              <span className="slider-value">{state.refBufferRadius} m</span>
+            </div>
+            <input type="range" className="sidebar-range"
+              min="5" max="5000" step="5" value={state.refBufferRadius}
+              onChange={e => dispatch({ type: 'SET_REF_BUFFER_RADIUS', payload: parseInt(e.target.value) })} />
+          </div>
+        )}
+      </div>
+
+      {/* ── MASKING (collapsible) ── */}
+      <div className="sidebar-section">
+        <SectionHeader icon="fa-mask" label="Masking" collapseKey="masking" />
+        {!collapsed.masking && (
           <>
-            <div className="slider-group">
-              <div className="slider-label">
-                <span>Radius</span>
-                <span className="slider-value">{state.refBufferRadius} m</span>
+            {state.layerMasks.map(mask => {
+              const range = datasetRanges[mask.dataset];
+              const rMin = range?.p2  ?? range?.min ?? 0;
+              const rMax = range?.p98 ?? range?.max ?? 1;
+              const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
+              return (
+                <div key={mask.id} className="layer-mask-row">
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
+                    <select className="sidebar-select" style={{ flex: 1, fontSize: '0.78em' }}
+                      value={mask.dataset}
+                      onChange={e => {
+                        const ds = e.target.value;
+                        const newRange = datasetRanges[ds];
+                        const defaultThreshold = newRange
+                          ? (mask.mode === 'max' ? (newRange.p98 ?? newRange.max) : (newRange.p2 ?? newRange.min)) ?? 0.5
+                          : 0.5;
+                        dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { dataset: ds, threshold: defaultThreshold } } });
+                      }}>
+                      {Object.keys(state.datasetInfo).map(name => (
+                        <option key={name} value={name}>{name}</option>
+                      ))}
+                    </select>
+                    <select className="sidebar-select" style={{ width: 56, fontSize: '0.78em', padding: '2px 4px' }}
+                      value={mask.mode}
+                      onChange={e => {
+                        const newMode = e.target.value as 'min' | 'max';
+                        const r = datasetRanges[mask.dataset];
+                        const newThreshold = r
+                          ? (newMode === 'max' ? (r.p98 ?? r.max) : (r.p2 ?? r.min)) ?? mask.threshold
+                          : mask.threshold;
+                        dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { mode: newMode, threshold: newThreshold } } });
+                      }}>
+                      <option value="min">≥</option>
+                      <option value="max">≤</option>
+                    </select>
+                    <button className="hist-btn"
+                      style={{ color: 'var(--sb-red)', padding: '2px 6px', flexShrink: 0 }}
+                      onClick={() => dispatch({ type: 'REMOVE_LAYER_MASK', payload: mask.id })}
+                    ><i className="fa-solid fa-xmark"></i></button>
+                  </div>
+                  <div className="slider-label">
+                    <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>
+                      Threshold{range ? ` [${rMin.toPrecision(3)}, ${rMax.toPrecision(3)}]` : ''}
+                    </span>
+                    <input type="number"
+                      style={{ width: 72, fontSize: '0.75em', background: 'var(--sb-surface2)', border: '1px solid var(--sb-border)', borderRadius: 4, color: 'var(--sb-text)', padding: '1px 4px', textAlign: 'right' }}
+                      step={step} value={parseFloat(mask.threshold.toPrecision(4))}
+                      onChange={e => {
+                        const v = parseFloat(e.target.value);
+                        if (!isNaN(v)) dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: v } } });
+                      }} />
+                  </div>
+                  <input type="range" className="sidebar-range"
+                    min={rMin} max={rMax} step={step} value={mask.threshold}
+                    onChange={e => dispatch({ type: 'UPDATE_LAYER_MASK', payload: { id: mask.id, updates: { threshold: parseFloat(e.target.value) } } })} />
+                </div>
+              );
+            })}
+            {Object.keys(state.datasetInfo).length > 0 && (
+              <button className="hist-btn" style={{ width: '100%', marginTop: 4 }}
+                onClick={() => {
+                  const firstDataset = Object.keys(state.datasetInfo)[0];
+                  const range = datasetRanges[firstDataset];
+                  dispatch({ type: 'ADD_LAYER_MASK', payload: {
+                    id: `mask_${Date.now()}`, dataset: firstDataset,
+                    threshold: range ? (range.p2 ?? range.min) : 0.5, mode: 'min',
+                  }});
+                }}>
+                <i className="fa-solid fa-plus" style={{ marginRight: 5 }}></i>Add layer mask
+              </button>
+            )}
+            <div className="custom-mask-row" style={{ marginTop: 8 }}>
+              <label className="minmax-label" style={{ marginBottom: 4 }}>Custom mask (GeoTIFF)</label>
+              <div className="custom-mask-controls">
+                <label className="hist-btn" style={{ cursor: 'pointer', textAlign: 'center' }}>
+                  Upload
+                  <input type="file" accept=".tif,.tiff" style={{ display: 'none' }}
+                    onChange={async e => {
+                      const f = e.target.files?.[0];
+                      if (!f) return;
+                      const form = new FormData();
+                      form.append('file', f);
+                      const res = await fetch('/upload_mask', { method: 'POST', body: form });
+                      if (res.ok) {
+                        const data = await res.json();
+                        dispatch({ type: 'SET_CUSTOM_MASK_PATH', payload: data.path });
+                      }
+                    }} />
+                </label>
+                {state.customMaskPath && (
+                  <button className="hist-btn" style={{ color: 'var(--sb-red)' }}
+                    onClick={() => dispatch({ type: 'SET_CUSTOM_MASK_PATH', payload: null })}>Clear</button>
+                )}
               </div>
-              <input
-                type="range" className="sidebar-range"
-                min="50" max="5000" step="50"
-                value={state.refBufferRadius}
-                onChange={e => dispatch({ type: 'SET_REF_BUFFER_RADIUS', payload: parseInt(e.target.value) })}
-              />
+              {state.customMaskPath && (
+                <div style={{ fontSize: '0.72em', color: 'var(--sb-muted)', wordBreak: 'break-all', marginTop: 2 }}>
+                  {state.customMaskPath.split('/').pop()}
+                </div>
+              )}
             </div>
           </>
         )}
       </div>
 
-      {/* ── CHART TOGGLES ── */}
+      {/* ── BUFFER SAMPLING (collapsible) ── */}
+      <div className="sidebar-section">
+        <SectionHeader icon="fa-circle-dot" label="Point Buffer" collapseKey="buffer" />
+        {!collapsed.buffer && (
+          <>
+            <div className="toggle-row">
+              <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>Enable buffer mode</span>
+              <button className={`toggle-pill${state.bufferEnabled ? ' active' : ''}`}
+                onClick={() => dispatch({ type: 'TOGGLE_BUFFER' })}>
+                {state.bufferEnabled ? 'ON' : 'OFF'}
+              </button>
+            </div>
+            {state.bufferEnabled && (
+              <>
+                <div className="slider-group">
+                  <div className="slider-label">
+                    <span>Radius</span><span className="slider-value">{state.bufferRadius} m</span>
+                  </div>
+                  <input type="range" className="sidebar-range"
+                    min="5" max="5000" step="5" value={state.bufferRadius}
+                    onChange={e => dispatch({ type: 'SET_BUFFER_RADIUS', payload: parseInt(e.target.value) })} />
+                </div>
+                <div className="slider-group">
+                  <div className="slider-label">
+                    <span>Samples shown</span><span className="slider-value">{state.bufferSamples}</span>
+                  </div>
+                  <input type="range" className="sidebar-range"
+                    min="0" max="50" step="1" value={state.bufferSamples}
+                    onChange={e => dispatch({ type: 'SET_BUFFER_SAMPLES', payload: parseInt(e.target.value) })} />
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ── FOOTER TOGGLES ── */}
       <div className="sidebar-footer">
-        <button
-          className={`toggle-pill${state.pickingEnabled ? ' active' : ''}`}
+        <button className={`toggle-pill${state.pickingEnabled ? ' active' : ''}`}
           style={{ width: '100%', marginBottom: 6, justifyContent: 'center' }}
           onClick={() => dispatch({ type: 'TOGGLE_PICKING' })}
-          title="Toggle map-click point picking"
-        >
+          title="Toggle map-click point picking">
           <i className="fa-solid fa-map-pin" style={{ marginRight: 6 }}></i>
           Point Picking: {state.pickingEnabled ? 'ON' : 'OFF'}
         </button>
-        <button
-          className={`toggle-pill${state.refEnabled ? ' active' : ''}`}
+        <button className={`toggle-pill${state.refEnabled ? ' active' : ''}`}
           style={{ width: '100%', marginBottom: 6, justifyContent: 'center' }}
           onClick={() => dispatch({ type: 'TOGGLE_REF_ENABLED' })}
-          title="Toggle spatial re-referencing"
-        >
+          title="Toggle spatial re-referencing">
           <i className="fa-solid fa-crosshairs" style={{ marginRight: 6 }}></i>
           Re-referencing: {state.refEnabled ? 'ON' : 'OFF'}
         </button>
-        <button
-          className="chart-toggle-btn"
-          onClick={() => dispatch({ type: 'TOGGLE_CHART' })}
-        >
+        <button className="chart-toggle-btn" onClick={() => dispatch({ type: 'TOGGLE_CHART' })}>
           <i className={`fa-solid ${state.showChart ? 'fa-chart-line' : 'fa-wave-square'}`}></i>
           {state.showChart ? 'Hide' : 'Show'} Time Series
         </button>
         {state.refBufferEnabled && (
-          <button
-            className="chart-toggle-btn"
-            style={{ marginTop: 4 }}
-            onClick={() => dispatch({ type: 'TOGGLE_REF_CHART' })}
-          >
+          <button className="chart-toggle-btn" style={{ marginTop: 4 }}
+            onClick={() => dispatch({ type: 'TOGGLE_REF_CHART' })}>
             <i className="fa-solid fa-crosshairs"></i>
             {state.showRefChart ? 'Hide' : 'Show'} Ref Buffer Chart
           </button>

--- a/src/components/Histogram.tsx
+++ b/src/components/Histogram.tsx
@@ -66,6 +66,12 @@ export default function Histogram() {
     dispatch({ type: 'SET_VMAX', payload: parseFloat(histData.p977.toFixed(4)) });
   };
 
+  const handleCenterZero = () => {
+    const absMax = parseFloat(Math.max(Math.abs(state.vmin), Math.abs(state.vmax)).toFixed(4));
+    dispatch({ type: 'SET_VMIN', payload: -absMax });
+    dispatch({ type: 'SET_VMAX', payload: absMax });
+  };
+
   if (!state.currentDataset || loading) {
     return <div className="histogram-loading">{loading ? 'Computing…' : ''}</div>;
   }
@@ -124,6 +130,9 @@ export default function Histogram() {
         </button>
         <button className="hist-btn" onClick={handleFullScale} title="Full range">
           Full
+        </button>
+        <button className="hist-btn" onClick={handleCenterZero} title="Symmetric around zero: ±max(|vmin|,|vmax|)">
+          ±0
         </button>
       </div>
     </div>

--- a/src/components/Histogram.tsx
+++ b/src/components/Histogram.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Tooltip } from 'chart.js';
+import { useAppContext } from '../context/AppContext';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip);
+
+interface HistogramData {
+  bins: number[];
+  counts: number[];
+  min: number;
+  max: number;
+  p2: number;
+  p98: number;
+  p16: number;
+  p84: number;
+  p23: number;
+  p977: number;
+}
+
+export default function Histogram() {
+  const { state, dispatch } = useAppContext();
+  const [histData, setHistData] = useState<HistogramData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchHistogram = useCallback(async () => {
+    if (!state.currentDataset) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ time_index: String(state.currentTimeIndex) });
+      const res = await fetch(`/histogram/${encodeURIComponent(state.currentDataset)}?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setHistData(data);
+      }
+    } catch (e) {
+      console.error('Error fetching histogram:', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [state.currentDataset, state.currentTimeIndex]);
+
+  useEffect(() => { fetchHistogram(); }, [fetchHistogram]);
+
+  const handleAutoScale = () => {
+    if (!histData) return;
+    dispatch({ type: 'SET_VMIN', payload: parseFloat(histData.p2.toFixed(4)) });
+    dispatch({ type: 'SET_VMAX', payload: parseFloat(histData.p98.toFixed(4)) });
+  };
+
+  const handleFullScale = () => {
+    if (!histData) return;
+    dispatch({ type: 'SET_VMIN', payload: parseFloat(histData.min.toFixed(4)) });
+    dispatch({ type: 'SET_VMAX', payload: parseFloat(histData.max.toFixed(4)) });
+  };
+
+  const handleSigmaScale = () => {
+    if (!histData || histData.p16 == null || histData.p84 == null) return;
+    dispatch({ type: 'SET_VMIN', payload: parseFloat(histData.p16.toFixed(4)) });
+    dispatch({ type: 'SET_VMAX', payload: parseFloat(histData.p84.toFixed(4)) });
+  };
+
+  const handleTwoSigmaScale = () => {
+    if (!histData || histData.p23 == null || histData.p977 == null) return;
+    dispatch({ type: 'SET_VMIN', payload: parseFloat(histData.p23.toFixed(4)) });
+    dispatch({ type: 'SET_VMAX', payload: parseFloat(histData.p977.toFixed(4)) });
+  };
+
+  if (!state.currentDataset || loading) {
+    return <div className="histogram-loading">{loading ? 'Computing…' : ''}</div>;
+  }
+  if (!histData || histData.bins.length < 2) return null;
+
+  const labels = histData.bins.slice(0, -1).map((b, i) =>
+    ((b + histData.bins[i + 1]) / 2).toFixed(4)
+  );
+
+  const bgColors = histData.bins.slice(0, -1).map((b, i) => {
+    const center = (b + histData.bins[i + 1]) / 2;
+    return center >= state.vmin && center <= state.vmax
+      ? 'rgba(77,157,224,0.85)'
+      : 'rgba(120,120,160,0.30)';
+  });
+
+  const chartData = {
+    labels,
+    datasets: [{ data: histData.counts, backgroundColor: bgColors, borderWidth: 0, borderRadius: 2 }],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 0 },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          title: (ctx: any) => `Value: ${ctx[0].label}`,
+          label: (ctx: any) => `Count: ${ctx.raw}`,
+        },
+      },
+    },
+    scales: { x: { display: false }, y: { display: false } },
+  };
+
+  return (
+    <div className="histogram-wrapper">
+      <div className="histogram-chart-area">
+        <Bar data={chartData} options={options as any} />
+      </div>
+      <div className="histogram-range">
+        <span className="hist-val">{histData.min.toFixed(3)}</span>
+        <span className="hist-val">{histData.max.toFixed(3)}</span>
+      </div>
+      <div className="histogram-buttons">
+        <button className="hist-btn" onClick={handleAutoScale} title="2nd–98th percentile">
+          2–98%
+        </button>
+        <button className="hist-btn" onClick={handleSigmaScale} title="±1σ (16–84%)">
+          ±1σ
+        </button>
+        <button className="hist-btn" onClick={handleTwoSigmaScale} title="±2σ (2.3–97.7%)">
+          ±2σ
+        </button>
+        <button className="hist-btn" onClick={handleFullScale} title="Full range">
+          Full
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Histogram.tsx
+++ b/src/components/Histogram.tsx
@@ -24,7 +24,7 @@ export default function Histogram() {
   const [loading, setLoading] = useState(false);
 
   const fetchHistogram = useCallback(async () => {
-    if (!state.currentDataset) return;
+    if (!state.currentDataset || state.isPlaying) return;
     setLoading(true);
     try {
       const params = new URLSearchParams({ time_index: String(state.currentTimeIndex) });
@@ -38,7 +38,7 @@ export default function Histogram() {
     } finally {
       setLoading(false);
     }
-  }, [state.currentDataset, state.currentTimeIndex]);
+  }, [state.currentDataset, state.currentTimeIndex, state.isPlaying]);
 
   useEffect(() => { fetchHistogram(); }, [fetchHistogram]);
 

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -7,7 +7,7 @@ import { useAppContext } from '../context/AppContext';
 import { baseMaps } from '../basemap';
 import { MousePositionControl } from '../mouse';
 import MeasureTool from './MeasureTool';
-import ProfileTool from './ProfileTool';
+import { ProfileToolMap, useProfileContext } from './ProfileTool';
 
 // Fix for default markers in React Leaflet
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -437,7 +437,7 @@ export default function MapContainer() {
   const center = getInitialCenter();
   const hasDatasets = Object.keys(state.datasetInfo).length > 0;
   const [measureActive, setMeasureActive] = useState(false);
-  const [profileActive, setProfileActive] = useState(false);
+  const { active: profileActive, setActive: setProfileActive } = useProfileContext();
 
   return (
     <div className="map-container">
@@ -452,7 +452,7 @@ export default function MapContainer() {
         <button
           className={`map-tool-btn${profileActive ? ' active' : ''}`}
           title="Draw profile line (click start, click end, double-click to extract)"
-          onClick={() => { setProfileActive(v => !v); setMeasureActive(false); }}
+          onClick={() => { setProfileActive(!profileActive); setMeasureActive(false); }}
         >
           <i className="fa-solid fa-chart-area"></i>
         </button>
@@ -476,7 +476,7 @@ export default function MapContainer() {
       <MousePosition />
       <ScaleBar />
       <MeasureTool active={measureActive} onDeactivate={() => setMeasureActive(false)} />
-      <ProfileTool active={profileActive} onDeactivate={() => setProfileActive(false)} />
+      <ProfileToolMap />
       <MapViewController />
     </LeafletMapContainer>
     </div>

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { MapContainer as LeafletMapContainer, TileLayer, Marker, useMapEvents, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -8,7 +8,6 @@ import { baseMaps } from '../basemap';
 import { MousePositionControl } from '../mouse';
 import MeasureTool from './MeasureTool';
 import ProfileTool from './ProfileTool';
-import RefPointChart from './RefPointChart';
 
 // Fix for default markers in React Leaflet
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -36,6 +35,50 @@ function MapEvents() {
           position: [e.latlng.lat, e.latlng.lng],
           name: `Point ${Date.now().toString().slice(-4)}`
         }
+      });
+    },
+  });
+
+  return null;
+}
+
+// Syncs map view ↔ state.viewBounds.
+// When viewBounds changes (user edited sidebar), fly to it.
+// When user pans/zooms, update viewBounds in state so sidebar stays in sync.
+function MapViewController() {
+  const { state, dispatch } = useAppContext();
+  const map = useMap();
+  const flyingRef = useRef(false);
+
+  // Fly to bounds when state changes (triggered from sidebar "Apply")
+  useEffect(() => {
+    if (!state.viewBounds) return;
+    const [s, w, n, e] = state.viewBounds;
+    flyingRef.current = true;
+    const bounds = L.latLngBounds([[s, w], [n, e]]);
+    const center = bounds.getCenter();
+    // getBoundsZoom with inside=true returns fractional zoom — no integer snapping
+    const zoom = map.getBoundsZoom(bounds, true);
+    map.setView(center, zoom, { animate: true });
+    const onEnd = () => { flyingRef.current = false; };
+    map.once('moveend', onEnd);
+    return () => { map.off('moveend', onEnd); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.viewBounds]);
+
+  // Update state when user moves map (throttled to moveend only)
+  useMapEvents({
+    moveend: () => {
+      if (flyingRef.current) return;
+      const b = map.getBounds();
+      dispatch({
+        type: 'SET_VIEW_BOUNDS',
+        payload: [
+          parseFloat(b.getSouth().toFixed(6)),
+          parseFloat(b.getWest().toFixed(6)),
+          parseFloat(b.getNorth().toFixed(6)),
+          parseFloat(b.getEast().toFixed(6)),
+        ],
       });
     },
   });
@@ -434,7 +477,7 @@ export default function MapContainer() {
       <ScaleBar />
       <MeasureTool active={measureActive} onDeactivate={() => setMeasureActive(false)} />
       <ProfileTool active={profileActive} onDeactivate={() => setProfileActive(false)} />
-      <RefPointChart />
+      <MapViewController />
     </LeafletMapContainer>
     </div>
   );

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -113,7 +113,9 @@ function RasterTileLayer() {
 
       // Add shift for reference point if available and re-referencing is enabled
       if (state.refEnabled && state.refValues[state.currentDataset] && currentDatasetInfo.algorithm === 'shift') {
-        const shift = state.refValues[state.currentDataset][timeIdx];
+        const refArr = state.refValues[state.currentDataset];
+        // For 2D variables (no time dim) the ref array has only one element; fall back to index 0
+        const shift = refArr[timeIdx] ?? refArr[0];
         if (shift !== undefined) {
           params.algorithm_params = JSON.stringify({ shift });
         }

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -75,7 +75,11 @@ function RasterTileLayer() {
   const [tileUrl, setTileUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!state.currentDataset || !state.datasetInfo[state.currentDataset]) {
+    if (!state.currentDataset || !state.datasetInfo[state.currentDataset] || !state.dataMode) {
+      return;
+    }
+    // dataMode starts as 'md' default; wait until datasets are loaded (which confirms mode is set)
+    if (state.dataMode !== 'md' && state.dataMode !== 'cog') {
       return;
     }
 
@@ -122,7 +126,7 @@ function RasterTileLayer() {
         const maskMinValue = currentDatasetInfo.mask_min_value;
 
         params.url = url;
-        if (maskUrl) params.mask = encodeURIComponent(maskUrl);
+        if (maskUrl) params.mask = maskUrl;
         if (maskMinValue !== undefined) params.mask_min_value = maskMinValue.toString();
         if (state.customMaskPath) params.custom_mask = state.customMaskPath;
         params.time_idx = timeIdx.toString();
@@ -158,8 +162,10 @@ function RasterTileLayer() {
       }
     };
 
-    updateTileLayer();
-    return () => controller.abort();
+    // Debounce: collapse rapid state changes (histogram → rescale → ref point)
+    // into a single request to avoid transient 500s from concurrent opens.
+    const debounceTimer = setTimeout(() => updateTileLayer(), 80);
+    return () => { clearTimeout(debounceTimer); controller.abort(); };
   }, [
     state.currentDataset,
     state.currentTimeIndex,
@@ -185,6 +191,56 @@ function RasterTileLayer() {
       maxZoom={19}
     />
   );
+}
+
+/** Draw radius circles on the map for buffer-enabled points and reference marker. */
+function RadiusCircles() {
+  const { state } = useAppContext();
+  const map = useMap();
+
+  useEffect(() => {
+    const circles: L.Circle[] = [];
+
+    // Time-series point buffer circles
+    if (state.bufferEnabled && state.bufferRadius > 0) {
+      state.timeSeriesPoints.filter(p => p.visible).forEach(point => {
+        circles.push(L.circle([point.position[0], point.position[1]], {
+          radius: state.bufferRadius,
+          color: point.color,
+          fillColor: point.color,
+          fillOpacity: 0.08,
+          weight: 1.5,
+          dashArray: '4 3',
+        }).addTo(map));
+      });
+    }
+
+    // Reference marker buffer circle
+    if (state.refEnabled && state.refBufferEnabled && state.refBufferRadius > 0) {
+      const [lat, lng] = state.refMarkerPosition;
+      circles.push(L.circle([lat, lng], {
+        radius: state.refBufferRadius,
+        color: '#e05d6a',
+        fillColor: '#e05d6a',
+        fillOpacity: 0.08,
+        weight: 1.5,
+        dashArray: '4 3',
+      }).addTo(map));
+    }
+
+    return () => { circles.forEach(c => c.remove()); };
+  }, [
+    map,
+    state.bufferEnabled,
+    state.bufferRadius,
+    state.refEnabled,
+    state.refBufferEnabled,
+    state.refBufferRadius,
+    state.refMarkerPosition,
+    JSON.stringify(state.timeSeriesPoints.map(p => ({ id: p.id, pos: p.position, vis: p.visible }))),
+  ]);
+
+  return null;
 }
 
 function MarkerEventHandlers() {
@@ -369,6 +425,7 @@ export default function MapContainer() {
         maxZoom={19}
       />
       <RasterTileLayer />
+      <RadiusCircles />
       <MarkerEventHandlers />
       <MapEvents />
       <MousePosition />

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -189,7 +189,7 @@ function RasterTileLayer() {
 
 function MarkerEventHandlers() {
   const { state, dispatch } = useAppContext();
-  const { fetchPointTimeSeries } = useApi();
+  const { fetchPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const map = useMap();
 
   const handleMarkerClick = (position: [number, number], pointName?: string) => {
@@ -228,12 +228,20 @@ function MarkerEventHandlers() {
     const info = ds ? state.datasetInfo[ds] : null;
     if (ds && info?.algorithm === 'shift') {
       try {
-        const values = await fetchPointTimeSeries(lng, lat, ds);
+        let values: number[] | undefined;
+        if (state.refBufferEnabled && state.refBufferRadius > 0) {
+          const result = await fetchBufferTimeSeries(lng, lat, ds, state.refBufferRadius, 0);
+          if (result?.median) {
+            const xValues = state.datasetInfo[ds]?.x_values?.map(String) ?? result.labels?.map(String) ?? [];
+            const byX = Object.fromEntries(result.median.map((pt: { x: string; y: number }) => [String(pt.x), pt.y]));
+            values = xValues.map((x: string) => byX[x] ?? NaN);
+          }
+        }
+        if (!values) {
+          values = await fetchPointTimeSeries(lng, lat, ds);
+        }
         if (values) {
-          dispatch({
-            type: 'SET_REF_VALUES',
-            payload: { dataset: ds, values },
-          });
+          dispatch({ type: 'SET_REF_VALUES', payload: { dataset: ds, values } });
         }
       } catch (err) {
         console.error('Error updating reference values after drag:', err);

--- a/src/components/MeasureTool.tsx
+++ b/src/components/MeasureTool.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+
+interface MeasureToolProps {
+  active: boolean;
+  onDeactivate: () => void;
+}
+
+export default function MeasureTool({ active, onDeactivate }: MeasureToolProps) {
+  const map = useMap();
+  const pointsRef = useRef<L.LatLng[]>([]);
+  const linesRef = useRef<L.Polyline[]>([]);
+  const markersRef = useRef<L.CircleMarker[]>([]);
+  const labelRef = useRef<L.Popup | null>(null);
+
+  const fmtDist = (m: number) => m >= 1000 ? `${(m / 1000).toFixed(2)} km` : `${m.toFixed(0)} m`;
+
+  const clearAll = () => {
+    linesRef.current.forEach(l => l.remove());
+    markersRef.current.forEach(m => m.remove());
+    if (labelRef.current) labelRef.current.remove();
+    pointsRef.current = [];
+    linesRef.current = [];
+    markersRef.current = [];
+    labelRef.current = null;
+  };
+
+  useEffect(() => {
+    if (!active) { clearAll(); return; }
+
+    map.getContainer().style.cursor = 'crosshair';
+
+    const onClick = (e: L.LeafletMouseEvent) => {
+      const pts = pointsRef.current;
+      pts.push(e.latlng);
+
+      const dot = L.circleMarker(e.latlng, {
+        radius: 4, color: '#4d9de0', fillColor: '#4d9de0', fillOpacity: 1, weight: 2,
+      }).addTo(map);
+      markersRef.current.push(dot);
+
+      if (pts.length > 1) {
+        const seg = L.polyline([pts[pts.length - 2], pts[pts.length - 1]], {
+          color: '#4d9de0', weight: 2, dashArray: '6 4',
+        }).addTo(map);
+        linesRef.current.push(seg);
+
+        const total = pts.reduce((acc, p, i) => i === 0 ? 0 : acc + pts[i - 1].distanceTo(p), 0);
+
+        if (labelRef.current) labelRef.current.remove();
+        labelRef.current = L.popup({ closeButton: false, autoClose: false, closeOnClick: false })
+          .setLatLng(e.latlng)
+          .setContent(`<b>${fmtDist(total)}</b>`)
+          .openOn(map);
+      }
+    };
+
+    const onDblClick = (e: L.LeafletMouseEvent) => {
+      L.DomEvent.stop(e);
+      onDeactivate();
+    };
+
+    map.on('click', onClick);
+    map.on('dblclick', onDblClick);
+    map.doubleClickZoom.disable();
+
+    return () => {
+      map.off('click', onClick);
+      map.off('dblclick', onDblClick);
+      map.doubleClickZoom.enable();
+      map.getContainer().style.cursor = '';
+      clearAll();
+    };
+  }, [active, map]);
+
+  return null;
+}

--- a/src/components/ProfileTool.tsx
+++ b/src/components/ProfileTool.tsx
@@ -4,7 +4,7 @@ import { Line } from 'react-chartjs-2';
 import L from 'leaflet';
 import { useAppContext } from '../context/AppContext';
 
-interface ProfilePoint { dist: number; value: number }
+interface CentrePoint { dist: number; value: number }
 
 // Vertex handle — defined once at module level, not recreated on each render
 const VERTEX_ICON = L.divIcon({
@@ -12,6 +12,11 @@ const VERTEX_ICON = L.divIcon({
   html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
   iconSize: [0, 0],
 });
+
+/** Read a CSS variable from the document root. */
+function cssVar(name: string, fallback: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
 
 export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { active: boolean; onDeactivate: () => void }) {
   const map = useMap();
@@ -24,11 +29,12 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   const ptsRef     = useRef<L.LatLng[]>([]);
   const modeRef    = useRef<'idle' | 'drawing' | 'ready'>('idle');
 
-  const [profileData, setProfileData] = useState<ProfilePoint[] | null>(null);
+  const [profileData, setProfileData] = useState<{ centre: CentrePoint[]; median: CentrePoint[] | null; samples: CentrePoint[][] } | null>(null);
   const [loading, setLoading]         = useState(false);
+  const [radius, setRadius]           = useState(0);
 
   // Always-current reference to fetchProfile so drag handlers never go stale
-  const fetchFn = useCallback(async (pts: L.LatLng[]) => {
+  const fetchFn = useCallback(async (pts: L.LatLng[], r: number) => {
     if (pts.length < 2 || !state.currentDataset) return;
     setLoading(true);
     try {
@@ -40,9 +46,22 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
           dataset_name: state.currentDataset,
           time_index: state.currentTimeIndex,
           n_samples: 200,
+          radius: r,
+          n_random: 5,
         }),
       });
-      if (res.ok) setProfileData(await res.json());
+      if (!res.ok) return;
+      const json = await res.json();
+      if (Array.isArray(json)) {
+        // Legacy centre-line response
+        setProfileData({ centre: json, median: null, samples: [] });
+      } else {
+        setProfileData({
+          centre: json.centre ?? [],
+          median: json.median ?? null,
+          samples: json.samples ?? [],
+        });
+      }
     } finally {
       setLoading(false);
     }
@@ -50,6 +69,9 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
 
   const fetchRef = useRef(fetchFn);
   useEffect(() => { fetchRef.current = fetchFn; }, [fetchFn]);
+
+  const radiusRef = useRef(radius);
+  useEffect(() => { radiusRef.current = radius; }, [radius]);
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -71,7 +93,7 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
       });
       m.on('dragend', () => {
         ptsRef.current[idx] = m.getLatLng();
-        fetchRef.current(ptsRef.current);
+        fetchRef.current(ptsRef.current, radiusRef.current);
       });
       return m;
     });
@@ -90,14 +112,72 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   // Re-fetch when time index changes while a profile is drawn
   useEffect(() => {
     if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current);
     }
   }, [state.currentTimeIndex, active]);
+
+  // Re-fetch when radius changes while a profile is ready
+  useEffect(() => {
+    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
+      fetchRef.current(ptsRef.current, radius);
+    }
+  }, [radius, active]);
+
+  // ── Buffer corridor visualization ──────────────────────────────────────────
+  useEffect(() => {
+    if (!active || radius <= 0 || ptsRef.current.length < 2) return;
+
+    // Build a polygon corridor around the polyline using L.circle at each vertex
+    // as a simple approach: draw two offset polylines forming a band.
+    // We use L.geodesicPolygon-style by computing perpendicular offsets via
+    // Leaflet's CRS projection.
+    const pts = ptsRef.current;
+    const offsetPoints: L.LatLng[][] = [[], []]; // [left side, right side]
+
+    for (let i = 0; i < pts.length; i++) {
+      // Bearing from prev or next segment
+      let bearingRad: number;
+      if (i < pts.length - 1) {
+        const dx = pts[i + 1].lng - pts[i].lng;
+        const dy = pts[i + 1].lat - pts[i].lat;
+        bearingRad = Math.atan2(dx, dy);
+      } else {
+        const dx = pts[i].lng - pts[i - 1].lng;
+        const dy = pts[i].lat - pts[i - 1].lat;
+        bearingRad = Math.atan2(dx, dy);
+      }
+
+      // Approximate degrees offset for the given radius in metres at this latitude
+      const lat = pts[i].lat;
+      const metersPerDegLat = 111320;
+      const metersPerDegLng = 111320 * Math.cos((lat * Math.PI) / 180);
+      const perpBearing = bearingRad + Math.PI / 2;
+      const dLat = (radius / metersPerDegLat) * Math.cos(perpBearing);
+      const dLng = (radius / metersPerDegLng) * Math.sin(perpBearing);
+
+      offsetPoints[0].push(L.latLng(pts[i].lat + dLat, pts[i].lng + dLng));
+      offsetPoints[1].push(L.latLng(pts[i].lat - dLat, pts[i].lng - dLng));
+    }
+
+    // Polygon: left side forward + right side reversed
+    const poly = L.polygon([...offsetPoints[0], ...offsetPoints[1].reverse()], {
+      color: '#f0a500',
+      fillColor: '#f0a500',
+      fillOpacity: 0.12,
+      weight: 1,
+      dashArray: '4 3',
+    }).addTo(map);
+
+    return () => { poly.remove(); };
+  }, [active, radius, map,
+    // re-run when pts change (after drawing / dragging)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    profileData,
+  ]);
 
   // ── Main map event effect ──────────────────────────────────────────────────
   useEffect(() => {
     if (!active) {
-      // Button turned off → clear everything
       clearAll();
       map.getContainer().style.cursor = '';
       return;
@@ -107,7 +187,6 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
 
     const onClick = (e: L.LeafletMouseEvent) => {
       if (modeRef.current === 'ready') {
-        // Start a fresh profile on the next click
         clearAll();
         modeRef.current = 'drawing';
         map.getContainer().style.cursor = 'crosshair';
@@ -137,7 +216,7 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
       modeRef.current = 'ready';
       map.getContainer().style.cursor = 'default';
       rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current);
     };
 
     map.on('click', onClick);
@@ -155,6 +234,8 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   }, [active, map, clearAll]);
 
   // ── Chart panel ────────────────────────────────────────────────────────────
+  if (!active) return null;
+
   if (loading) {
     return (
       <div className="profile-panel">
@@ -163,37 +244,92 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
     );
   }
 
-  if (!profileData || profileData.length === 0 || !state.showProfile) return null;
+  const textColor  = cssVar('--sb-text',   '#dde0f0');
+  const mutedColor = cssVar('--sb-muted',  '#7880a8');
+  const gridColor  = cssVar('--sb-border', '#2c2f4a');
 
-  const chartData = {
-    labels: profileData.map(p => p.dist.toFixed(0)),
-    datasets: [{
-      label: state.currentDataset,
-      data: profileData.map(p => p.value),
-      borderColor: '#4d9de0',
-      backgroundColor: 'rgba(77,157,224,0.15)',
-      borderWidth: 1.5,
+  const hasData = profileData && (profileData.centre.length > 0 || (profileData.median && profileData.median.length > 0));
+
+  const datasets: any[] = [];
+
+  if (hasData) {
+    const useBuffer = radius > 0 && profileData!.median && profileData!.median.length > 0;
+
+    // Random sample lines — thin, semi-transparent, behind everything
+    if (useBuffer) {
+      profileData!.samples.forEach((s, i) => {
+        datasets.push({
+          label: `sample ${i}`,
+          data: s.map(p => p.value),
+          labels: s.map(p => p.dist.toFixed(0)),
+          borderColor: '#4d9de028',
+          backgroundColor: 'transparent',
+          borderWidth: 1,
+          pointRadius: 0,
+          fill: false,
+          tension: 0.2,
+        });
+      });
+    }
+
+    // Centre line
+    const centre = profileData!.centre;
+    datasets.push({
+      label: useBuffer ? 'centre' : state.currentDataset,
+      data: centre.map(p => p.value),
+      borderColor: useBuffer ? '#4d9de088' : '#4d9de0',
+      backgroundColor: useBuffer ? 'transparent' : 'rgba(77,157,224,0.15)',
+      borderWidth: useBuffer ? 1 : 1.5,
       pointRadius: 0,
-      fill: true,
+      fill: !useBuffer,
       tension: 0.2,
-    }],
-  };
+    });
+
+    // Median line — prominent
+    if (useBuffer && profileData!.median) {
+      datasets.push({
+        label: 'median',
+        data: profileData!.median.map(p => p.value),
+        borderColor: '#4d9de0',
+        backgroundColor: 'transparent',
+        borderWidth: 2.5,
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2,
+      });
+    }
+  }
+
+  // Use centre (or median) for x-axis labels
+  const xLabels = profileData
+    ? (profileData.centre.length > 0 ? profileData.centre : profileData.median ?? []).map(p => p.dist.toFixed(0))
+    : [];
+
+  const chartData = { labels: xLabels, datasets };
 
   const options = {
     responsive: true,
     maintainAspectRatio: false,
     animation: { duration: 0 },
-    plugins: { legend: { display: false } },
+    plugins: {
+      legend: {
+        display: radius > 0,
+        labels: {
+          color: textColor,
+          filter: (item: any) => !item.text.startsWith('sample'),
+        },
+      },
+    },
     scales: {
       x: {
-        title: { display: true, text: 'Distance (m)', color: '#aaa' },
-        ticks: { color: '#aaa', maxTicksLimit: 8 },
-        grid: { color: 'rgba(255,255,255,0.1)' },
+        title: { display: true, text: 'Distance (m)', color: mutedColor },
+        ticks: { color: mutedColor, maxTicksLimit: 8 },
+        grid: { color: gridColor },
       },
       y: {
-        title: { display: true, text: state.currentDataset, color: '#aaa' },
-        ticks: { color: '#aaa' },
-        grid: { color: 'rgba(255,255,255,0.1)' },
+        title: { display: true, text: state.currentDataset, color: mutedColor },
+        ticks: { color: mutedColor },
+        grid: { color: gridColor },
       },
     },
   };
@@ -202,13 +338,29 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
     <div className="profile-panel">
       <div className="chart-header">
         <h4>Profile — {state.currentDataset}</h4>
+        <div className="profile-radius-control">
+          <label htmlFor="profile-radius" style={{ color: mutedColor, fontSize: '0.8em', marginRight: 4 }}>
+            Radius (m):
+          </label>
+          <input
+            id="profile-radius"
+            type="number"
+            min={0}
+            step={100}
+            value={radius}
+            onChange={e => setRadius(Math.max(0, Number(e.target.value)))}
+            className="profile-radius-input"
+          />
+        </div>
         <button className="chart-btn" onClick={clearAll} title="Clear profile">
           <i className="fa-solid fa-xmark"></i>
         </button>
       </div>
-      <div style={{ height: 180, position: 'relative' }}>
-        <Line data={chartData} options={options as any} />
-      </div>
+      {hasData && (
+        <div style={{ height: 180, position: 'relative' }}>
+          <Line data={chartData} options={options as any} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ProfileTool.tsx
+++ b/src/components/ProfileTool.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, createContext, useContext } from 'react';
 import { useMap } from 'react-leaflet';
 import { Line } from 'react-chartjs-2';
 import L from 'leaflet';
@@ -14,44 +14,83 @@ interface ProfileResponse {
   bin_width?: number;
 }
 
-// Vertex handle — defined once at module level, not recreated on each render
+interface ProfileState {
+  data: ProfileResponse | null;
+  loading: boolean;
+  radius: number;
+  samplingInterval: number;
+  active: boolean;
+  setActive: (a: boolean) => void;
+  setRadius: (r: number) => void;
+  setSamplingInterval: (s: number) => void;
+  clearAll: () => void;
+  // private setters for ProfileToolMap
+  _setData: (d: ProfileResponse | null) => void;
+  _setLoading: (l: boolean) => void;
+}
+
+export const ProfileContext = createContext<ProfileState>({
+  data: null, loading: false, radius: 0, samplingInterval: 0, active: false,
+  setActive: () => {}, setRadius: () => {}, setSamplingInterval: () => {}, clearAll: () => {},
+  _setData: () => {}, _setLoading: () => {},
+});
+
+export function useProfileContext() { return useContext(ProfileContext); }
+
 const VERTEX_ICON = L.divIcon({
   className: '',
   html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
   iconSize: [0, 0],
 });
 
-/** Read a CSS variable from the document root. */
 function cssVar(name: string, fallback: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
-export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { active: boolean; onDeactivate: () => void }) {
+// ── Provider ──────────────────────────────────────────────────────────────────
+export function ProfileProvider({ children }: { children: React.ReactNode }) {
+  const [data, setData] = useState<ProfileResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [radius, setRadius] = useState(0);
+  const [samplingInterval, setSamplingInterval] = useState(0);
+  const [active, setActive] = useState(false);
+  const clearAll = useCallback(() => setData(null), []);
+
+  return (
+    <ProfileContext.Provider value={{
+      data, loading, radius, samplingInterval, active,
+      setActive, setRadius, setSamplingInterval, clearAll,
+      _setData: setData, _setLoading: setLoading,
+    }}>
+      {children}
+    </ProfileContext.Provider>
+  );
+}
+
+// ── Map-only component (inside Leaflet MapContainer, renders null) ─────────────
+export function ProfileToolMap() {
   const map = useMap();
   const { state } = useAppContext();
-  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
-    defaultWidth: 540,
-    defaultHeight: 280,
-    initialRight: 20,
-    initialBottom: 20,
-  });
+  const ctx = useContext(ProfileContext);
+  const { active, radius, samplingInterval, _setData, _setLoading, clearAll: ctxClearAll } = ctx;
 
-  // All mutable map state kept in refs to avoid stale closures in Leaflet handlers
   const polyRef    = useRef<L.Polyline | null>(null);
   const previewRef = useRef<L.Polyline | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
   const ptsRef     = useRef<L.LatLng[]>([]);
   const modeRef    = useRef<'idle' | 'drawing' | 'ready'>('idle');
 
-  const [profileData, setProfileData] = useState<ProfileResponse | null>(null);
-  const [loading, setLoading]         = useState(false);
-  const [radius, setRadius]           = useState(0);
-  const [samplingInterval, setSamplingInterval] = useState(0);
+  // Always-current refs so Leaflet handlers don't close over stale values
+  const radiusRef = useRef(radius);
+  const siRef     = useRef(samplingInterval);
+  useEffect(() => { radiusRef.current = radius; }, [radius]);
+  useEffect(() => { siRef.current = samplingInterval; }, [samplingInterval]);
 
-  // Always-current reference to fetchProfile so drag handlers never go stale
-  const fetchFn = useCallback(async (pts: L.LatLng[], r: number, si: number) => {
+  const fetchFnRef = useRef<(pts: L.LatLng[], r: number, si: number) => Promise<void>>();
+
+  const fetchProfile = useCallback(async (pts: L.LatLng[], r: number, si: number) => {
     if (pts.length < 2 || !state.currentDataset) return;
-    setLoading(true);
+    _setLoading(true);
     try {
       const res = await fetch('/profile', {
         method: 'POST',
@@ -69,9 +108,9 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
       if (!res.ok) return;
       const json = await res.json();
       if (Array.isArray(json)) {
-        setProfileData({ centre: json, median: null, samples: [], binned: false });
+        _setData({ centre: json, median: null, samples: [], binned: false });
       } else {
-        setProfileData({
+        _setData({
           centre: json.centre ?? [],
           median: json.median ?? null,
           samples: json.samples ?? [],
@@ -80,40 +119,25 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
         });
       }
     } finally {
-      setLoading(false);
+      _setLoading(false);
     }
-  }, [state.currentDataset, state.currentTimeIndex]);
+  }, [state.currentDataset, state.currentTimeIndex, _setData, _setLoading]);
 
-  const fetchRef = useRef(fetchFn);
-  useEffect(() => { fetchRef.current = fetchFn; }, [fetchFn]);
-
-  const radiusRef = useRef(radius);
-  useEffect(() => { radiusRef.current = radius; }, [radius]);
-
-  const samplingIntervalRef = useRef(samplingInterval);
-  useEffect(() => { samplingIntervalRef.current = samplingInterval; }, [samplingInterval]);
-
-  // ── Helpers ────────────────────────────────────────────────────────────────
+  fetchFnRef.current = fetchProfile;
 
   const updatePoly = (pts: L.LatLng[]) => {
-    if (polyRef.current) {
-      polyRef.current.setLatLngs(pts);
-    } else {
-      polyRef.current = L.polyline(pts, { color: '#f0a500', weight: 2.5 }).addTo(map);
-    }
+    if (polyRef.current) polyRef.current.setLatLngs(pts);
+    else polyRef.current = L.polyline(pts, { color: '#f0a500', weight: 2.5 }).addTo(map);
   };
 
   const rebuildMarkers = (pts: L.LatLng[]) => {
     markersRef.current.forEach(m => m.remove());
     markersRef.current = pts.map((pt, idx) => {
       const m = L.marker(pt, { icon: VERTEX_ICON, draggable: true }).addTo(map);
-      m.on('drag', () => {
-        ptsRef.current[idx] = m.getLatLng();
-        updatePoly(ptsRef.current);
-      });
+      m.on('drag', () => { ptsRef.current[idx] = m.getLatLng(); updatePoly(ptsRef.current); });
       m.on('dragend', () => {
         ptsRef.current[idx] = m.getLatLng();
-        fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
+        fetchFnRef.current?.(ptsRef.current, radiusRef.current, siRef.current);
       });
       return m;
     });
@@ -126,115 +150,69 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
     markersRef.current = [];
     ptsRef.current = [];
     modeRef.current = 'idle';
-    setProfileData(null);
-  }, []);
+    ctxClearAll();
+  }, [ctxClearAll]);
 
-  // Re-fetch when time index changes while a profile is drawn
+  // Re-fetch when time index changes
   useEffect(() => {
-    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
-    }
+    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2)
+      fetchFnRef.current?.(ptsRef.current, radiusRef.current, siRef.current);
   }, [state.currentTimeIndex, active]);
 
-  // Re-fetch when radius changes while a profile is ready
+  // Re-fetch when radius changes
   useEffect(() => {
-    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radius, samplingIntervalRef.current);
-    }
+    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2)
+      fetchFnRef.current?.(ptsRef.current, radius, siRef.current);
   }, [radius, active]);
 
-  // Re-fetch when samplingInterval changes while a profile is ready
+  // Re-fetch when samplingInterval changes
   useEffect(() => {
-    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radiusRef.current, samplingInterval);
-    }
+    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2)
+      fetchFnRef.current?.(ptsRef.current, radiusRef.current, samplingInterval);
   }, [samplingInterval, active]);
 
-  // ── Buffer corridor visualization ──────────────────────────────────────────
+  // Buffer corridor visualization
   useEffect(() => {
     if (!active || radius <= 0 || ptsRef.current.length < 2) return;
-
-    // Build a polygon corridor around the polyline using L.circle at each vertex
-    // as a simple approach: draw two offset polylines forming a band.
-    // We use L.geodesicPolygon-style by computing perpendicular offsets via
-    // Leaflet's CRS projection.
     const pts = ptsRef.current;
-    const offsetPoints: L.LatLng[][] = [[], []]; // [left side, right side]
-
+    const offsetPoints: L.LatLng[][] = [[], []];
     for (let i = 0; i < pts.length; i++) {
-      // Bearing from prev or next segment
-      let bearingRad: number;
-      if (i < pts.length - 1) {
-        const dx = pts[i + 1].lng - pts[i].lng;
-        const dy = pts[i + 1].lat - pts[i].lat;
-        bearingRad = Math.atan2(dx, dy);
-      } else {
-        const dx = pts[i].lng - pts[i - 1].lng;
-        const dy = pts[i].lat - pts[i - 1].lat;
-        bearingRad = Math.atan2(dx, dy);
-      }
-
-      // Approximate degrees offset for the given radius in metres at this latitude
+      const bearingRad = i < pts.length - 1
+        ? Math.atan2(pts[i+1].lng - pts[i].lng, pts[i+1].lat - pts[i].lat)
+        : Math.atan2(pts[i].lng - pts[i-1].lng, pts[i].lat - pts[i-1].lat);
       const lat = pts[i].lat;
-      const metersPerDegLat = 111320;
-      const metersPerDegLng = 111320 * Math.cos((lat * Math.PI) / 180);
-      const perpBearing = bearingRad + Math.PI / 2;
-      const dLat = (radius / metersPerDegLat) * Math.cos(perpBearing);
-      const dLng = (radius / metersPerDegLng) * Math.sin(perpBearing);
-
+      const mPerDegLat = 111320;
+      const mPerDegLng = 111320 * Math.cos((lat * Math.PI) / 180);
+      const perp = bearingRad + Math.PI / 2;
+      const dLat = (radius / mPerDegLat) * Math.cos(perp);
+      const dLng = (radius / mPerDegLng) * Math.sin(perp);
       offsetPoints[0].push(L.latLng(pts[i].lat + dLat, pts[i].lng + dLng));
       offsetPoints[1].push(L.latLng(pts[i].lat - dLat, pts[i].lng - dLng));
     }
-
-    // Polygon: left side forward + right side reversed
     const poly = L.polygon([...offsetPoints[0], ...offsetPoints[1].reverse()], {
-      color: '#f0a500',
-      fillColor: '#f0a500',
-      fillOpacity: 0.12,
-      weight: 1,
-      dashArray: '4 3',
+      color: '#f0a500', fillColor: '#f0a500', fillOpacity: 0.12, weight: 1, dashArray: '4 3',
     }).addTo(map);
-
     return () => { poly.remove(); };
-  }, [active, radius, map,
-    // re-run when pts change (after drawing / dragging)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    profileData,
-  ]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, radius, map, ctx.data]);
 
-  // ── Main map event effect ──────────────────────────────────────────────────
+  // Main map interaction
   useEffect(() => {
-    if (!active) {
-      clearAll();
-      map.getContainer().style.cursor = '';
-      return;
-    }
-
+    if (!active) { clearAll(); map.getContainer().style.cursor = ''; return; }
     map.getContainer().style.cursor = 'crosshair';
 
     const onClick = (e: L.LeafletMouseEvent) => {
-      if (modeRef.current === 'ready') {
-        clearAll();
-        modeRef.current = 'drawing';
-        map.getContainer().style.cursor = 'crosshair';
-      }
+      if (modeRef.current === 'ready') { clearAll(); modeRef.current = 'drawing'; map.getContainer().style.cursor = 'crosshair'; }
       modeRef.current = 'drawing';
       ptsRef.current = [...ptsRef.current, e.latlng];
       updatePoly(ptsRef.current);
     };
-
     const onMouseMove = (e: L.LeafletMouseEvent) => {
       if (modeRef.current !== 'drawing' || ptsRef.current.length === 0) return;
       const preview = [...ptsRef.current, e.latlng];
-      if (previewRef.current) {
-        previewRef.current.setLatLngs(preview);
-      } else {
-        previewRef.current = L.polyline(preview, {
-          color: '#f0a500', weight: 2, dashArray: '6 4',
-        }).addTo(map);
-      }
+      if (previewRef.current) previewRef.current.setLatLngs(preview);
+      else previewRef.current = L.polyline(preview, { color: '#f0a500', weight: 2, dashArray: '6 4' }).addTo(map);
     };
-
     const onDblClick = (e: L.LeafletMouseEvent) => {
       L.DomEvent.stop(e);
       if (modeRef.current !== 'drawing' || ptsRef.current.length < 2) return;
@@ -243,14 +221,13 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
       modeRef.current = 'ready';
       map.getContainer().style.cursor = 'default';
       rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
+      fetchFnRef.current?.(ptsRef.current, radiusRef.current, siRef.current);
     };
 
     map.on('click', onClick);
     map.on('mousemove', onMouseMove);
     map.on('dblclick', onDblClick);
     map.doubleClickZoom.disable();
-
     return () => {
       map.off('click', onClick);
       map.off('mousemove', onMouseMove);
@@ -260,16 +237,27 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
     };
   }, [active, map, clearAll]);
 
-  // ── Chart panel ────────────────────────────────────────────────────────────
+  return null;
+}
+
+// ── Chart panel (outside MapContainer, no Leaflet DOM) ────────────────────────
+export function ProfileChart() {
+  const { state } = useAppContext();
+  const { active, data: profileData, loading, radius, samplingInterval, setRadius, setSamplingInterval, clearAll } =
+    useProfileContext();
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 540, defaultHeight: 280, initialRight: 20, initialBottom: 20,
+    minWidth: 200, minHeight: 150,
+  });
+
   if (!active) return null;
 
-  if (loading) {
-    return (
-      <div ref={panelRef} className="profile-panel" style={panelStyle} onMouseDown={e => e.stopPropagation()}>
-        <div className="chart-placeholder"><p>Extracting profile…</p></div>
-      </div>
-    );
-  }
+  if (loading) return (
+    <div ref={panelRef} style={{ ...panelStyle, position: 'fixed' }} className="profile-panel"
+      onMouseDown={e => e.stopPropagation()}>
+      <div className="chart-placeholder"><p>Extracting profile…</p></div>
+    </div>
+  );
 
   const textColor  = cssVar('--sb-text',   '#dde0f0');
   const mutedColor = cssVar('--sb-muted',  '#7880a8');
@@ -277,170 +265,78 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
 
   const hasData = profileData && (profileData.centre.length > 0 || (profileData.median && profileData.median.length > 0));
   const isBinned = !!(profileData?.binned && samplingInterval > 0);
-
   const datasets: any[] = [];
 
   if (hasData) {
     const useBuffer = radius > 0 && profileData!.median && profileData!.median.length > 0;
-
     if (isBinned) {
-      // Binned mode: show faint sample lines + median as circles (no connecting line)
-      profileData!.samples.forEach((s, i) => {
-        datasets.push({
-          label: `sample ${i}`,
-          data: s.map(p => p.value),
-          borderColor: '#4d9de028',
-          backgroundColor: 'transparent',
-          borderWidth: 1,
-          pointRadius: 0,
-          fill: false,
-          tension: 0.3,
-        });
+      profileData!.samples.forEach((s, i) => datasets.push({
+        label: `sample ${i}`, data: s.map(p => p.value),
+        borderColor: '#4d9de028', backgroundColor: 'transparent', borderWidth: 1, pointRadius: 0, fill: false, tension: 0.3,
+      }));
+      if (profileData!.centre.length > 0) datasets.push({
+        label: 'centre', data: profileData!.centre.map(p => p.value),
+        borderColor: '#4d9de066', backgroundColor: 'transparent', borderWidth: 1, borderDash: [4, 3], pointRadius: 0, fill: false, tension: 0,
       });
-      // Centre (along-track median) — thin dashed line
-      if (profileData!.centre.length > 0) {
-        datasets.push({
-          label: 'centre',
-          data: profileData!.centre.map(p => p.value),
-          borderColor: '#4d9de066',
-          backgroundColor: 'transparent',
-          borderWidth: 1,
-          borderDash: [4, 3],
-          pointRadius: 0,
-          fill: false,
-          tension: 0,
-        });
-      }
-      // Full-window median — circle markers, no line
-      if (profileData!.median) {
-        datasets.push({
-          label: 'median',
-          data: profileData!.median.map(p => p.value),
-          borderColor: '#4d9de0',
-          backgroundColor: '#4d9de0',
-          borderWidth: 0,
-          showLine: false,
-          pointStyle: 'circle',
-          pointRadius: 5,
-          pointHoverRadius: 7,
-          fill: false,
-        });
-      }
+      if (profileData!.median) datasets.push({
+        label: 'median', data: profileData!.median.map(p => p.value),
+        borderColor: '#4d9de0', backgroundColor: '#4d9de0', borderWidth: 0, showLine: false,
+        pointStyle: 'circle', pointRadius: 5, pointHoverRadius: 7, fill: false,
+      });
     } else {
-      // Legacy / plain buffer mode
-      if (useBuffer) {
-        profileData!.samples.forEach((s, i) => {
-          datasets.push({
-            label: `sample ${i}`,
-            data: s.map(p => p.value),
-            borderColor: '#4d9de028',
-            backgroundColor: 'transparent',
-            borderWidth: 1,
-            pointRadius: 0,
-            fill: false,
-            tension: 0.2,
-          });
-        });
-      }
+      if (useBuffer) profileData!.samples.forEach((s, i) => datasets.push({
+        label: `sample ${i}`, data: s.map(p => p.value),
+        borderColor: '#4d9de028', backgroundColor: 'transparent', borderWidth: 1, pointRadius: 0, fill: false, tension: 0.2,
+      }));
       const centre = profileData!.centre;
       datasets.push({
         label: useBuffer ? 'centre' : state.currentDataset,
         data: centre.map(p => p.value),
         borderColor: useBuffer ? '#4d9de088' : '#4d9de0',
         backgroundColor: useBuffer ? 'transparent' : 'rgba(77,157,224,0.15)',
-        borderWidth: useBuffer ? 1 : 1.5,
-        pointRadius: 0,
-        fill: !useBuffer,
-        tension: 0.2,
+        borderWidth: useBuffer ? 1 : 1.5, pointRadius: 0, fill: !useBuffer, tension: 0.2,
       });
-      if (useBuffer && profileData!.median) {
-        datasets.push({
-          label: 'median',
-          data: profileData!.median.map(p => p.value),
-          borderColor: '#4d9de0',
-          backgroundColor: 'transparent',
-          borderWidth: 2.5,
-          pointRadius: 0,
-          fill: false,
-          tension: 0.2,
-        });
-      }
+      if (useBuffer && profileData!.median) datasets.push({
+        label: 'median', data: profileData!.median.map(p => p.value),
+        borderColor: '#4d9de0', backgroundColor: 'transparent', borderWidth: 2.5, pointRadius: 0, fill: false, tension: 0.2,
+      });
     }
   }
 
-  // x-axis labels from whichever series has the bin positions
   const xSourcePts = profileData
     ? (isBinned && profileData.median ? profileData.median
       : profileData.centre.length > 0 ? profileData.centre
       : profileData.median ?? [])
     : [];
   const xLabels = xSourcePts.map(p => p.dist.toFixed(0));
-
   const chartData = { labels: xLabels, datasets };
 
   const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 0 },
+    responsive: true, maintainAspectRatio: false, animation: { duration: 0 },
     plugins: {
-      legend: {
-        display: radius > 0 || isBinned,
-        labels: {
-          color: textColor,
-          filter: (item: any) => !item.text.startsWith('sample'),
-        },
-      },
-      tooltip: {
-        callbacks: {
-          title: (ctx: any) => `${ctx[0]?.label ?? ''} m`,
-        },
-      },
+      legend: { display: radius > 0 || isBinned, labels: { color: textColor, filter: (item: any) => !item.text.startsWith('sample') } },
+      tooltip: { callbacks: { title: (ctx: any) => `${ctx[0]?.label ?? ''} m` } },
     },
     scales: {
-      x: {
-        title: { display: true, text: 'Distance (m)', color: mutedColor },
-        ticks: { color: mutedColor, maxTicksLimit: 8 },
-        grid: { color: gridColor },
-      },
-      y: {
-        title: { display: true, text: state.currentDataset, color: mutedColor },
-        ticks: { color: mutedColor },
-        grid: { color: gridColor },
-      },
+      x: { title: { display: true, text: 'Distance (m)', color: mutedColor }, ticks: { color: mutedColor, maxTicksLimit: 8 }, grid: { color: gridColor } },
+      y: { title: { display: true, text: state.currentDataset, color: mutedColor }, ticks: { color: mutedColor }, grid: { color: gridColor } },
     },
   };
 
   return (
-    <div ref={panelRef} className="profile-panel" style={panelStyle} onMouseDown={e => e.stopPropagation()}>
+    <div ref={panelRef} className="profile-panel" style={{ ...panelStyle, position: 'fixed' }}
+      onMouseDown={e => e.stopPropagation()}>
       <div className="chart-header" onMouseDown={onDragMouseDown} style={{ cursor: 'grab' }}>
         <h4>Profile — {state.currentDataset}</h4>
         <div className="profile-radius-control">
-          <label htmlFor="profile-sampling" style={{ color: mutedColor, fontSize: '0.8em', marginRight: 4 }}>
-            Sampling (m):
-          </label>
-          <input
-            id="profile-sampling"
-            type="number"
-            min={0}
-            step={50}
-            value={samplingInterval}
+          <label style={{ color: mutedColor, fontSize: '0.8em', marginRight: 4 }}>Sampling (m):</label>
+          <input type="number" min={0} step={50} value={samplingInterval}
             onChange={e => setSamplingInterval(Math.max(0, Number(e.target.value)))}
-            className="profile-radius-input"
-            title="Bin spacing along profile (0 = continuous dense line)"
-          />
-          <label htmlFor="profile-radius" style={{ color: mutedColor, fontSize: '0.8em', marginLeft: 8, marginRight: 4 }}>
-            Radius (m):
-          </label>
-          <input
-            id="profile-radius"
-            type="number"
-            min={0}
-            step={100}
-            value={radius}
+            className="profile-radius-input" onMouseDown={e => e.stopPropagation()} />
+          <label style={{ color: mutedColor, fontSize: '0.8em', marginLeft: 8, marginRight: 4 }}>Radius (m):</label>
+          <input type="number" min={0} step={100} value={radius}
             onChange={e => setRadius(Math.max(0, Number(e.target.value)))}
-            className="profile-radius-input"
-            title="Perpendicular buffer width (0 = centre line only)"
-          />
+            className="profile-radius-input" onMouseDown={e => e.stopPropagation()} />
         </div>
         <button className="chart-btn" onClick={clearAll} title="Clear profile">
           <i className="fa-solid fa-xmark"></i>
@@ -455,3 +351,5 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
     </div>
   );
 }
+
+export default ProfileToolMap;

--- a/src/components/ProfileTool.tsx
+++ b/src/components/ProfileTool.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useMap } from 'react-leaflet';
+import { Line } from 'react-chartjs-2';
+import L from 'leaflet';
+import { useAppContext } from '../context/AppContext';
+
+interface ProfilePoint { dist: number; value: number }
+
+// Vertex handle — defined once at module level, not recreated on each render
+const VERTEX_ICON = L.divIcon({
+  className: '',
+  html: '<div style="width:12px;height:12px;border-radius:50%;background:#f0a500;border:2px solid white;box-sizing:border-box;margin-left:-6px;margin-top:-6px;cursor:grab"></div>',
+  iconSize: [0, 0],
+});
+
+export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { active: boolean; onDeactivate: () => void }) {
+  const map = useMap();
+  const { state } = useAppContext();
+
+  // All mutable map state kept in refs to avoid stale closures in Leaflet handlers
+  const polyRef    = useRef<L.Polyline | null>(null);
+  const previewRef = useRef<L.Polyline | null>(null);
+  const markersRef = useRef<L.Marker[]>([]);
+  const ptsRef     = useRef<L.LatLng[]>([]);
+  const modeRef    = useRef<'idle' | 'drawing' | 'ready'>('idle');
+
+  const [profileData, setProfileData] = useState<ProfilePoint[] | null>(null);
+  const [loading, setLoading]         = useState(false);
+
+  // Always-current reference to fetchProfile so drag handlers never go stale
+  const fetchFn = useCallback(async (pts: L.LatLng[]) => {
+    if (pts.length < 2 || !state.currentDataset) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          coords: pts.map(p => [p.lng, p.lat]),
+          dataset_name: state.currentDataset,
+          time_index: state.currentTimeIndex,
+          n_samples: 200,
+        }),
+      });
+      if (res.ok) setProfileData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [state.currentDataset, state.currentTimeIndex]);
+
+  const fetchRef = useRef(fetchFn);
+  useEffect(() => { fetchRef.current = fetchFn; }, [fetchFn]);
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  const updatePoly = (pts: L.LatLng[]) => {
+    if (polyRef.current) {
+      polyRef.current.setLatLngs(pts);
+    } else {
+      polyRef.current = L.polyline(pts, { color: '#f0a500', weight: 2.5 }).addTo(map);
+    }
+  };
+
+  const rebuildMarkers = (pts: L.LatLng[]) => {
+    markersRef.current.forEach(m => m.remove());
+    markersRef.current = pts.map((pt, idx) => {
+      const m = L.marker(pt, { icon: VERTEX_ICON, draggable: true }).addTo(map);
+      m.on('drag', () => {
+        ptsRef.current[idx] = m.getLatLng();
+        updatePoly(ptsRef.current);
+      });
+      m.on('dragend', () => {
+        ptsRef.current[idx] = m.getLatLng();
+        fetchRef.current(ptsRef.current);
+      });
+      return m;
+    });
+  };
+
+  const clearAll = useCallback(() => {
+    polyRef.current?.remove();    polyRef.current = null;
+    previewRef.current?.remove(); previewRef.current = null;
+    markersRef.current.forEach(m => m.remove());
+    markersRef.current = [];
+    ptsRef.current = [];
+    modeRef.current = 'idle';
+    setProfileData(null);
+  }, []);
+
+  // Re-fetch when time index changes while a profile is drawn
+  useEffect(() => {
+    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
+      fetchRef.current(ptsRef.current);
+    }
+  }, [state.currentTimeIndex, active]);
+
+  // ── Main map event effect ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (!active) {
+      // Button turned off → clear everything
+      clearAll();
+      map.getContainer().style.cursor = '';
+      return;
+    }
+
+    map.getContainer().style.cursor = 'crosshair';
+
+    const onClick = (e: L.LeafletMouseEvent) => {
+      if (modeRef.current === 'ready') {
+        // Start a fresh profile on the next click
+        clearAll();
+        modeRef.current = 'drawing';
+        map.getContainer().style.cursor = 'crosshair';
+      }
+      modeRef.current = 'drawing';
+      ptsRef.current = [...ptsRef.current, e.latlng];
+      updatePoly(ptsRef.current);
+    };
+
+    const onMouseMove = (e: L.LeafletMouseEvent) => {
+      if (modeRef.current !== 'drawing' || ptsRef.current.length === 0) return;
+      const preview = [...ptsRef.current, e.latlng];
+      if (previewRef.current) {
+        previewRef.current.setLatLngs(preview);
+      } else {
+        previewRef.current = L.polyline(preview, {
+          color: '#f0a500', weight: 2, dashArray: '6 4',
+        }).addTo(map);
+      }
+    };
+
+    const onDblClick = (e: L.LeafletMouseEvent) => {
+      L.DomEvent.stop(e);
+      if (modeRef.current !== 'drawing' || ptsRef.current.length < 2) return;
+      previewRef.current?.remove(); previewRef.current = null;
+      updatePoly(ptsRef.current);
+      modeRef.current = 'ready';
+      map.getContainer().style.cursor = 'default';
+      rebuildMarkers(ptsRef.current);
+      fetchRef.current(ptsRef.current);
+    };
+
+    map.on('click', onClick);
+    map.on('mousemove', onMouseMove);
+    map.on('dblclick', onDblClick);
+    map.doubleClickZoom.disable();
+
+    return () => {
+      map.off('click', onClick);
+      map.off('mousemove', onMouseMove);
+      map.off('dblclick', onDblClick);
+      map.doubleClickZoom.enable();
+      map.getContainer().style.cursor = '';
+    };
+  }, [active, map, clearAll]);
+
+  // ── Chart panel ────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="profile-panel">
+        <div className="chart-placeholder"><p>Extracting profile…</p></div>
+      </div>
+    );
+  }
+
+  if (!profileData || profileData.length === 0 || !state.showProfile) return null;
+
+  const chartData = {
+    labels: profileData.map(p => p.dist.toFixed(0)),
+    datasets: [{
+      label: state.currentDataset,
+      data: profileData.map(p => p.value),
+      borderColor: '#4d9de0',
+      backgroundColor: 'rgba(77,157,224,0.15)',
+      borderWidth: 1.5,
+      pointRadius: 0,
+      fill: true,
+      tension: 0.2,
+    }],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 0 },
+    plugins: { legend: { display: false } },
+    scales: {
+      x: {
+        title: { display: true, text: 'Distance (m)', color: '#aaa' },
+        ticks: { color: '#aaa', maxTicksLimit: 8 },
+        grid: { color: 'rgba(255,255,255,0.1)' },
+      },
+      y: {
+        title: { display: true, text: state.currentDataset, color: '#aaa' },
+        ticks: { color: '#aaa' },
+        grid: { color: 'rgba(255,255,255,0.1)' },
+      },
+    },
+  };
+
+  return (
+    <div className="profile-panel">
+      <div className="chart-header">
+        <h4>Profile — {state.currentDataset}</h4>
+        <button className="chart-btn" onClick={clearAll} title="Clear profile">
+          <i className="fa-solid fa-xmark"></i>
+        </button>
+      </div>
+      <div style={{ height: 180, position: 'relative' }}>
+        <Line data={chartData} options={options as any} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileTool.tsx
+++ b/src/components/ProfileTool.tsx
@@ -3,8 +3,16 @@ import { useMap } from 'react-leaflet';
 import { Line } from 'react-chartjs-2';
 import L from 'leaflet';
 import { useAppContext } from '../context/AppContext';
+import { useDraggableResizable } from '../hooks/useDraggableResizable';
 
 interface CentrePoint { dist: number; value: number }
+interface ProfileResponse {
+  centre: CentrePoint[];
+  median: CentrePoint[] | null;
+  samples: CentrePoint[][];
+  binned?: boolean;
+  bin_width?: number;
+}
 
 // Vertex handle — defined once at module level, not recreated on each render
 const VERTEX_ICON = L.divIcon({
@@ -21,6 +29,12 @@ function cssVar(name: string, fallback: string): string {
 export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { active: boolean; onDeactivate: () => void }) {
   const map = useMap();
   const { state } = useAppContext();
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 540,
+    defaultHeight: 280,
+    initialRight: 20,
+    initialBottom: 20,
+  });
 
   // All mutable map state kept in refs to avoid stale closures in Leaflet handlers
   const polyRef    = useRef<L.Polyline | null>(null);
@@ -29,12 +43,13 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   const ptsRef     = useRef<L.LatLng[]>([]);
   const modeRef    = useRef<'idle' | 'drawing' | 'ready'>('idle');
 
-  const [profileData, setProfileData] = useState<{ centre: CentrePoint[]; median: CentrePoint[] | null; samples: CentrePoint[][] } | null>(null);
+  const [profileData, setProfileData] = useState<ProfileResponse | null>(null);
   const [loading, setLoading]         = useState(false);
   const [radius, setRadius]           = useState(0);
+  const [samplingInterval, setSamplingInterval] = useState(0);
 
   // Always-current reference to fetchProfile so drag handlers never go stale
-  const fetchFn = useCallback(async (pts: L.LatLng[], r: number) => {
+  const fetchFn = useCallback(async (pts: L.LatLng[], r: number, si: number) => {
     if (pts.length < 2 || !state.currentDataset) return;
     setLoading(true);
     try {
@@ -48,18 +63,20 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
           n_samples: 200,
           radius: r,
           n_random: 5,
+          sampling_interval: si,
         }),
       });
       if (!res.ok) return;
       const json = await res.json();
       if (Array.isArray(json)) {
-        // Legacy centre-line response
-        setProfileData({ centre: json, median: null, samples: [] });
+        setProfileData({ centre: json, median: null, samples: [], binned: false });
       } else {
         setProfileData({
           centre: json.centre ?? [],
           median: json.median ?? null,
           samples: json.samples ?? [],
+          binned: json.binned ?? false,
+          bin_width: json.bin_width,
         });
       }
     } finally {
@@ -72,6 +89,9 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
 
   const radiusRef = useRef(radius);
   useEffect(() => { radiusRef.current = radius; }, [radius]);
+
+  const samplingIntervalRef = useRef(samplingInterval);
+  useEffect(() => { samplingIntervalRef.current = samplingInterval; }, [samplingInterval]);
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -93,7 +113,7 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
       });
       m.on('dragend', () => {
         ptsRef.current[idx] = m.getLatLng();
-        fetchRef.current(ptsRef.current, radiusRef.current);
+        fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
       });
       return m;
     });
@@ -112,16 +132,23 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   // Re-fetch when time index changes while a profile is drawn
   useEffect(() => {
     if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radiusRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
     }
   }, [state.currentTimeIndex, active]);
 
   // Re-fetch when radius changes while a profile is ready
   useEffect(() => {
     if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
-      fetchRef.current(ptsRef.current, radius);
+      fetchRef.current(ptsRef.current, radius, samplingIntervalRef.current);
     }
   }, [radius, active]);
+
+  // Re-fetch when samplingInterval changes while a profile is ready
+  useEffect(() => {
+    if (active && modeRef.current === 'ready' && ptsRef.current.length >= 2) {
+      fetchRef.current(ptsRef.current, radiusRef.current, samplingInterval);
+    }
+  }, [samplingInterval, active]);
 
   // ── Buffer corridor visualization ──────────────────────────────────────────
   useEffect(() => {
@@ -216,7 +243,7 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
       modeRef.current = 'ready';
       map.getContainer().style.cursor = 'default';
       rebuildMarkers(ptsRef.current);
-      fetchRef.current(ptsRef.current, radiusRef.current);
+      fetchRef.current(ptsRef.current, radiusRef.current, samplingIntervalRef.current);
     };
 
     map.on('click', onClick);
@@ -238,7 +265,7 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
 
   if (loading) {
     return (
-      <div className="profile-panel">
+      <div ref={panelRef} className="profile-panel" style={panelStyle} onMouseDown={e => e.stopPropagation()}>
         <div className="chart-placeholder"><p>Extracting profile…</p></div>
       </div>
     );
@@ -249,61 +276,105 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   const gridColor  = cssVar('--sb-border', '#2c2f4a');
 
   const hasData = profileData && (profileData.centre.length > 0 || (profileData.median && profileData.median.length > 0));
+  const isBinned = !!(profileData?.binned && samplingInterval > 0);
 
   const datasets: any[] = [];
 
   if (hasData) {
     const useBuffer = radius > 0 && profileData!.median && profileData!.median.length > 0;
 
-    // Random sample lines — thin, semi-transparent, behind everything
-    if (useBuffer) {
+    if (isBinned) {
+      // Binned mode: show faint sample lines + median as circles (no connecting line)
       profileData!.samples.forEach((s, i) => {
         datasets.push({
           label: `sample ${i}`,
           data: s.map(p => p.value),
-          labels: s.map(p => p.dist.toFixed(0)),
           borderColor: '#4d9de028',
           backgroundColor: 'transparent',
           borderWidth: 1,
           pointRadius: 0,
           fill: false,
-          tension: 0.2,
+          tension: 0.3,
         });
       });
-    }
-
-    // Centre line
-    const centre = profileData!.centre;
-    datasets.push({
-      label: useBuffer ? 'centre' : state.currentDataset,
-      data: centre.map(p => p.value),
-      borderColor: useBuffer ? '#4d9de088' : '#4d9de0',
-      backgroundColor: useBuffer ? 'transparent' : 'rgba(77,157,224,0.15)',
-      borderWidth: useBuffer ? 1 : 1.5,
-      pointRadius: 0,
-      fill: !useBuffer,
-      tension: 0.2,
-    });
-
-    // Median line — prominent
-    if (useBuffer && profileData!.median) {
+      // Centre (along-track median) — thin dashed line
+      if (profileData!.centre.length > 0) {
+        datasets.push({
+          label: 'centre',
+          data: profileData!.centre.map(p => p.value),
+          borderColor: '#4d9de066',
+          backgroundColor: 'transparent',
+          borderWidth: 1,
+          borderDash: [4, 3],
+          pointRadius: 0,
+          fill: false,
+          tension: 0,
+        });
+      }
+      // Full-window median — circle markers, no line
+      if (profileData!.median) {
+        datasets.push({
+          label: 'median',
+          data: profileData!.median.map(p => p.value),
+          borderColor: '#4d9de0',
+          backgroundColor: '#4d9de0',
+          borderWidth: 0,
+          showLine: false,
+          pointStyle: 'circle',
+          pointRadius: 5,
+          pointHoverRadius: 7,
+          fill: false,
+        });
+      }
+    } else {
+      // Legacy / plain buffer mode
+      if (useBuffer) {
+        profileData!.samples.forEach((s, i) => {
+          datasets.push({
+            label: `sample ${i}`,
+            data: s.map(p => p.value),
+            borderColor: '#4d9de028',
+            backgroundColor: 'transparent',
+            borderWidth: 1,
+            pointRadius: 0,
+            fill: false,
+            tension: 0.2,
+          });
+        });
+      }
+      const centre = profileData!.centre;
       datasets.push({
-        label: 'median',
-        data: profileData!.median.map(p => p.value),
-        borderColor: '#4d9de0',
-        backgroundColor: 'transparent',
-        borderWidth: 2.5,
+        label: useBuffer ? 'centre' : state.currentDataset,
+        data: centre.map(p => p.value),
+        borderColor: useBuffer ? '#4d9de088' : '#4d9de0',
+        backgroundColor: useBuffer ? 'transparent' : 'rgba(77,157,224,0.15)',
+        borderWidth: useBuffer ? 1 : 1.5,
         pointRadius: 0,
-        fill: false,
+        fill: !useBuffer,
         tension: 0.2,
       });
+      if (useBuffer && profileData!.median) {
+        datasets.push({
+          label: 'median',
+          data: profileData!.median.map(p => p.value),
+          borderColor: '#4d9de0',
+          backgroundColor: 'transparent',
+          borderWidth: 2.5,
+          pointRadius: 0,
+          fill: false,
+          tension: 0.2,
+        });
+      }
     }
   }
 
-  // Use centre (or median) for x-axis labels
-  const xLabels = profileData
-    ? (profileData.centre.length > 0 ? profileData.centre : profileData.median ?? []).map(p => p.dist.toFixed(0))
+  // x-axis labels from whichever series has the bin positions
+  const xSourcePts = profileData
+    ? (isBinned && profileData.median ? profileData.median
+      : profileData.centre.length > 0 ? profileData.centre
+      : profileData.median ?? [])
     : [];
+  const xLabels = xSourcePts.map(p => p.dist.toFixed(0));
 
   const chartData = { labels: xLabels, datasets };
 
@@ -313,10 +384,15 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
     animation: { duration: 0 },
     plugins: {
       legend: {
-        display: radius > 0,
+        display: radius > 0 || isBinned,
         labels: {
           color: textColor,
           filter: (item: any) => !item.text.startsWith('sample'),
+        },
+      },
+      tooltip: {
+        callbacks: {
+          title: (ctx: any) => `${ctx[0]?.label ?? ''} m`,
         },
       },
     },
@@ -335,11 +411,24 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
   };
 
   return (
-    <div className="profile-panel">
-      <div className="chart-header">
+    <div ref={panelRef} className="profile-panel" style={panelStyle} onMouseDown={e => e.stopPropagation()}>
+      <div className="chart-header" onMouseDown={onDragMouseDown} style={{ cursor: 'grab' }}>
         <h4>Profile — {state.currentDataset}</h4>
         <div className="profile-radius-control">
-          <label htmlFor="profile-radius" style={{ color: mutedColor, fontSize: '0.8em', marginRight: 4 }}>
+          <label htmlFor="profile-sampling" style={{ color: mutedColor, fontSize: '0.8em', marginRight: 4 }}>
+            Sampling (m):
+          </label>
+          <input
+            id="profile-sampling"
+            type="number"
+            min={0}
+            step={50}
+            value={samplingInterval}
+            onChange={e => setSamplingInterval(Math.max(0, Number(e.target.value)))}
+            className="profile-radius-input"
+            title="Bin spacing along profile (0 = continuous dense line)"
+          />
+          <label htmlFor="profile-radius" style={{ color: mutedColor, fontSize: '0.8em', marginLeft: 8, marginRight: 4 }}>
             Radius (m):
           </label>
           <input
@@ -350,6 +439,7 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
             value={radius}
             onChange={e => setRadius(Math.max(0, Number(e.target.value)))}
             className="profile-radius-input"
+            title="Perpendicular buffer width (0 = centre line only)"
           />
         </div>
         <button className="chart-btn" onClick={clearAll} title="Clear profile">
@@ -357,10 +447,11 @@ export default function ProfileTool({ active, onDeactivate: _onDeactivate }: { a
         </button>
       </div>
       {hasData && (
-        <div style={{ height: 180, position: 'relative' }}>
+        <div style={{ flex: 1, minHeight: 120, position: 'relative' }}>
           <Line data={chartData} options={options as any} />
         </div>
       )}
+      {resizeGrip}
     </div>
   );
 }

--- a/src/components/RefPointChart.tsx
+++ b/src/components/RefPointChart.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState, useRef } from 'react';
+import { Line } from 'react-chartjs-2';
+import { useAppContext } from '../context/AppContext';
+import { useApi } from '../hooks/useApi';
+
+interface BufferResult {
+  labels: string[];
+  median: number[];
+  samples: number[][];
+  n_pixels: number;
+}
+
+export default function RefPointChart() {
+  const { state } = useAppContext();
+  const { fetchBufferTimeSeries } = useApi();
+  const [bufferData, setBufferData] = useState<BufferResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!state.refBufferEnabled || !state.showRefChart || !state.currentDataset) {
+      setBufferData(null);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
+    const [lat, lng] = state.refMarkerPosition;
+
+    setLoading(true);
+    fetchBufferTimeSeries(lng, lat, state.currentDataset, state.refBufferRadius, 20)
+      .then(data => {
+        if (!ctrl.signal.aborted && data) setBufferData(data);
+      })
+      .finally(() => { if (!ctrl.signal.aborted) setLoading(false); });
+
+    return () => ctrl.abort();
+  }, [
+    state.refBufferEnabled,
+    state.showRefChart,
+    state.currentDataset,
+    state.refMarkerPosition,
+    state.refBufferRadius,
+  ]);
+
+  if (!state.refBufferEnabled || !state.showRefChart) return null;
+  if (loading) {
+    return (
+      <div className="profile-panel" style={{ left: '50%', transform: 'translateX(-50%)', bottom: 0, right: 'auto', width: 500 }}>
+        <div className="chart-placeholder"><p>Loading reference buffer…</p></div>
+      </div>
+    );
+  }
+  if (!bufferData || bufferData.labels.length === 0) return null;
+
+  const { median, samples } = bufferData;
+
+  // Use dataset info x_values as the authoritative label source — identical to
+  // what the main time series chart uses, guaranteeing the axes match.
+  const rawLabels: string[] =
+    (state.datasetInfo[state.currentDataset]?.x_values ?? bufferData.labels).map(String);
+  const n = rawLabels.length;
+
+  const toDisplay = (l: string) => {
+    const parts = l.split('_');
+    if (parts.length === 2 && /^\d{8}$/.test(parts[1])) {
+      const d = parts[1];
+      return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
+    }
+    return l.slice(0, 10);
+  };
+  const displayLabels = rawLabels.map(toDisplay);
+
+  // Compute mean and std per date from samples
+  const mean: number[] = Array(n).fill(0);
+  const std: number[] = Array(n).fill(0);
+
+  if (samples.length > 0) {
+    for (let t = 0; t < n; t++) {
+      const vals = samples.map(s => s[t]).filter(v => isFinite(v));
+      if (vals.length === 0) { mean[t] = NaN; std[t] = NaN; continue; }
+      const m = vals.reduce((a, b) => a + b, 0) / vals.length;
+      mean[t] = m;
+      std[t] = Math.sqrt(vals.reduce((a, b) => a + (b - m) ** 2, 0) / vals.length);
+    }
+  }
+
+  const meanPlusStd = mean.map((m, i) => isFinite(m) ? m + std[i] : NaN);
+  const meanMinusStd = mean.map((m, i) => isFinite(m) ? m - std[i] : NaN);
+
+  const sampleDatasets = samples.slice(0, 8).map((s, i) => ({
+    label: `sample ${i + 1}`,
+    data: s,
+    borderColor: 'rgba(150,180,220,0.18)',
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    pointRadius: 0,
+    tension: 0.15,
+  }));
+
+  // Fixed dataset order: index 0 = +1σ, index 1 = -1σ, rest are non-filled.
+  // Use fill: { target: 1 } to pin the fill to dataset index 1 regardless of sample count.
+  const chartData = {
+    labels: displayLabels,
+    datasets: [
+      // +1σ bound — fills toward -1σ (dataset index 1)
+      {
+        label: '+1σ',
+        data: meanPlusStd,
+        borderColor: 'rgba(77,157,224,0.4)',
+        backgroundColor: 'rgba(77,157,224,0.12)',
+        borderWidth: 1,
+        borderDash: [3, 3],
+        pointRadius: 0,
+        fill: { target: 1, above: 'rgba(77,157,224,0.12)' },
+        tension: 0.2,
+      },
+      // -1σ bound
+      {
+        label: '-1σ',
+        data: meanMinusStd,
+        borderColor: 'rgba(77,157,224,0.4)',
+        backgroundColor: 'transparent',
+        borderWidth: 1,
+        borderDash: [3, 3],
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2,
+      },
+      // Mean
+      {
+        label: 'Mean',
+        data: mean,
+        borderColor: '#4d9de0',
+        backgroundColor: 'transparent',
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.2,
+      },
+      // Median
+      {
+        label: 'Median',
+        data: median,
+        borderColor: '#3ec97a',
+        backgroundColor: 'transparent',
+        borderWidth: 2,
+        borderDash: [6, 4],
+        pointRadius: 0,
+        fill: false,
+        tension: 0.2,
+      },
+      // Individual samples (faint, behind main lines)
+      ...sampleDatasets,
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: { duration: 0 },
+    plugins: {
+      legend: {
+        display: true,
+        labels: {
+          color: '#aaa',
+          filter: (item: any) => ['Mean', 'Median', '+1σ'].includes(item.text),
+          boxWidth: 20,
+          font: { size: 11 },
+        },
+      },
+      tooltip: { mode: 'index' as const, intersect: false },
+    },
+    scales: {
+      x: {
+        ticks: { color: '#aaa', maxTicksLimit: 8, maxRotation: 45 },
+        grid: { color: 'rgba(255,255,255,0.08)' },
+      },
+      y: {
+        title: { display: true, text: state.currentDataset, color: '#aaa' },
+        ticks: { color: '#aaa' },
+        grid: { color: 'rgba(255,255,255,0.08)' },
+      },
+    },
+  };
+
+  return (
+    <div className="profile-panel" style={{ right: 16, left: 'auto', width: 520 }}>
+      <div className="chart-header">
+        <h4>
+          Ref Buffer — {bufferData.n_pixels} px, r={state.refBufferRadius} m
+        </h4>
+      </div>
+      <div style={{ height: 200, position: 'relative' }}>
+        <Line data={chartData as any} options={options as any} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/RefPointChart.tsx
+++ b/src/components/RefPointChart.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { Line } from 'react-chartjs-2';
 import { useAppContext } from '../context/AppContext';
 import { useApi } from '../hooks/useApi';
+import { useDraggableResizable } from '../hooks/useDraggableResizable';
 
 interface BufferResult {
   labels: string[];
@@ -16,6 +17,12 @@ export default function RefPointChart() {
   const [bufferData, setBufferData] = useState<BufferResult | null>(null);
   const [loading, setLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 520,
+    defaultHeight: 280,
+    initialRight: 16,
+    initialBottom: 20,
+  });
 
   useEffect(() => {
     if (!state.refBufferEnabled || !state.showRefChart || !state.currentDataset) {
@@ -48,7 +55,7 @@ export default function RefPointChart() {
   if (!state.refBufferEnabled || !state.showRefChart) return null;
   if (loading) {
     return (
-      <div className="profile-panel" style={{ left: '50%', transform: 'translateX(-50%)', bottom: 0, right: 'auto', width: 500 }}>
+      <div ref={panelRef} className="profile-panel" style={panelStyle} onMouseDown={e => e.stopPropagation()}>
         <div className="chart-placeholder"><p>Loading reference buffer…</p></div>
       </div>
     );
@@ -186,15 +193,16 @@ export default function RefPointChart() {
   };
 
   return (
-    <div className="profile-panel" style={{ right: 16, left: 'auto', width: 520 }}>
-      <div className="chart-header">
+    <div ref={panelRef} className="profile-panel" style={panelStyle} onMouseDown={e => e.stopPropagation()}>
+      <div className="chart-header" onMouseDown={onDragMouseDown} style={{ cursor: 'grab' }}>
         <h4>
           Ref Buffer — {bufferData.n_pixels} px, r={state.refBufferRadius} m
         </h4>
       </div>
-      <div style={{ height: 200, position: 'relative' }}>
+      <div style={{ flex: 1, minHeight: 120, position: 'relative' }}>
         <Line data={chartData as any} options={options as any} />
       </div>
+      {resizeGrip}
     </div>
   );
 }

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useDraggableResizable } from '../hooks/useDraggableResizable.tsx';
 import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, InteractionItem } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-adapter-date-fns';
@@ -6,6 +7,41 @@ import zoomPlugin from 'chartjs-plugin-zoom';
 import { useAppContext } from '../context/AppContext';
 import { useApi } from '../hooks/useApi';
 import { MultiPointTimeSeriesData } from '../types';
+
+// Chart.js plugin to wire legend-click visibility to all related datasets (raw, trend,
+// residual, samples, median) that share the same base label.
+const linkedLegendPlugin = {
+  id: 'linkedLegend',
+  afterInit(chart: ChartJS) {
+    if ((chart as any)._linkedLegendPatched) return;
+    (chart as any)._linkedLegendPatched = true;
+    const origClick = (chart.options.plugins?.legend as any)?.onClick;
+    (chart.options.plugins!.legend as any).onClick = function(
+      e: any, legendItem: any, legend: any
+    ) {
+      // Run default toggle on the clicked dataset first
+      if (origClick) origClick.call(this, e, legendItem, legend);
+      else ChartJS.defaults.plugins.legend.onClick.call(this, e, legendItem, legend);
+
+      // Then sync visibility of all datasets that share the same base label
+      const clickedDs = chart.data.datasets[legendItem.datasetIndex];
+      if (!clickedDs) return;
+      const baseLabel = (clickedDs as any)._baseLabel as string | undefined;
+      if (!baseLabel) return;
+      const hidden = !chart.isDatasetVisible(legendItem.datasetIndex);
+      chart.data.datasets.forEach((ds: any, i: number) => {
+        if (i === legendItem.datasetIndex) return;
+        if (ds._baseLabel === baseLabel) {
+          const meta = chart.getDatasetMeta(i);
+          meta.hidden = hidden;
+        }
+      });
+      chart.update();
+    };
+  },
+};
+
+ChartJS.register(linkedLegendPlugin);
 
 ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, zoomPlugin);
 
@@ -41,70 +77,102 @@ interface BufferResult {
   n_pixels: number;
 }
 
-export default function TimeSeriesChart() {
+export default function TimeSeriesChart({ windowId }: { windowId: string }) {
   const { state, dispatch } = useAppContext();
+  const window_ = state.chartWindows.find(w => w.id === windowId);
   const { fetchMultiPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const themeVersion = useThemeVersion();
-  const [chartData, setChartData] = useState<MultiPointTimeSeriesData | null>(null);
-  const [bufferData, setBufferData] = useState<{ [pointId: string]: BufferResult }>({});
+  // chartData keyed by dataset name
+  const [chartDataMap, setChartDataMap] = useState<{ [ds: string]: MultiPointTimeSeriesData }>({});
+  const [bufferData, setBufferData] = useState<{ [key: string]: BufferResult }>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isZoomed, setIsZoomed] = useState(false);
+  // Per-dataset vertical offset (in data units) for separating overlapping layers
+  const [dsOffsets, setDsOffsets] = useState<{ [ds: string]: number }>({});
+  // Per-dataset color overrides (keyed by dsName, overrides all points in that dataset)
+  const [dsColorOverrides, setDsColorOverrides] = useState<{ [ds: string]: string }>({});
+  // Per-dataset y-axis limits; empty string = auto
+  const [dsYLimits, setDsYLimits] = useState<{ [ds: string]: { min: string; max: string } }>({});
   const chartRef = useRef<ChartJS<'line'>>(null);
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: Math.min(560, window.innerWidth * 0.38),
+    defaultHeight: 420,
+  });
+
+  // Datasets for this window: window's dsNames if set, else follow currentDataset
+  const winDsNames = window_?.dsNames ?? [];
+  const activeDatasetsForChart: string[] = winDsNames.length > 0
+    ? winDsNames
+    : (state.currentDataset ? [state.currentDataset] : []);
 
   const updateChart = useCallback(async () => {
     if (!state.showChart || !state.currentDataset || state.timeSeriesPoints.length === 0) {
-      setChartData(null);
+      setChartDataMap({});
       return;
     }
     setIsLoading(true);
-    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
     const visiblePoints = state.timeSeriesPoints.filter(p => p.visible);
     if (visiblePoints.length === 0) {
-      setChartData(null);
+      setChartDataMap({});
       setIsLoading(false);
       return;
     }
+    // Skip datasets that have no time dimension (e.g. velocity, coherence scalars)
+    const timeDatasets = activeDatasetsForChart.filter(ds => {
+      const info = state.datasetInfo[ds];
+      return info && Array.isArray(info.x_values) && info.x_values.length > 0;
+    });
+    if (timeDatasets.length === 0) {
+      setChartDataMap({});
+      setIsLoading(false);
+      return;
+    }
+    const apiPoints = visiblePoints.map(point => ({
+      id: point.id,
+      lat: point.position[0],
+      lon: point.position[1],
+      color: point.color,
+      name: point.name,
+    }));
     try {
-      const apiPoints = visiblePoints.map(point => ({
-        id: point.id,
-        lat: point.position[0],
-        lon: point.position[1],
-        color: point.color,
-        name: point.name,
-      }));
-      let refLon, refLat;
-      if (currentDatasetInfo?.uses_spatial_ref && state.refEnabled) {
-        [refLat, refLon] = state.refMarkerPosition;
-      }
-      const tsData = await fetchMultiPointTimeSeries(
-        apiPoints, state.currentDataset, refLon, refLat, state.showTrends,
-        state.layerMasks,
-        state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0,
+      const results = await Promise.all(
+        timeDatasets.map(async dsName => {
+          const dsInfo = state.datasetInfo[dsName];
+          let refLon: number | undefined, refLat: number | undefined;
+          if (dsInfo?.uses_spatial_ref && state.refEnabled) {
+            [refLat, refLon] = state.refMarkerPosition;
+          }
+          const tsData = await fetchMultiPointTimeSeries(
+            apiPoints, dsName, refLon, refLat, state.showTrends,
+            state.layerMasks,
+            state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0,
+          );
+          return { dsName, tsData };
+        })
       );
-      if (tsData) {
-        setChartData(tsData);
-        if (state.showTrends && tsData.datasets) {
-          setTimeout(() => {
-            tsData.datasets.forEach(dataset => {
-              if (dataset.trend) {
-                dispatch({
-                  type: 'SET_POINT_TREND_DATA',
-                  payload: {
-                    pointId: dataset.pointId,
-                    dataset: state.currentDataset,
-                    trend: {
-                      slope: dataset.trend.slope,
-                      intercept: dataset.trend.intercept,
-                      rSquared: dataset.trend.rSquared,
-                      mmPerYear: dataset.trend.mmPerYear,
+      const newMap: { [ds: string]: MultiPointTimeSeriesData } = {};
+      results.forEach(({ dsName, tsData }) => {
+        if (tsData) {
+          newMap[dsName] = tsData;
+          if (state.showTrends) {
+            setTimeout(() => {
+              tsData.datasets.forEach(dataset => {
+                if (dataset.trend) {
+                  dispatch({
+                    type: 'SET_POINT_TREND_DATA',
+                    payload: {
+                      pointId: dataset.pointId,
+                      dataset: dsName,
+                      trend: dataset.trend,
                     },
-                  },
-                });
-              }
-            });
-          }, 0);
+                  });
+                }
+              });
+            }, 0);
+          }
         }
-      }
+      });
+      setChartDataMap(newMap);
     } catch (error) {
       console.error('Error updating chart:', error);
     } finally {
@@ -113,6 +181,7 @@ export default function TimeSeriesChart() {
   }, [
     state.showChart,
     state.currentDataset,
+    JSON.stringify(activeDatasetsForChart),
     JSON.stringify(state.timeSeriesPoints.map(p => ({ id: p.id, position: p.position, visible: p.visible }))),
     state.refMarkerPosition,
     state.refEnabled,
@@ -124,7 +193,7 @@ export default function TimeSeriesChart() {
 
   useEffect(() => { updateChart(); }, [updateChart]);
 
-  // Fetch buffer data for each visible point when buffer mode is enabled
+  // Fetch buffer data for each visible point × each active dataset
   useEffect(() => {
     if (!state.bufferEnabled || !state.showChart || !state.currentDataset) {
       setBufferData({});
@@ -133,34 +202,41 @@ export default function TimeSeriesChart() {
     const visiblePoints = state.timeSeriesPoints.filter(p => p.visible);
     if (visiblePoints.length === 0) { setBufferData({}); return; }
 
-    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
-    let refLon: number | undefined, refLat: number | undefined;
-    if (currentDatasetInfo?.uses_spatial_ref && state.refEnabled) {
-      [refLat, refLon] = state.refMarkerPosition;
-    }
-
+    const timeDatasets = activeDatasetsForChart.filter(ds => {
+      const info = state.datasetInfo[ds];
+      return info && Array.isArray(info.x_values) && info.x_values.length > 0;
+    });
+    if (timeDatasets.length === 0) { setBufferData({}); return; }
     Promise.all(
-      visiblePoints.map(async p => {
-        const result = await fetchBufferTimeSeries(
-          p.position[1], p.position[0],
-          state.currentDataset,
-          state.bufferRadius,
-          state.bufferSamples,
-          refLon, refLat,
-          state.layerMasks,
-          state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0,
-        );
-        return { id: p.id, result };
+      timeDatasets.flatMap(dsName => {
+        const dsInfo = state.datasetInfo[dsName];
+        let refLon: number | undefined, refLat: number | undefined;
+        if (dsInfo?.uses_spatial_ref && state.refEnabled) {
+          [refLat, refLon] = state.refMarkerPosition;
+        }
+        return visiblePoints.map(async p => {
+          const result = await fetchBufferTimeSeries(
+            p.position[1], p.position[0],
+            dsName,
+            state.bufferRadius,
+            state.bufferSamples,
+            refLon, refLat,
+            state.layerMasks,
+            state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0,
+          );
+          return { key: `${dsName}::${p.id}`, result };
+        });
       })
     ).then(results => {
-      const newData: { [id: string]: any } = {};
-      results.forEach(({ id, result }) => { if (result) newData[id] = result; });
+      const newData: { [key: string]: any } = {};
+      results.forEach(({ key, result }) => { if (result) newData[key] = result; });
       setBufferData(newData);
     });
   }, [
     state.bufferEnabled,
     state.showChart,
     state.currentDataset,
+    JSON.stringify(activeDatasetsForChart),
     state.bufferRadius,
     state.bufferSamples,
     state.refEnabled,
@@ -172,63 +248,97 @@ export default function TimeSeriesChart() {
     fetchBufferTimeSeries,
   ]);
 
+  // Derive a single merged chartData view from chartDataMap for click/export
+  // Use the first available dataset as the canonical labels source
+  const firstDs = Object.values(chartDataMap)[0] ?? null;
+
   const handleChartClick = useCallback((_event: any, elements: InteractionItem[]) => {
-    if (elements.length === 0 || !chartData) return;
+    if (elements.length === 0 || !firstDs) return;
     const dataIndex = elements[0].index;
-    if (dataIndex !== undefined && dataIndex < chartData.labels.length) {
+    if (dataIndex !== undefined && dataIndex < firstDs.labels.length) {
       dispatch({ type: 'SET_TIME_INDEX', payload: dataIndex });
     }
-  }, [chartData, dispatch]);
+  }, [firstDs, dispatch]);
 
   const handleExportToCSV = useCallback(() => {
-    if (!chartData || !chartData.datasets || chartData.datasets.length === 0) return;
-    const headers = ['Time', ...chartData.datasets.map(d => d.label)];
-    const rows: string[][] = [];
-    chartData.labels.forEach((label, idx) => {
-      const row = [label];
-      chartData.datasets.forEach(dataset => {
-        const dataPoint = dataset.data[idx];
-        row.push(dataPoint ? dataPoint.y.toString() : '');
-      });
-      rows.push(row);
+    if (!firstDs) return;
+    const allDatasets = Object.entries(chartDataMap).flatMap(([dsName, cd]) =>
+      cd.datasets.map(d => ({ ...d, _dsName: dsName }))
+    );
+    if (allDatasets.length === 0) return;
+    const multiDs = activeDatasetsForChart.length > 1;
+    const headers = ['Time', ...allDatasets.map(d => multiDs ? `${d._dsName} — ${d.label}` : d.label)];
+    const byLabel: Record<string, Record<string, number>> = {};
+    allDatasets.forEach(d => {
+      const key = multiDs ? `${d._dsName}::${d.label}` : d.label;
+      d.data.forEach(pt => { (byLabel[pt.x as string] ??= {})[key] = pt.y; });
     });
-    const trendRows: string[][] = [];
-    if (state.showTrends && chartData.datasets.some(d => d.trend)) {
-      trendRows.push(['']);
-      trendRows.push(['Point', 'Rate (mm/year)', 'R²', 'Slope', 'Intercept']);
-      chartData.datasets.forEach(dataset => {
-        if (dataset.trend) {
-          trendRows.push([
-            dataset.label,
-            dataset.trend.mmPerYear.toFixed(6),
-            dataset.trend.rSquared.toFixed(6),
-            dataset.trend.slope.toFixed(6),
-            dataset.trend.intercept.toFixed(6),
-          ]);
-        }
+    const allTimes = [...new Set(allDatasets.flatMap(d => d.data.map(pt => pt.x as string)))].sort();
+    const rows = allTimes.map(t => {
+      const row = [t];
+      allDatasets.forEach(d => {
+        const key = multiDs ? `${d._dsName}::${d.label}` : d.label;
+        row.push(byLabel[t]?.[key]?.toString() ?? '');
       });
-    }
-    const csvContent = [headers, ...rows, ...trendRows].map(r => r.join(',')).join('\n');
+      return row;
+    });
+    const csvContent = [headers, ...rows].map(r => r.join(',')).join('\n');
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
-    link.setAttribute('href', url);
-    link.setAttribute('download', `time-series-${state.currentDataset}-${timestamp}.csv`);
+    link.setAttribute('href', URL.createObjectURL(blob));
+    link.setAttribute('download', `time-series-${state.currentDataset}-${new Date().toISOString().slice(0, 16).replace(/[:.]/g, '-')}.csv`);
     link.style.visibility = 'hidden';
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-  }, [chartData, state.showTrends, state.currentDataset]);
+  }, [chartDataMap, firstDs, activeDatasetsForChart, state.currentDataset]);
+
+  // Ordered list of dataset names currently in chartDataMap
+  const activeChartDs = Object.keys(chartDataMap);
 
   const chartOptions = useMemo(() => {
     const textColor  = cssVar('--sb-text',   '#dde0f0');
     const mutedColor = cssVar('--sb-muted',  '#7880a8');
     const gridColor  = cssVar('--sb-border', '#2c2f4a');
-    const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
-    const yLabel = dsInfo?.label && dsInfo?.unit
-      ? `${dsInfo.label} (${dsInfo.unit})`
-      : dsInfo?.label || dsInfo?.unit || 'Displacement (m)';
+
+    // Per-dataset y-axes: first on left, extras on right
+    const scales: any = {
+      x: {
+        type: 'time' as const,
+        time: { displayFormats: { month: 'MMM yyyy', day: 'MMM d', year: 'yyyy' } },
+        title: { display: true, text: 'Date', color: mutedColor },
+        grid: { color: gridColor },
+        ticks: { color: mutedColor },
+      },
+    };
+
+    activeChartDs.forEach((ds, i) => {
+      const info = state.datasetInfo[ds];
+      const yLabel = info?.label && info?.unit
+        ? `${info.label} (${info.unit})`
+        : info?.label || info?.unit || ds;
+      const axisColor = dsColorOverrides[ds] ?? (i === 0 ? mutedColor : mutedColor);
+      const offset = dsOffsets[ds] ?? 0;
+      const lim = dsYLimits[ds];
+      const userMin = lim?.min !== '' && lim?.min !== undefined ? parseFloat(lim.min) : NaN;
+      const userMax = lim?.max !== '' && lim?.max !== undefined ? parseFloat(lim.max) : NaN;
+
+      const axisScale: any = {
+        position: i === 0 ? 'left' as const : 'right' as const,
+        title: { display: true, text: yLabel, color: axisColor, font: { size: 10 } },
+        grid: { color: i === 0 ? gridColor : 'transparent' },
+        ticks: { color: axisColor, font: { size: 10 } },
+      };
+      // Only fix bounds when user has explicitly set them; otherwise let Chart.js autoscale
+      if (!isNaN(userMin)) axisScale.min = userMin + offset;
+      if (!isNaN(userMax)) axisScale.max = userMax + offset;
+      // When offset is non-zero but no explicit limits, use suggestedMin/Max to shift axis without clipping
+      if (isNaN(userMin) && offset !== 0) axisScale.suggestedMin = undefined;
+      if (isNaN(userMax) && offset !== 0) axisScale.suggestedMax = undefined;
+
+      scales[`y${i}`] = axisScale;
+    });
+
     return {
       responsive: true,
       maintainAspectRatio: false,
@@ -243,26 +353,32 @@ export default function TimeSeriesChart() {
             padding: 16,
             color: textColor,
             generateLabels: (chart: any) => {
-              if (!chartData?.datasets) return [];
+              const isBuffer = chart.data.datasets.some((ds: any) => ds.label?.endsWith(' median'));
               return chart.data.datasets
                 .map((ds: any, index: number) => ({ ds, index }))
-                .filter(({ ds }: any) =>
-                  !ds.label.endsWith(' trend') &&
-                  !ds.label.endsWith(' residual') &&
-                  !ds.label.includes(' sample ') &&
-                  !ds.label.endsWith(' median')
-                )
-                .map(({ ds, index }: any) => ({
-                  text: ds.label + (ds.label && chartData.datasets.find(d => d.label === ds.label)?.trend?.mmPerYear !== undefined
-                    ? ` (${chartData.datasets.find(d => d.label === ds.label)!.trend!.mmPerYear.toFixed(1)} mm/yr)`
-                    : ''),
-                  pointStyle: 'circle' as const,
-                  fillStyle: ds.borderColor,
-                  strokeStyle: ds.borderColor,
-                  fontColor: textColor,
-                  lineWidth: 2,
-                  datasetIndex: index,
-                }));
+                .filter(({ ds }: any) => {
+                  if (ds.label.includes(' sample ')) return false;
+                  if (ds.label.endsWith(' trend')) return false;
+                  if (ds.label.endsWith(' residual')) return false;
+                  if (isBuffer) return ds.label.endsWith(' median');
+                  return !ds.label.endsWith(' median');
+                })
+                .map(({ ds, index }: any) => {
+                  const baseLabel = (ds as any)._baseLabel || ds.label;
+                  const trendMmPerYear = (ds as any)._trendMmPerYear;
+                  const displayText = baseLabel + (trendMmPerYear !== undefined && state.showTrends
+                    ? ` (${trendMmPerYear.toFixed(1)} mm/yr)` : '');
+                  return {
+                    text: displayText,
+                    pointStyle: 'circle' as const,
+                    fillStyle: ds.borderColor,
+                    strokeStyle: ds.borderColor,
+                    fontColor: textColor,
+                    lineWidth: 2,
+                    datasetIndex: index,
+                    hidden: !chart.isDatasetVisible(index),
+                  };
+                });
             },
           },
         },
@@ -270,23 +386,18 @@ export default function TimeSeriesChart() {
           callbacks: {
             title: (context: any) => `${context[0]?.label || ''}`,
             label: (context: any) => {
-              const dataset = chartData?.datasets?.[context.datasetIndex];
-              if (!dataset) return '';
-              const unit = dsInfo?.unit || 'm';
-              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} ${unit}`;
-              if (dataset.trend?.mmPerYear !== undefined && state.showTrends) {
-                label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
-              }
+              const ds = context.chart.data.datasets[context.datasetIndex];
+              if (!ds) return '';
+              const unit = (ds as any)._unit || 'm';
+              let label = `${(ds as any)._baseLabel || ds.label}: ${context.parsed.y.toFixed(4)} ${unit}`;
+              const mmPy = (ds as any)._trendMmPerYear;
+              if (mmPy !== undefined && state.showTrends) label += ` (${mmPy.toFixed(1)} mm/yr)`;
               return label;
             },
           },
         },
         zoom: {
-          pan: {
-            enabled: true,
-            mode: 'x' as const,
-            onPanComplete: () => setIsZoomed(true),
-          },
+          pan: { enabled: true, mode: 'x' as const, onPanComplete: () => setIsZoomed(true) },
           zoom: {
             wheel: { enabled: true },
             pinch: { enabled: true },
@@ -295,198 +406,367 @@ export default function TimeSeriesChart() {
           },
         },
       },
-      scales: {
-        x: {
-          type: 'time' as const,
-          time: { displayFormats: { month: 'MMM yyyy', day: 'MMM d', year: 'yyyy' } },
-          title: { display: true, text: 'Date', color: mutedColor },
-          grid: { color: gridColor },
-          ticks: { color: mutedColor },
-        },
-        y: {
-          title: { display: true, text: yLabel, color: mutedColor },
-          suggestedMin: state.vmin,
-          suggestedMax: state.vmax,
-          grid: { color: gridColor },
-          ticks: { color: mutedColor },
-        },
-      },
+      scales,
       onClick: handleChartClick,
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, state.currentDataset, state.datasetInfo, handleChartClick]);
+  }, [themeVersion, state.showTrends, state.vmin, state.vmax, state.datasetInfo, state.bufferEnabled, handleChartClick, JSON.stringify(activeChartDs), JSON.stringify(dsOffsets), JSON.stringify(dsColorOverrides), JSON.stringify(dsYLimits), JSON.stringify(Object.fromEntries(Object.entries(chartDataMap).map(([k, v]) => [k, v.datasets.flatMap(d => d.data.map(pt => pt.y))]))) ]);
 
   if (!state.showChart) return null;
 
+  // Dataset selector helpers
+  const allDsNames = Object.keys(state.datasetInfo);
+  const setWinDs = (dsNames: string[]) =>
+    dispatch({ type: 'SET_CHART_WINDOW_DS', payload: { id: windowId, dsNames } });
+  const addWinDs = (ds: string) => { if (!winDsNames.includes(ds)) setWinDs([...winDsNames, ds]); };
+  const removeWinDs = (ds: string) => setWinDs(winDsNames.filter(d => d !== ds));
+  const spawnNewChart = () => dispatch({
+    type: 'ADD_CHART_WINDOW',
+    payload: { id: `chart_${Date.now()}`, dsNames: [] },
+  });
+  const closeThis = () => dispatch({ type: 'REMOVE_CHART_WINDOW', payload: windowId });
+
+  const headerContent = (
+    <>
+      <div className="chart-header" onMouseDown={onDragMouseDown} style={{ cursor: 'grab' }}>
+        <h4 style={{ margin: 0, fontSize: '0.9em' }}>Time Series</h4>
+        <div className="chart-controls">
+          <button className="chart-btn" onClick={() => dispatch({ type: 'TOGGLE_TRENDS' })} title="Toggle trend analysis">
+            <i className={`fa-solid ${state.showTrends ? 'fa-chart-line' : 'fa-chart-simple'}`}></i>
+            {state.showTrends ? 'Trends ✓' : 'Trends'}
+          </button>
+          {state.showTrends && (
+            <button className="chart-btn" onClick={() => dispatch({ type: 'TOGGLE_RESIDUALS' })} title="Show residuals">
+              <i className="fa-solid fa-wave-square"></i>
+              {state.showResiduals ? 'Resid ✓' : 'Resid'}
+            </button>
+          )}
+          {isZoomed && (
+            <button className="chart-btn" onClick={() => { chartRef.current?.resetZoom(); setIsZoomed(false); }} title="Reset zoom">
+              <i className="fa-solid fa-magnifying-glass-minus"></i>
+            </button>
+          )}
+          <button className="chart-btn" onClick={handleExportToCSV} title="Export CSV">
+            <i className="fa-solid fa-download"></i>
+          </button>
+          <button className="chart-btn" title="New chart window" onClick={spawnNewChart}>
+            <i className="fa-solid fa-plus"></i>
+          </button>
+          <button className="chart-btn" style={{ color: 'var(--sb-red)' }} title="Close this chart" onClick={closeThis}>
+            <i className="fa-solid fa-xmark"></i>
+          </button>
+        </div>
+      </div>
+      <div className="chart-sliders" style={{ marginBottom: 4, paddingBottom: 4, flexWrap: 'wrap' }}>
+        {winDsNames.length === 0 ? (
+          state.currentDataset ? (
+            <span style={{
+              display: 'inline-flex', alignItems: 'center', gap: 3, padding: '1px 6px',
+              background: 'var(--sb-surface2)', border: '1px solid var(--sb-border)',
+              borderRadius: 10, fontSize: '0.72em', color: 'var(--sb-text)', flexShrink: 0,
+            }}>
+              {state.currentDataset}
+              <button onClick={() => setWinDs(allDsNames.filter(d => d !== state.currentDataset))} style={{
+                background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+                color: 'var(--sb-muted)', fontSize: '0.9em', lineHeight: 1,
+              }} title={`Remove ${state.currentDataset}`}>✕</button>
+            </span>
+          ) : (
+            <span style={{ fontSize: '0.75em', color: 'var(--sb-muted)' }}>No layer selected</span>
+          )
+        ) : (
+          winDsNames.map(ds => (
+            <span key={ds} style={{
+              display: 'inline-flex', alignItems: 'center', gap: 3, padding: '1px 6px',
+              background: 'var(--sb-surface2)', border: '1px solid var(--sb-border)',
+              borderRadius: 10, fontSize: '0.72em', color: 'var(--sb-text)', flexShrink: 0,
+            }}>
+              {ds}
+              <button onClick={() => removeWinDs(ds)} style={{
+                background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+                color: 'var(--sb-muted)', fontSize: '0.9em', lineHeight: 1,
+              }} title={`Remove ${ds}`}>✕</button>
+            </span>
+          ))
+        )}
+        {(() => {
+          const excluded = winDsNames.length === 0
+            ? [...winDsNames, state.currentDataset].filter(Boolean)
+            : winDsNames;
+          const available = allDsNames.filter((ds: string) => !excluded.includes(ds));
+          return available.length > 0 ? (
+            <select className="sidebar-select"
+              style={{ fontSize: '0.72em', padding: '1px 4px', height: 22, flex: '0 0 auto', maxWidth: 130 }}
+              value="" onChange={e => { if (e.target.value) { addWinDs(e.target.value); e.currentTarget.value = ''; } }}
+            >
+              <option value="">＋ layer…</option>
+              {available.map((ds: string) => (
+                <option key={ds} value={ds}>{ds}</option>
+              ))}
+            </select>
+          ) : null;
+        })()}
+        {winDsNames.length > 0 && (
+          <button className="chart-btn" style={{ fontSize: '0.7em', padding: '1px 5px' }}
+            onClick={() => setWinDs([])} title="Reset to map layer">↺ reset</button>
+        )}
+      </div>
+    </>
+  );
+
   if (state.timeSeriesPoints.length === 0) {
     return (
-      <div id="chart-container">
+      <div id="chart-container" ref={panelRef} style={panelStyle}>
+        {headerContent}
         <div className="chart-placeholder">
-          <p>No points selected.</p>
-          <p><small>Click on the map to add points.</small></p>
+          <p>No points selected.</p><p><small>Click on the map to add points.</small></p>
         </div>
+        {resizeGrip}
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div id="chart-container">
+      <div id="chart-container" ref={panelRef} style={panelStyle}>
+        {headerContent}
         <div className="chart-placeholder"><p>Loading…</p></div>
+        {resizeGrip}
       </div>
     );
   }
 
-  if (!chartData || !chartData.datasets || chartData.datasets.length === 0) {
-    return (
-      <div id="chart-container">
-        <div className="chart-placeholder"><p>No data for selected points.</p></div>
-      </div>
-    );
-  }
-
-  // Transform x-values to ISO dates so Chart.js time scale can parse them
-  const isoLabels = chartData.labels.map(toIsoDate);
-
-  // Convert ISO date string to days since first label (matches backend regression basis)
-  const day0 = isoLabels.length > 0 ? new Date(isoLabels[0]).getTime() / 86400000 : 0;
-  const isoToDay = (iso: string) => new Date(iso).getTime() / 86400000 - day0;
-
-  const datasetList: any[] = [];
-  chartData.datasets.forEach(dataset => {
-    const isoData = dataset.data.map(pt => ({ x: toIsoDate(pt.x as string), y: pt.y }));
-    datasetList.push({
-      label: dataset.label,
-      data: isoData,
-      borderColor: dataset.borderColor,
-      backgroundColor: dataset.backgroundColor,
-      borderWidth: 2,
-      pointRadius: 4,
-      pointHoverRadius: 6,
-      tension: 0.1,
-      fill: false,
+  if (Object.keys(chartDataMap).length === 0) {
+    const allNoTime = activeDatasetsForChart.every((ds: string) => {
+      const info = state.datasetInfo[ds];
+      return info && Array.isArray(info.x_values) && info.x_values.length === 0;
     });
+    return (
+      <div id="chart-container" ref={panelRef} style={panelStyle}>
+        {headerContent}
+        <div className="chart-placeholder">
+          {allNoTime
+            ? <><p>Selected layer has no time dimension.</p><p><small>Switch to a time-series dataset to view the chart.</small></p></>
+            : <p>No data for selected points.</p>
+          }
+        </div>
+        {resizeGrip}
+      </div>
+    );
+  }
 
-    // Add dashed trend line if trends are enabled and data exists
-    if (state.showTrends && dataset.trend && isoData.length > 1) {
-      const { slope, intercept } = dataset.trend;
-      const trendData = isoData.map(pt => ({
-        x: pt.x,
-        y: slope * isoToDay(pt.x) + intercept,
-      }));
-      datasetList.push({
-        label: `${dataset.label} trend`,
-        data: trendData,
-        borderColor: dataset.borderColor,
-        backgroundColor: 'transparent',
-        borderWidth: 1.5,
-        borderDash: [6, 4],
-        pointRadius: 0,
-        pointHoverRadius: 0,
-        tension: 0,
-        fill: false,
-      });
+  // ── Build unified dataset list from all active chart datasets ─────────────
+  const multiDs = activeDatasetsForChart.length > 1;
+  const dateStart = state.dateRangeStart ? new Date(state.dateRangeStart).getTime() : -Infinity;
+  const dateEnd   = state.dateRangeEnd   ? new Date(state.dateRangeEnd).getTime()   : Infinity;
 
-      // Residuals: actual - trend
-      if (state.showResiduals) {
-        const residualData = isoData.map(pt => ({
-          x: pt.x,
-          y: pt.y - (slope * isoToDay(pt.x) + intercept),
-        }));
-        datasetList.push({
-          label: `${dataset.label} residual`,
-          data: residualData,
-          borderColor: dataset.borderColor,
-          backgroundColor: dataset.backgroundColor,
-          borderWidth: 1,
-          borderDash: [2, 3],
-          pointRadius: 2,
-          pointHoverRadius: 4,
-          tension: 0,
-          fill: false,
-          borderDashOffset: 0,
-        });
-      }
-    }
+  // Collect all ISO dates across all datasets for the x-axis
+  const allIsoLabels = [...new Set(
+    Object.values(chartDataMap).flatMap(cd => cd.labels.map(toIsoDate))
+  )].sort();
+
+  const isoLabels = allIsoLabels.filter(d => {
+    const t = new Date(d).getTime();
+    return t >= dateStart && t <= dateEnd;
   });
 
-  // Append buffer sample + median datasets (thin lines behind points)
-  if (state.bufferEnabled) {
-    chartData.datasets.forEach(dataset => {
-      const buf = bufferData[dataset.pointId];
-      if (!buf) return;
-      const color = dataset.borderColor;
+  const day0 = allIsoLabels.length > 0 ? new Date(allIsoLabels[0]).getTime() / 86400000 : 0;
+  const isoToDay = (iso: string) => new Date(iso).getTime() / 86400000 - day0;
+  const ms = state.markerSize;
 
-      // Sample lines — thin, semi-transparent, no points, not in legend
-      buf.samples.forEach((sample: Array<{ x: string; y: number }>, i: number) => {
-        datasetList.push({
-          label: `${dataset.label} sample ${i}`,
-          data: sample.map(pt => ({ x: toIsoDate(pt.x), y: pt.y })),
-          borderColor: color + '28',
-          backgroundColor: 'transparent',
-          borderWidth: 1,
-          pointRadius: 0,
-          pointHoverRadius: 0,
-          tension: 0.1,
-          fill: false,
+  const datasetList: any[] = [];
+
+  Object.entries(chartDataMap).forEach(([dsName, cd]) => {
+    const dsInfo = state.datasetInfo[dsName];
+    const unit = dsInfo?.unit;
+    const colorOverride = dsColorOverrides[dsName] ?? null;
+    const axisIdx = activeChartDs.indexOf(dsName);
+    const yAxisID = `y${axisIdx}`;
+
+    cd.datasets.forEach(dataset => {
+      const baseLabel = multiDs ? `${dataset.label} [${dsName}]` : dataset.label;
+      const borderColor = colorOverride ?? dataset.borderColor;
+      const backgroundColor = colorOverride ? colorOverride + '20' : dataset.backgroundColor;
+
+      if (state.bufferEnabled) {
+        const buf = bufferData[`${dsName}::${dataset.pointId}`];
+        if (!buf) return;
+
+        buf.samples.forEach((sample: Array<{ x: string; y: number }>, i: number) => {
+          datasetList.push({
+            label: `${baseLabel} sample ${i}`,
+            _baseLabel: baseLabel,
+            _unit: unit,
+            yAxisID,
+            data: sample
+              .map(pt => ({ x: toIsoDate(pt.x), y: pt.y }))
+              .filter(pt => { const t = new Date(pt.x).getTime(); return t >= dateStart && t <= dateEnd; }),
+            borderColor: borderColor + '28',
+            backgroundColor: 'transparent',
+            borderWidth: 1, pointRadius: 0, pointHoverRadius: 0, tension: 0.1, fill: false,
+          });
         });
-      });
 
-      // Median line — same color, thick, dashed, no points
-      datasetList.push({
-        label: `${dataset.label} median`,
-        data: buf.median.map((pt: { x: string; y: number }) => ({ x: toIsoDate(pt.x), y: pt.y })),
-        borderColor: color,
-        backgroundColor: 'transparent',
-        borderWidth: 3,
-        borderDash: [4, 3],
-        pointRadius: 0,
-        pointHoverRadius: 0,
-        tension: 0.1,
-        fill: false,
-      });
+        const medianData = buf.median
+          .map((pt: { x: string; y: number }) => ({ x: toIsoDate(pt.x), y: pt.y }))
+          .filter((pt: { x: string; y: number }) => { const t = new Date(pt.x).getTime(); return t >= dateStart && t <= dateEnd; });
+        datasetList.push({
+          label: `${baseLabel} median`,
+          _baseLabel: baseLabel,
+          _unit: unit,
+          yAxisID,
+          data: medianData,
+          borderColor, backgroundColor: borderColor,
+          borderWidth: 0, showLine: false, pointStyle: 'circle',
+          pointRadius: ms, pointHoverRadius: ms + 2, fill: false,
+        });
+      } else {
+        const isoData = dataset.data
+          .map(pt => ({ x: toIsoDate(pt.x as string), y: pt.y }))
+          .filter(pt => { const t = new Date(pt.x).getTime(); return t >= dateStart && t <= dateEnd; });
+
+        datasetList.push({
+          label: baseLabel,
+          _baseLabel: baseLabel,
+          _unit: unit,
+          _trendMmPerYear: dataset.trend?.mmPerYear,
+          yAxisID,
+          data: isoData,
+          borderColor,
+          backgroundColor,
+          borderWidth: 2, pointRadius: ms, pointHoverRadius: ms + 2, tension: 0.1, fill: false,
+        });
+
+        if (state.showTrends && dataset.trend && isoData.length > 1) {
+          const { slope, intercept, mmPerYear } = dataset.trend;
+          datasetList.push({
+            label: `${baseLabel} trend`,
+            _baseLabel: baseLabel,
+            _unit: unit,
+            _trendMmPerYear: mmPerYear,
+            yAxisID,
+            data: isoData.map(pt => ({ x: pt.x, y: slope * isoToDay(pt.x) + intercept })),
+            borderColor, backgroundColor: 'transparent',
+            borderWidth: 1.5, borderDash: [6, 4], pointRadius: 0, pointHoverRadius: 0, tension: 0, fill: false,
+          });
+
+          if (state.showResiduals) {
+            datasetList.push({
+              label: `${baseLabel} residual`,
+              _baseLabel: baseLabel,
+              _unit: unit,
+              yAxisID,
+              data: isoData.map(pt => ({ x: pt.x, y: pt.y - (slope * isoToDay(pt.x) + intercept) })),
+              borderColor, backgroundColor,
+              borderWidth: 1, borderDash: [2, 3],
+              pointRadius: ms > 2 ? ms - 1 : 2, pointHoverRadius: ms + 1, tension: 0, fill: false,
+            });
+          }
+        }
+      }
     });
-  }
+  });
 
   const formattedChartData = { labels: isoLabels, datasets: datasetList };
+  const minDate = allIsoLabels[0] ?? '';
+  const maxDate = allIsoLabels[allIsoLabels.length - 1] ?? '';
+  const sliderStart = state.dateRangeStart ?? minDate;
+  const sliderEnd   = state.dateRangeEnd   ?? maxDate;
 
   return (
-    <div id="chart-container">
-      <div className="chart-header">
-        <h4>Time Series</h4>
-        <div className="chart-controls">
-          <button
-            className="chart-btn"
-            onClick={() => dispatch({ type: 'TOGGLE_TRENDS' })}
-            title="Toggle trend analysis"
-          >
-            <i className={`fa-solid ${state.showTrends ? 'fa-chart-line' : 'fa-chart-simple'}`}></i>
-            {state.showTrends ? 'Hide' : 'Show'} Trends
-          </button>
-          {state.showTrends && (
-            <button
-              className="chart-btn"
-              onClick={() => dispatch({ type: 'TOGGLE_RESIDUALS' })}
-              title="Show residuals (data minus trend)"
-            >
-              <i className={`fa-solid ${state.showResiduals ? 'fa-wave-square' : 'fa-chart-scatter'}`}></i>
-              {state.showResiduals ? 'Hide' : 'Show'} Residuals
-            </button>
-          )}
-          {isZoomed && (
-            <button
-              className="chart-btn"
-              onClick={() => { chartRef.current?.resetZoom(); setIsZoomed(false); }}
-              title="Reset zoom"
-            >
-              <i className="fa-solid fa-magnifying-glass-minus"></i> Reset
-            </button>
-          )}
-          <button className="chart-btn" onClick={handleExportToCSV} title="Export data to CSV">
-            <i className="fa-solid fa-download"></i> CSV
-          </button>
-        </div>
+    <div id="chart-container" ref={panelRef} style={panelStyle}>
+      {headerContent}
+
+      {/* Marker size + date range sliders */}
+      <div className="chart-sliders">
+        <label className="chart-slider-label">
+          <span>Marker</span>
+          <input type="range" min={1} max={12} step={1} value={state.markerSize}
+            onChange={e => dispatch({ type: 'SET_MARKER_SIZE', payload: Number(e.target.value) })} />
+          <span>{state.markerSize}px</span>
+        </label>
+        {allIsoLabels.length > 1 && (
+          <>
+            <label className="chart-slider-label">
+              <span>From</span>
+              <input type="date" min={minDate} max={sliderEnd || maxDate} value={sliderStart}
+                onChange={e => dispatch({ type: 'SET_DATE_RANGE_START', payload: e.target.value || null })} />
+            </label>
+            <label className="chart-slider-label">
+              <span>To</span>
+              <input type="date" min={sliderStart || minDate} max={maxDate} value={sliderEnd}
+                onChange={e => dispatch({ type: 'SET_DATE_RANGE_END', payload: e.target.value || null })} />
+            </label>
+            {(state.dateRangeStart || state.dateRangeEnd) && (
+              <button className="chart-btn" title="Reset date range"
+                onClick={() => { dispatch({ type: 'SET_DATE_RANGE_START', payload: null }); dispatch({ type: 'SET_DATE_RANGE_END', payload: null }); }}>
+                <i className="fa-solid fa-xmark"></i>
+              </button>
+            )}
+          </>
+        )}
       </div>
+
+      {/* Per-dataset controls (offset + color) — shown for ALL datasets when multiple */}
+      {activeChartDs.map((ds, i) => {
+        const off = dsOffsets[ds] ?? 0;
+        const baseColor = chartDataMap[ds]?.datasets[0]?.borderColor ?? '#7880a8';
+        const color = dsColorOverrides[ds] ?? baseColor;
+        const info = state.datasetInfo[ds];
+        const unit = info?.unit || '';
+        const allY = chartDataMap[ds]?.datasets.flatMap(d => d.data.map(pt => pt.y)) ?? [];
+        const dataSpan = allY.length > 1 ? Math.max(...allY) - Math.min(...allY) : 1;
+        const sliderRange = Math.max(dataSpan * 2, 0.001);
+        const step = parseFloat((sliderRange / 500).toPrecision(2));
+        const lim = dsYLimits[ds] ?? { min: '', max: '' };
+        const hasLimit = lim.min !== '' || lim.max !== '';
+        const inputStyle: React.CSSProperties = { width: 58, fontSize: '0.72em', background: 'var(--sb-surface2)', border: '1px solid var(--sb-border)', borderRadius: 4, color: 'var(--sb-text)', padding: '1px 4px', textAlign: 'right', flexShrink: 0 };
+        return (
+          <div key={ds} className="chart-sliders" style={{ borderTop: i === 0 ? undefined : 'none', paddingTop: i === 0 ? undefined : 0, flexWrap: 'wrap', rowGap: 2 }}>
+            {/* Row 1: color + name + offset slider — only when multiple datasets */}
+            {multiDs && (
+              <label className="chart-slider-label" style={{ flex: '1 1 100%' }}>
+                <input type="color" value={color.length === 7 ? color : baseColor}
+                  style={{ width: 20, height: 20, padding: 0, border: 'none', background: 'none', cursor: 'pointer', flexShrink: 0 }}
+                  title="Change layer color"
+                  onChange={e => setDsColorOverrides(prev => ({ ...prev, [ds]: e.target.value }))}
+                />
+                <span style={{ color, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 80 }} title={ds}>{ds}</span>
+                <span style={{ fontSize: '0.72em', color: 'var(--sb-muted)', flexShrink: 0 }}>y{i} off</span>
+                <input type="range" min={-sliderRange} max={sliderRange} step={step}
+                  value={off} style={{ flex: 1 }}
+                  onChange={e => setDsOffsets(prev => ({ ...prev, [ds]: Number(e.target.value) }))}
+                />
+                <input type="number" step={step} value={parseFloat(off.toPrecision(4))}
+                  style={{ ...inputStyle }}
+                  onChange={e => { const v = parseFloat(e.target.value); if (!isNaN(v)) setDsOffsets(prev => ({ ...prev, [ds]: v })); }}
+                />
+                {off !== 0 && (
+                  <button className="chart-btn" style={{ padding: '1px 6px', flexShrink: 0 }}
+                    onClick={() => setDsOffsets(prev => ({ ...prev, [ds]: 0 }))} title="Reset offset">✕</button>
+                )}
+              </label>
+            )}
+            {/* Row 2: y-axis min/max limits */}
+            <label className="chart-slider-label" style={{ flex: '1 1 100%', gap: 4 }}>
+              <span style={{ fontSize: '0.72em', color: 'var(--sb-muted)', flexShrink: 0 }}>y{i} min</span>
+              <input type="number" placeholder="auto" value={lim.min} style={{ ...inputStyle, flex: 1 }}
+                onChange={e => setDsYLimits(prev => ({ ...prev, [ds]: { ...lim, min: e.target.value } }))}
+              />
+              <span style={{ fontSize: '0.72em', color: 'var(--sb-muted)', flexShrink: 0 }}>max</span>
+              <input type="number" placeholder="auto" value={lim.max} style={{ ...inputStyle, flex: 1 }}
+                onChange={e => setDsYLimits(prev => ({ ...prev, [ds]: { ...lim, max: e.target.value } }))}
+              />
+              <span style={{ fontSize: '0.7em', color: 'var(--sb-muted)', flexShrink: 0 }}>{unit}</span>
+              {hasLimit && (
+                <button className="chart-btn" style={{ padding: '1px 6px', flexShrink: 0 }}
+                  onClick={() => setDsYLimits(prev => ({ ...prev, [ds]: { min: '', max: '' } }))} title="Reset y limits">✕</button>
+              )}
+            </label>
+          </div>
+        );
+      })}
+
       <div className="chart-content">
         <Line ref={chartRef} data={formattedChartData} options={chartOptions as any} />
       </div>
@@ -498,6 +778,7 @@ export default function TimeSeriesChart() {
           )}
         </small>
       </div>
+      {resizeGrip}
     </div>
   );
 }

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, InteractionItem } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-adapter-date-fns';
+import zoomPlugin from 'chartjs-plugin-zoom';
 import { useAppContext } from '../context/AppContext';
 import { useApi } from '../hooks/useApi';
 import { MultiPointTimeSeriesData } from '../types';
+
+ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, zoomPlugin);
 
 /** Read a CSS variable from the document root at call time. */
 function cssVar(name: string, fallback: string): string {
@@ -21,8 +24,6 @@ function useThemeVersion(): number {
   }, []);
   return v;
 }
-
-ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 /** Convert "YYYYMMDD_YYYYMMDD" or "YYYYMMDD" → "YYYY-MM-DD" (secondary/only date). */
 function toIsoDate(xVal: string): string {
@@ -47,6 +48,8 @@ export default function TimeSeriesChart() {
   const [chartData, setChartData] = useState<MultiPointTimeSeriesData | null>(null);
   const [bufferData, setBufferData] = useState<{ [pointId: string]: BufferResult }>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [isZoomed, setIsZoomed] = useState(false);
+  const chartRef = useRef<ChartJS<'line'>>(null);
 
   const updateChart = useCallback(async () => {
     if (!state.showChart || !state.currentDataset || state.timeSeriesPoints.length === 0) {
@@ -222,6 +225,10 @@ export default function TimeSeriesChart() {
     const textColor  = cssVar('--sb-text',   '#dde0f0');
     const mutedColor = cssVar('--sb-muted',  '#7880a8');
     const gridColor  = cssVar('--sb-border', '#2c2f4a');
+    const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
+    const yLabel = dsInfo?.label && dsInfo?.unit
+      ? `${dsInfo.label} (${dsInfo.unit})`
+      : dsInfo?.label || dsInfo?.unit || 'Displacement (m)';
     return {
       responsive: true,
       maintainAspectRatio: false,
@@ -265,12 +272,26 @@ export default function TimeSeriesChart() {
             label: (context: any) => {
               const dataset = chartData?.datasets?.[context.datasetIndex];
               if (!dataset) return '';
-              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
+              const unit = dsInfo?.unit || 'm';
+              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} ${unit}`;
               if (dataset.trend?.mmPerYear !== undefined && state.showTrends) {
                 label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
               }
               return label;
             },
+          },
+        },
+        zoom: {
+          pan: {
+            enabled: true,
+            mode: 'x' as const,
+            onPanComplete: () => setIsZoomed(true),
+          },
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            mode: 'x' as const,
+            onZoomComplete: () => setIsZoomed(true),
           },
         },
       },
@@ -283,7 +304,7 @@ export default function TimeSeriesChart() {
           ticks: { color: mutedColor },
         },
         y: {
-          title: { display: true, text: 'Displacement (m)', color: mutedColor },
+          title: { display: true, text: yLabel, color: mutedColor },
           suggestedMin: state.vmin,
           suggestedMax: state.vmax,
           grid: { color: gridColor },
@@ -293,7 +314,7 @@ export default function TimeSeriesChart() {
       onClick: handleChartClick,
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, handleChartClick]);
+  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, state.currentDataset, state.datasetInfo, handleChartClick]);
 
   if (!state.showChart) return null;
 
@@ -452,17 +473,26 @@ export default function TimeSeriesChart() {
               {state.showResiduals ? 'Hide' : 'Show'} Residuals
             </button>
           )}
+          {isZoomed && (
+            <button
+              className="chart-btn"
+              onClick={() => { chartRef.current?.resetZoom(); setIsZoomed(false); }}
+              title="Reset zoom"
+            >
+              <i className="fa-solid fa-magnifying-glass-minus"></i> Reset
+            </button>
+          )}
           <button className="chart-btn" onClick={handleExportToCSV} title="Export data to CSV">
             <i className="fa-solid fa-download"></i> CSV
           </button>
         </div>
       </div>
       <div className="chart-content">
-        <Line data={formattedChartData} options={chartOptions} />
+        <Line ref={chartRef} data={formattedChartData} options={chartOptions as any} />
       </div>
       <div className="chart-help">
         <small>
-          Click chart points to sync map time
+          Scroll to zoom · Drag to pan · Click points to sync map time
           {state.bufferEnabled && Object.keys(bufferData).length > 0 && (
             <> · Buffer: {Object.values(bufferData).map((b: any) => b.n_pixels).join(', ')} px</>
           )}

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -1,10 +1,26 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { Chart as ChartJS, TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, InteractionItem } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import 'chartjs-adapter-date-fns';
 import { useAppContext } from '../context/AppContext';
 import { useApi } from '../hooks/useApi';
 import { MultiPointTimeSeriesData } from '../types';
+
+/** Read a CSS variable from the document root at call time. */
+function cssVar(name: string, fallback: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+/** Returns a counter that increments whenever data-theme attribute changes on <html>. */
+function useThemeVersion(): number {
+  const [v, setV] = useState(0);
+  useEffect(() => {
+    const obs = new MutationObserver(() => setV(n => n + 1));
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => obs.disconnect();
+  }, []);
+  return v;
+}
 
 ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
@@ -27,6 +43,7 @@ interface BufferResult {
 export default function TimeSeriesChart() {
   const { state, dispatch } = useAppContext();
   const { fetchMultiPointTimeSeries, fetchBufferTimeSeries } = useApi();
+  const themeVersion = useThemeVersion();
   const [chartData, setChartData] = useState<MultiPointTimeSeriesData | null>(null);
   const [bufferData, setBufferData] = useState<{ [pointId: string]: BufferResult }>({});
   const [isLoading, setIsLoading] = useState(false);
@@ -201,75 +218,82 @@ export default function TimeSeriesChart() {
     document.body.removeChild(link);
   }, [chartData, state.showTrends, state.currentDataset]);
 
-  const chartOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    animation: { duration: 300 },
-    interaction: { mode: 'index' as const, intersect: false },
-    plugins: {
-      legend: {
-        display: true,
-        position: 'top' as const,
-        labels: {
-          usePointStyle: true,
-          padding: 16,
-          color: '#ffffff',
-          generateLabels: (chart: any) => {
-            if (!chartData?.datasets) return [];
-            return chart.data.datasets
-              .map((ds: any, index: number) => ({ ds, index }))
-              .filter(({ ds }: any) =>
-                !ds.label.endsWith(' trend') &&
-                !ds.label.endsWith(' residual') &&
-                !ds.label.includes(' sample ') &&
-                !ds.label.endsWith(' median')
-              )
-              .map(({ ds, index }: any) => ({
-                text: ds.label + (ds.label && chartData.datasets.find(d => d.label === ds.label)?.trend?.mmPerYear !== undefined
-                  ? ` (${chartData.datasets.find(d => d.label === ds.label)!.trend!.mmPerYear.toFixed(1)} mm/yr)`
-                  : ''),
-                pointStyle: 'circle' as const,
-                fillStyle: ds.borderColor,
-                strokeStyle: ds.borderColor,
-                lineWidth: 2,
-                datasetIndex: index,
-              }));
+  const chartOptions = useMemo(() => {
+    const textColor  = cssVar('--sb-text',   '#dde0f0');
+    const mutedColor = cssVar('--sb-muted',  '#7880a8');
+    const gridColor  = cssVar('--sb-border', '#2c2f4a');
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: { duration: 300 },
+      interaction: { mode: 'index' as const, intersect: false },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'top' as const,
+          labels: {
+            usePointStyle: true,
+            padding: 16,
+            color: textColor,
+            generateLabels: (chart: any) => {
+              if (!chartData?.datasets) return [];
+              return chart.data.datasets
+                .map((ds: any, index: number) => ({ ds, index }))
+                .filter(({ ds }: any) =>
+                  !ds.label.endsWith(' trend') &&
+                  !ds.label.endsWith(' residual') &&
+                  !ds.label.includes(' sample ') &&
+                  !ds.label.endsWith(' median')
+                )
+                .map(({ ds, index }: any) => ({
+                  text: ds.label + (ds.label && chartData.datasets.find(d => d.label === ds.label)?.trend?.mmPerYear !== undefined
+                    ? ` (${chartData.datasets.find(d => d.label === ds.label)!.trend!.mmPerYear.toFixed(1)} mm/yr)`
+                    : ''),
+                  pointStyle: 'circle' as const,
+                  fillStyle: ds.borderColor,
+                  strokeStyle: ds.borderColor,
+                  fontColor: textColor,
+                  lineWidth: 2,
+                  datasetIndex: index,
+                }));
+            },
+          },
+        },
+        tooltip: {
+          callbacks: {
+            title: (context: any) => `${context[0]?.label || ''}`,
+            label: (context: any) => {
+              const dataset = chartData?.datasets?.[context.datasetIndex];
+              if (!dataset) return '';
+              let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
+              if (dataset.trend?.mmPerYear !== undefined && state.showTrends) {
+                label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
+              }
+              return label;
+            },
           },
         },
       },
-      tooltip: {
-        callbacks: {
-          title: (context: any) => `${context[0]?.label || ''}`,
-          label: (context: any) => {
-            const dataset = chartData?.datasets?.[context.datasetIndex];
-            if (!dataset) return '';
-            let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
-            if (dataset.trend?.mmPerYear !== undefined && state.showTrends) {
-              label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
-            }
-            return label;
-          },
+      scales: {
+        x: {
+          type: 'time' as const,
+          time: { displayFormats: { month: 'MMM yyyy', day: 'MMM d', year: 'yyyy' } },
+          title: { display: true, text: 'Date', color: mutedColor },
+          grid: { color: gridColor },
+          ticks: { color: mutedColor },
+        },
+        y: {
+          title: { display: true, text: 'Displacement (m)', color: mutedColor },
+          suggestedMin: state.vmin,
+          suggestedMax: state.vmax,
+          grid: { color: gridColor },
+          ticks: { color: mutedColor },
         },
       },
-    },
-    scales: {
-      x: {
-        type: 'time' as const,
-        time: { displayFormats: { month: 'MMM yyyy', day: 'MMM d', year: 'yyyy' } },
-        title: { display: true, text: 'Date' },
-        grid: { color: 'rgba(255,255,255,0.1)' },
-        ticks: { color: '#aaa' },
-      },
-      y: {
-        title: { display: true, text: 'Displacement (m)' },
-        suggestedMin: state.vmin,
-        suggestedMax: state.vmax,
-        grid: { color: 'rgba(255,255,255,0.1)' },
-        ticks: { color: '#aaa' },
-      },
-    },
-    onClick: handleChartClick,
-  };
+      onClick: handleChartClick,
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [themeVersion, chartData, state.showTrends, state.vmin, state.vmax, handleChartClick]);
 
   if (!state.showChart) return null;
 

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -6,13 +6,29 @@ import { useAppContext } from '../context/AppContext';
 import { useApi } from '../hooks/useApi';
 import { MultiPointTimeSeriesData } from '../types';
 
-// Register Chart.js components
 ChartJS.register(TimeScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+/** Convert "YYYYMMDD_YYYYMMDD" or "YYYYMMDD" → "YYYY-MM-DD" (secondary/only date). */
+function toIsoDate(xVal: string): string {
+  const dateStr = xVal.includes('_') ? xVal.split('_').pop()! : xVal;
+  if (/^\d{8}$/.test(dateStr)) {
+    return `${dateStr.slice(0, 4)}-${dateStr.slice(4, 6)}-${dateStr.slice(6, 8)}`;
+  }
+  return xVal;
+}
+
+interface BufferResult {
+  labels: string[];
+  median: Array<{ x: string; y: number }>;
+  samples: Array<Array<{ x: string; y: number }>>;
+  n_pixels: number;
+}
 
 export default function TimeSeriesChart() {
   const { state, dispatch } = useAppContext();
-  const { fetchMultiPointTimeSeries } = useApi();
+  const { fetchMultiPointTimeSeries, fetchBufferTimeSeries } = useApi();
   const [chartData, setChartData] = useState<MultiPointTimeSeriesData | null>(null);
+  const [bufferData, setBufferData] = useState<{ [pointId: string]: BufferResult }>({});
   const [isLoading, setIsLoading] = useState(false);
 
   const updateChart = useCallback(async () => {
@@ -20,21 +36,15 @@ export default function TimeSeriesChart() {
       setChartData(null);
       return;
     }
-
     setIsLoading(true);
     const currentDatasetInfo = state.datasetInfo[state.currentDataset];
-
-    // Filter visible points
     const visiblePoints = state.timeSeriesPoints.filter(p => p.visible);
-
     if (visiblePoints.length === 0) {
       setChartData(null);
       setIsLoading(false);
       return;
     }
-
     try {
-      // Format points for API
       const apiPoints = visiblePoints.map(point => ({
         id: point.id,
         lat: point.position[0],
@@ -42,27 +52,18 @@ export default function TimeSeriesChart() {
         color: point.color,
         name: point.name,
       }));
-
-      // Fetch multi-point data
       let refLon, refLat;
-      if (currentDatasetInfo?.uses_spatial_ref) {
+      if (currentDatasetInfo?.uses_spatial_ref && state.refEnabled) {
         [refLat, refLon] = state.refMarkerPosition;
       }
-
       const tsData = await fetchMultiPointTimeSeries(
-        apiPoints,
-        state.currentDataset,
-        refLon,
-        refLat,
-        state.showTrends
+        apiPoints, state.currentDataset, refLon, refLat, state.showTrends,
+        state.layerMasks,
+        state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0,
       );
-
       if (tsData) {
         setChartData(tsData);
-
-        // Update trend data in state only if trends are being calculated
         if (state.showTrends && tsData.datasets) {
-          // Use setTimeout to avoid re-render loop during state updates
           setTimeout(() => {
             tsData.datasets.forEach(dataset => {
               if (dataset.trend) {
@@ -92,26 +93,68 @@ export default function TimeSeriesChart() {
   }, [
     state.showChart,
     state.currentDataset,
-    JSON.stringify(state.timeSeriesPoints.map(p => ({ id: p.id, position: p.position, visible: p.visible }))), // Only track relevant point changes
+    JSON.stringify(state.timeSeriesPoints.map(p => ({ id: p.id, position: p.position, visible: p.visible }))),
     state.refMarkerPosition,
+    state.refEnabled,
     state.datasetInfo,
     state.showTrends,
+    state.layerMasks,
     fetchMultiPointTimeSeries,
   ]);
 
+  useEffect(() => { updateChart(); }, [updateChart]);
+
+  // Fetch buffer data for each visible point when buffer mode is enabled
   useEffect(() => {
-    updateChart();
+    if (!state.bufferEnabled || !state.showChart || !state.currentDataset) {
+      setBufferData({});
+      return;
+    }
+    const visiblePoints = state.timeSeriesPoints.filter(p => p.visible);
+    if (visiblePoints.length === 0) { setBufferData({}); return; }
+
+    const currentDatasetInfo = state.datasetInfo[state.currentDataset];
+    let refLon: number | undefined, refLat: number | undefined;
+    if (currentDatasetInfo?.uses_spatial_ref && state.refEnabled) {
+      [refLat, refLon] = state.refMarkerPosition;
+    }
+
+    Promise.all(
+      visiblePoints.map(async p => {
+        const result = await fetchBufferTimeSeries(
+          p.position[1], p.position[0],
+          state.currentDataset,
+          state.bufferRadius,
+          state.bufferSamples,
+          refLon, refLat,
+          state.layerMasks,
+          state.refEnabled && state.refBufferEnabled ? state.refBufferRadius : 0,
+        );
+        return { id: p.id, result };
+      })
+    ).then(results => {
+      const newData: { [id: string]: any } = {};
+      results.forEach(({ id, result }) => { if (result) newData[id] = result; });
+      setBufferData(newData);
+    });
   }, [
-    updateChart,
+    state.bufferEnabled,
+    state.showChart,
+    state.currentDataset,
+    state.bufferRadius,
+    state.bufferSamples,
+    state.refEnabled,
+    state.refBufferEnabled,
+    state.refBufferRadius,
+    state.layerMasks,
+    JSON.stringify(state.timeSeriesPoints.map(p => ({ id: p.id, position: p.position, visible: p.visible }))),
+    state.refMarkerPosition,
+    fetchBufferTimeSeries,
   ]);
 
   const handleChartClick = useCallback((_event: any, elements: InteractionItem[]) => {
     if (elements.length === 0 || !chartData) return;
-
-    const element = elements[0];
-    const dataIndex = element.index;
-
-    // Update the current time index to sync with the clicked point
+    const dataIndex = elements[0].index;
     if (dataIndex !== undefined && dataIndex < chartData.labels.length) {
       dispatch({ type: 'SET_TIME_INDEX', payload: dataIndex });
     }
@@ -119,11 +162,7 @@ export default function TimeSeriesChart() {
 
   const handleExportToCSV = useCallback(() => {
     if (!chartData || !chartData.datasets || chartData.datasets.length === 0) return;
-
-    // Build CSV header
     const headers = ['Time', ...chartData.datasets.map(d => d.label)];
-
-    // Build data rows
     const rows: string[][] = [];
     chartData.labels.forEach((label, idx) => {
       const row = [label];
@@ -133,11 +172,9 @@ export default function TimeSeriesChart() {
       });
       rows.push(row);
     });
-
-    // Add trend information if available
     const trendRows: string[][] = [];
     if (state.showTrends && chartData.datasets.some(d => d.trend)) {
-      trendRows.push(['']); // Empty row separator
+      trendRows.push(['']);
       trendRows.push(['Point', 'Rate (mm/year)', 'R²', 'Slope', 'Intercept']);
       chartData.datasets.forEach(dataset => {
         if (dataset.trend) {
@@ -151,16 +188,10 @@ export default function TimeSeriesChart() {
         }
       });
     }
-
-    // Combine all rows and convert to CSV
-    const allRows = [headers, ...rows, ...trendRows];
-    const csvContent = allRows.map(row => row.join(',')).join('\n');
-
-    // Create and trigger download
+    const csvContent = [headers, ...rows, ...trendRows].map(r => r.join(',')).join('\n');
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
-
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
     link.setAttribute('href', url);
     link.setAttribute('download', `time-series-${state.currentDataset}-${timestamp}.csv`);
@@ -173,49 +204,49 @@ export default function TimeSeriesChart() {
   const chartOptions = {
     responsive: true,
     maintainAspectRatio: false,
-    animation: {
-      duration: 300,
-    },
-    interaction: {
-      mode: 'index' as const,
-      intersect: false,
-    },
+    animation: { duration: 300 },
+    interaction: { mode: 'index' as const, intersect: false },
     plugins: {
       legend: {
         display: true,
         position: 'top' as const,
         labels: {
           usePointStyle: true,
-          padding: 20,
-          generateLabels: (_chart: any) => {
+          padding: 16,
+          color: '#ffffff',
+          generateLabels: (chart: any) => {
             if (!chartData?.datasets) return [];
-
-            return chartData.datasets.map((dataset, index) => ({
-              text: `${dataset.label}${dataset.trend && dataset.trend.mmPerYear !== undefined ? ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)` : ''}`,
-              pointStyle: 'circle' as const,
-              fillStyle: dataset.borderColor,
-              strokeStyle: dataset.borderColor,
-              lineWidth: 2,
-              datasetIndex: index,
-            }));
+            return chart.data.datasets
+              .map((ds: any, index: number) => ({ ds, index }))
+              .filter(({ ds }: any) =>
+                !ds.label.endsWith(' trend') &&
+                !ds.label.endsWith(' residual') &&
+                !ds.label.includes(' sample ') &&
+                !ds.label.endsWith(' median')
+              )
+              .map(({ ds, index }: any) => ({
+                text: ds.label + (ds.label && chartData.datasets.find(d => d.label === ds.label)?.trend?.mmPerYear !== undefined
+                  ? ` (${chartData.datasets.find(d => d.label === ds.label)!.trend!.mmPerYear.toFixed(1)} mm/yr)`
+                  : ''),
+                pointStyle: 'circle' as const,
+                fillStyle: ds.borderColor,
+                strokeStyle: ds.borderColor,
+                lineWidth: 2,
+                datasetIndex: index,
+              }));
           },
         },
       },
       tooltip: {
         callbacks: {
-          title: (context: any) => {
-            return `Time: ${context[0]?.label || ''}`;
-          },
+          title: (context: any) => `${context[0]?.label || ''}`,
           label: (context: any) => {
             const dataset = chartData?.datasets?.[context.datasetIndex];
             if (!dataset) return '';
-
-            let label = `${dataset.label}: ${context.parsed.y.toFixed(3)}`;
-
-            if (dataset.trend && dataset.trend.mmPerYear !== undefined && state.showTrends) {
+            let label = `${dataset.label}: ${context.parsed.y.toFixed(4)} m`;
+            if (dataset.trend?.mmPerYear !== undefined && state.showTrends) {
               label += ` (${dataset.trend.mmPerYear.toFixed(1)} mm/yr)`;
             }
-
             return label;
           },
         },
@@ -224,38 +255,29 @@ export default function TimeSeriesChart() {
     scales: {
       x: {
         type: 'time' as const,
-        time: {
-          displayFormats: {
-            month: 'MMM yyyy',
-            year: 'yyyy',
-          },
-        },
-        title: {
-          display: true,
-          text: 'Time',
-        },
+        time: { displayFormats: { month: 'MMM yyyy', day: 'MMM d', year: 'yyyy' } },
+        title: { display: true, text: 'Date' },
+        grid: { color: 'rgba(255,255,255,0.1)' },
+        ticks: { color: '#aaa' },
       },
       y: {
-        title: {
-          display: true,
-          text: 'Displacement (m)',
-        },
+        title: { display: true, text: 'Displacement (m)' },
         suggestedMin: state.vmin,
         suggestedMax: state.vmax,
+        grid: { color: 'rgba(255,255,255,0.1)' },
+        ticks: { color: '#aaa' },
       },
     },
     onClick: handleChartClick,
   };
 
-  if (!state.showChart) {
-    return null;
-  }
+  if (!state.showChart) return null;
 
   if (state.timeSeriesPoints.length === 0) {
     return (
       <div id="chart-container">
         <div className="chart-placeholder">
-          <p>No time series points selected.</p>
+          <p>No points selected.</p>
           <p><small>Click on the map to add points.</small></p>
         </div>
       </div>
@@ -265,9 +287,7 @@ export default function TimeSeriesChart() {
   if (isLoading) {
     return (
       <div id="chart-container">
-        <div className="chart-placeholder">
-          <p>Loading time series data...</p>
-        </div>
+        <div className="chart-placeholder"><p>Loading…</p></div>
       </div>
     );
   }
@@ -275,49 +295,141 @@ export default function TimeSeriesChart() {
   if (!chartData || !chartData.datasets || chartData.datasets.length === 0) {
     return (
       <div id="chart-container">
-        <div className="chart-placeholder">
-          <p>No data available for selected points.</p>
-        </div>
+        <div className="chart-placeholder"><p>No data for selected points.</p></div>
       </div>
     );
   }
 
-  // Format data for Chart.js
-  const formattedChartData = {
-    labels: chartData.labels,
-    datasets: chartData.datasets.map(dataset => ({
+  // Transform x-values to ISO dates so Chart.js time scale can parse them
+  const isoLabels = chartData.labels.map(toIsoDate);
+
+  // Convert ISO date string to days since first label (matches backend regression basis)
+  const day0 = isoLabels.length > 0 ? new Date(isoLabels[0]).getTime() / 86400000 : 0;
+  const isoToDay = (iso: string) => new Date(iso).getTime() / 86400000 - day0;
+
+  const datasetList: any[] = [];
+  chartData.datasets.forEach(dataset => {
+    const isoData = dataset.data.map(pt => ({ x: toIsoDate(pt.x as string), y: pt.y }));
+    datasetList.push({
       label: dataset.label,
-      data: dataset.data,
+      data: isoData,
       borderColor: dataset.borderColor,
       backgroundColor: dataset.backgroundColor,
       borderWidth: 2,
-      pointRadius: 3,
-      pointHoverRadius: 5,
+      pointRadius: 4,
+      pointHoverRadius: 6,
       tension: 0.1,
       fill: false,
-    })),
-  };
+    });
+
+    // Add dashed trend line if trends are enabled and data exists
+    if (state.showTrends && dataset.trend && isoData.length > 1) {
+      const { slope, intercept } = dataset.trend;
+      const trendData = isoData.map(pt => ({
+        x: pt.x,
+        y: slope * isoToDay(pt.x) + intercept,
+      }));
+      datasetList.push({
+        label: `${dataset.label} trend`,
+        data: trendData,
+        borderColor: dataset.borderColor,
+        backgroundColor: 'transparent',
+        borderWidth: 1.5,
+        borderDash: [6, 4],
+        pointRadius: 0,
+        pointHoverRadius: 0,
+        tension: 0,
+        fill: false,
+      });
+
+      // Residuals: actual - trend
+      if (state.showResiduals) {
+        const residualData = isoData.map(pt => ({
+          x: pt.x,
+          y: pt.y - (slope * isoToDay(pt.x) + intercept),
+        }));
+        datasetList.push({
+          label: `${dataset.label} residual`,
+          data: residualData,
+          borderColor: dataset.borderColor,
+          backgroundColor: dataset.backgroundColor,
+          borderWidth: 1,
+          borderDash: [2, 3],
+          pointRadius: 2,
+          pointHoverRadius: 4,
+          tension: 0,
+          fill: false,
+          borderDashOffset: 0,
+        });
+      }
+    }
+  });
+
+  // Append buffer sample + median datasets (thin lines behind points)
+  if (state.bufferEnabled) {
+    chartData.datasets.forEach(dataset => {
+      const buf = bufferData[dataset.pointId];
+      if (!buf) return;
+      const color = dataset.borderColor;
+
+      // Sample lines — thin, semi-transparent, no points, not in legend
+      buf.samples.forEach((sample: Array<{ x: string; y: number }>, i: number) => {
+        datasetList.push({
+          label: `${dataset.label} sample ${i}`,
+          data: sample.map(pt => ({ x: toIsoDate(pt.x), y: pt.y })),
+          borderColor: color + '28',
+          backgroundColor: 'transparent',
+          borderWidth: 1,
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          tension: 0.1,
+          fill: false,
+        });
+      });
+
+      // Median line — same color, thick, dashed, no points
+      datasetList.push({
+        label: `${dataset.label} median`,
+        data: buf.median.map((pt: { x: string; y: number }) => ({ x: toIsoDate(pt.x), y: pt.y })),
+        borderColor: color,
+        backgroundColor: 'transparent',
+        borderWidth: 3,
+        borderDash: [4, 3],
+        pointRadius: 0,
+        pointHoverRadius: 0,
+        tension: 0.1,
+        fill: false,
+      });
+    });
+  }
+
+  const formattedChartData = { labels: isoLabels, datasets: datasetList };
 
   return (
     <div id="chart-container">
       <div className="chart-header">
-        <h4>Time Series Analysis</h4>
+        <h4>Time Series</h4>
         <div className="chart-controls">
           <button
-            className="pure-button"
+            className="chart-btn"
             onClick={() => dispatch({ type: 'TOGGLE_TRENDS' })}
             title="Toggle trend analysis"
           >
             <i className={`fa-solid ${state.showTrends ? 'fa-chart-line' : 'fa-chart-simple'}`}></i>
             {state.showTrends ? 'Hide' : 'Show'} Trends
           </button>
-          <button
-            className="pure-button"
-            onClick={handleExportToCSV}
-            title="Export data to CSV"
-          >
-            <i className="fa-solid fa-download"></i>
-            Export CSV
+          {state.showTrends && (
+            <button
+              className="chart-btn"
+              onClick={() => dispatch({ type: 'TOGGLE_RESIDUALS' })}
+              title="Show residuals (data minus trend)"
+            >
+              <i className={`fa-solid ${state.showResiduals ? 'fa-wave-square' : 'fa-chart-scatter'}`}></i>
+              {state.showResiduals ? 'Hide' : 'Show'} Residuals
+            </button>
+          )}
+          <button className="chart-btn" onClick={handleExportToCSV} title="Export data to CSV">
+            <i className="fa-solid fa-download"></i> CSV
           </button>
         </div>
       </div>
@@ -325,7 +437,12 @@ export default function TimeSeriesChart() {
         <Line data={formattedChartData} options={chartOptions} />
       </div>
       <div className="chart-help">
-        <small>Click on chart points to sync map time • Trends show mm/year rates</small>
+        <small>
+          Click chart points to sync map time
+          {state.bufferEnabled && Object.keys(bufferData).length > 0 && (
+            <> · Buffer: {Object.values(bufferData).map((b: any) => b.n_pixels).join(', ')} px</>
+          )}
+        </small>
       </div>
     </div>
   );

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -40,11 +40,13 @@ const initialState: AppState = {
   bufferEnabled: false,
   bufferRadius: 500,
   bufferSamples: 10,
-  pickingEnabled: true,
+  pickingEnabled: false,
   refEnabled: true,
   refBufferEnabled: false,
   refBufferRadius: 500,
   showRefChart: false,
+  isPlaying: false,
+  animationSpeed: 500,
 };
 
 function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppState {
@@ -215,6 +217,12 @@ function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppSt
       return { ...state, refBufferRadius: action.payload };
     case 'TOGGLE_REF_CHART':
       return { ...state, showRefChart: !state.showRefChart };
+    case 'TOGGLE_PLAYING':
+      return { ...state, isPlaying: !state.isPlaying };
+    case 'SET_PLAYING':
+      return { ...state, isPlaying: action.payload };
+    case 'SET_ANIMATION_SPEED':
+      return { ...state, animationSpeed: action.payload };
     case 'TOGGLE_CHART':
       return { ...state, showChart: !state.showChart };
     default:

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -42,7 +42,6 @@ const initialState: AppState = {
   bufferSamples: 10,
   pickingEnabled: true,
   refEnabled: true,
-  showProfile: false,
   refBufferEnabled: false,
   refBufferRadius: 500,
   showRefChart: false,
@@ -210,8 +209,6 @@ function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppSt
       return { ...state, pickingEnabled: !state.pickingEnabled };
     case 'TOGGLE_REF_ENABLED':
       return { ...state, refEnabled: !state.refEnabled };
-    case 'TOGGLE_PROFILE':
-      return { ...state, showProfile: !state.showProfile };
     case 'TOGGLE_REF_BUFFER':
       return { ...state, refBufferEnabled: !state.refBufferEnabled };
     case 'SET_REF_BUFFER_RADIUS':

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, ReactNode } from 'react';
-import { AppState, AppAction, LegacyAppAction, TimeSeriesPoint } from '../types';
+import { AppState, AppAction, LegacyAppAction, TimeSeriesPoint, ChartWindow } from '../types';
 
 // Color palette for different points
 const POINT_COLORS = [
@@ -32,6 +32,7 @@ const initialState: AppState = {
   vmax: 1,
   opacity: 1,
   showChart: false,
+  chartWindows: [],
   selectedPointId: null,
   showTrends: false,
   showResiduals: false,
@@ -47,6 +48,11 @@ const initialState: AppState = {
   showRefChart: false,
   isPlaying: false,
   animationSpeed: 500,
+  markerSize: 4,
+  dateRangeStart: null,
+  dateRangeEnd: null,
+  viewBounds: null,
+  showColorbar: false,
 };
 
 function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppState {
@@ -223,8 +229,36 @@ function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppSt
       return { ...state, isPlaying: action.payload };
     case 'SET_ANIMATION_SPEED':
       return { ...state, animationSpeed: action.payload };
-    case 'TOGGLE_CHART':
-      return { ...state, showChart: !state.showChart };
+    case 'SET_MARKER_SIZE':
+      return { ...state, markerSize: action.payload };
+    case 'SET_DATE_RANGE_START':
+      return { ...state, dateRangeStart: action.payload };
+    case 'SET_DATE_RANGE_END':
+      return { ...state, dateRangeEnd: action.payload };
+    case 'SET_VIEW_BOUNDS':
+      return { ...state, viewBounds: action.payload };
+    case 'TOGGLE_COLORBAR':
+      return { ...state, showColorbar: !state.showColorbar };
+    case 'ADD_CHART_WINDOW':
+      return { ...state, chartWindows: [...state.chartWindows, action.payload] };
+    case 'REMOVE_CHART_WINDOW':
+      return { ...state, chartWindows: state.chartWindows.filter(w => w.id !== action.payload) };
+    case 'SET_CHART_WINDOW_DS':
+      return {
+        ...state,
+        chartWindows: state.chartWindows.map(w =>
+          w.id === action.payload.id ? { ...w, dsNames: action.payload.dsNames } : w
+        ),
+      };
+    case 'TOGGLE_CHART': {
+      const opening = !state.showChart;
+      const firstWindow: ChartWindow = { id: `chart_${Date.now()}`, dsNames: [] };
+      return {
+        ...state,
+        showChart: opening,
+        chartWindows: opening && state.chartWindows.length === 0 ? [firstWindow] : state.chartWindows,
+      };
+    }
     default:
       return state;
   }

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -13,6 +13,11 @@ export function useApi() {
     return data.mode;
   }, []);
 
+  const fetchConfig = useCallback(async (): Promise<{ title: string }> => {
+    const response = await fetch('/config');
+    return await response.json();
+  }, []);
+
   const fetchPointTimeSeries = useCallback(async (lon: number, lat: number, datasetName: string) => {
     const params = new URLSearchParams({
       dataset_name: datasetName,
@@ -167,6 +172,7 @@ export function useApi() {
   return {
     fetchDatasets,
     fetchDataMode,
+    fetchConfig,
     fetchPointTimeSeries,
     fetchChartTimeSeries,
     fetchMultiPointTimeSeries,

--- a/src/hooks/useDraggableResizable.tsx
+++ b/src/hooks/useDraggableResizable.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface Options {
+  defaultWidth: number;
+  defaultHeight: number;
+  /** Offset from right edge for initial placement (default 20) */
+  initialRight?: number;
+  /** Offset from bottom edge for initial placement (default 20) */
+  initialBottom?: number;
+  minWidth?: number;
+  minHeight?: number;
+}
+
+export function useDraggableResizable({ defaultWidth, defaultHeight, initialRight = 20, initialBottom = 20, minWidth = 320, minHeight = 180 }: Options) {
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const [size, setSize] = useState({ width: defaultWidth, height: defaultHeight });
+  const panelRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef<{ startX: number; startY: number; startLeft: number; startTop: number } | null>(null);
+  const resizeState = useRef<{ startX: number; startY: number; startW: number; startH: number } | null>(null);
+
+  // Initialise to bottom-right on first render
+  useEffect(() => {
+    setPos(p => p ?? {
+      left: window.innerWidth  - defaultWidth  - initialRight,
+      top:  window.innerHeight - defaultHeight - initialBottom,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onDragMouseDown = (e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('button, input, select')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const cur = pos ?? { left: window.innerWidth - defaultWidth - initialRight, top: window.innerHeight - defaultHeight - initialBottom };
+    dragState.current = { startX: e.clientX, startY: e.clientY, startLeft: cur.left, startTop: cur.top };
+    const onMove = (me: MouseEvent) => {
+      if (!dragState.current) return;
+      setPos({
+        left: Math.max(0, Math.min(window.innerWidth  - size.width,  dragState.current.startLeft + me.clientX - dragState.current.startX)),
+        top:  Math.max(0, Math.min(window.innerHeight - 60,           dragState.current.startTop  + me.clientY - dragState.current.startY)),
+      });
+    };
+    const onUp = () => { dragState.current = null; window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const onResizeMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizeState.current = { startX: e.clientX, startY: e.clientY, startW: size.width, startH: size.height };
+    const onMove = (me: MouseEvent) => {
+      if (!resizeState.current) return;
+      setSize({
+        width:  Math.max(minWidth,  resizeState.current.startW + me.clientX - resizeState.current.startX),
+        height: Math.max(minHeight, resizeState.current.startH + me.clientY - resizeState.current.startY),
+      });
+    };
+    const onUp = () => { resizeState.current = null; window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
+
+  const resolvedPos = pos ?? { left: window.innerWidth - defaultWidth - initialRight, top: window.innerHeight - defaultHeight - initialBottom };
+  const panelStyle: React.CSSProperties = {
+    left: resolvedPos.left, top: resolvedPos.top,
+    width: size.width, height: size.height,
+    bottom: 'auto', right: 'auto', transform: 'none',
+  };
+
+  const resizeGrip = (
+    <div
+      onMouseDown={onResizeMouseDown}
+      style={{
+        position: 'absolute', right: 0, bottom: 0, width: 18, height: 18,
+        cursor: 'nwse-resize', zIndex: 10, display: 'flex',
+        alignItems: 'flex-end', justifyContent: 'flex-end',
+        padding: 3, color: 'var(--sb-muted)', fontSize: 11, userSelect: 'none',
+      }}
+      title="Resize"
+    >⤡</div>
+  );
+
+  return { panelRef, panelStyle, size, onDragMouseDown, resizeGrip };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -24,6 +24,45 @@
   background-color: var(--sb-bg);
 }
 
+/* ── Theme toggle button ───────────────────────────────────── */
+.sidebar-theme-toggle {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 10px 0;
+}
+
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  color: var(--sb-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 0.85em;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.theme-toggle-btn:hover {
+  color: var(--sb-text);
+  border-color: var(--sb-accent);
+}
+
+/* ── Light theme ───────────────────────────────────────────── */
+[data-theme="light"] {
+  --sb-bg:        #f0f2f8;
+  --sb-surface:   #ffffff;
+  --sb-surface2:  #e4e7f0;
+  --sb-border:    #c8cce0;
+  --sb-text:      #1a1d2e;
+  --sb-muted:     #6068a0;
+  --sb-accent:    #2478c8;
+  --sb-accent2:   #1a5fa0;
+  --sb-green:     #1e8f50;
+  --sb-red:       #c0303e;
+  color: var(--sb-text);
+  background-color: var(--sb-bg);
+}
+
 a { font-weight: 500; color: var(--sb-accent); text-decoration: none; }
 a:hover { color: var(--sb-accent2); }
 
@@ -374,11 +413,11 @@ img.huechange { filter: hue-rotate(120deg); }
   bottom: 20px;
   right: 20px;
   padding: 14px;
-  background: rgba(19, 21, 31, 0.95);
+  background: var(--sb-surface);
   backdrop-filter: blur(8px);
   z-index: 3000;
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   border: 1px solid var(--sb-border);
   display: flex;
   flex-direction: column;
@@ -455,12 +494,13 @@ img.huechange { filter: hue-rotate(120deg); }
 
 /* ── Mouse position control ─────────────────────────────────── */
 .leaflet-control-mouseposition {
-  background-color: rgba(19, 21, 31, 0.8);
-  box-shadow: 0 0 5px rgba(0,0,0,0.4);
+  background-color: var(--sb-surface);
+  box-shadow: 0 0 5px rgba(0,0,0,0.3);
   padding: 2px 6px;
   color: var(--sb-text);
   font: 11px/1.5 "Inter", "Helvetica Neue", Arial, sans-serif;
   border-radius: 4px;
+  border: 1px solid var(--sb-border);
 }
 
 /* ── Point Manager Panel ────────────────────────────────────── */
@@ -689,14 +729,37 @@ img.huechange { filter: hue-rotate(120deg); }
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  width: 500px;
-  max-width: 90vw;
-  background: rgba(19, 21, 31, 0.95);
+  width: 540px;
+  max-width: 92vw;
+  background: var(--sb-surface);
   border: 1px solid var(--sb-border);
   border-radius: 12px;
   padding: 12px 14px;
   z-index: 3500;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   backdrop-filter: blur(8px);
   color: var(--sb-text);
+}
+
+.profile-radius-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 4px;
+}
+
+.profile-radius-input {
+  width: 70px;
+  background: var(--sb-surface2);
+  border: 1px solid var(--sb-border);
+  border-radius: 5px;
+  color: var(--sb-text);
+  font-size: 0.8em;
+  padding: 2px 5px;
+  text-align: right;
+}
+
+.profile-radius-input:focus {
+  outline: none;
+  border-color: var(--sb-accent);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -414,13 +414,9 @@ img.huechange { filter: hue-rotate(120deg); }
 
 /* ── Time Series Chart ──────────────────────────────────────── */
 #chart-container {
-  width: 38vw;
-  max-width: 560px;
-  min-width: 320px;
-  height: 420px;
   position: fixed;
-  bottom: 20px;
-  right: 20px;
+  min-width: 320px;
+  min-height: 260px;
   padding: 14px;
   background: var(--sb-surface);
   backdrop-filter: blur(8px);
@@ -431,6 +427,7 @@ img.huechange { filter: hue-rotate(120deg); }
   display: flex;
   flex-direction: column;
   color: var(--sb-text);
+  user-select: none;
 }
 
 .chart-header {
@@ -473,6 +470,40 @@ img.huechange { filter: hue-rotate(120deg); }
   background: var(--sb-accent);
   color: white;
   border-color: var(--sb-accent);
+}
+
+.chart-sliders {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--sb-border);
+}
+
+.chart-slider-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78em;
+  color: var(--sb-muted);
+}
+
+.chart-slider-label input[type="range"] {
+  width: 80px;
+  accent-color: var(--sb-accent);
+  cursor: pointer;
+}
+
+.chart-slider-label input[type="date"] {
+  background: var(--sb-surface2);
+  color: var(--sb-text);
+  border: 1px solid var(--sb-border);
+  border-radius: 4px;
+  padding: 2px 5px;
+  font-size: 0.85em;
+  cursor: pointer;
 }
 
 .chart-content {
@@ -776,15 +807,15 @@ img.huechange { filter: hue-rotate(120deg); }
 /* ── Profile panel ──────────────────────────────────────────── */
 .profile-panel {
   position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 540px;
-  max-width: 92vw;
+  min-width: 320px;
+  min-height: 160px;
+  user-select: none;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 14px;
   background: var(--sb-surface);
   border: 1px solid var(--sb-border);
   border-radius: 12px;
-  padding: 12px 14px;
   z-index: 3500;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
   backdrop-filter: blur(8px);

--- a/src/style.css
+++ b/src/style.css
@@ -25,6 +25,15 @@
 }
 
 /* ── Theme toggle button ───────────────────────────────────── */
+.sidebar-title {
+  padding: 8px 12px 4px;
+  font-size: 0.95em;
+  font-weight: 600;
+  color: var(--sb-text);
+  text-align: center;
+  word-break: break-word;
+}
+
 .sidebar-theme-toggle {
   display: flex;
   justify-content: flex-end;
@@ -490,6 +499,47 @@ img.huechange { filter: hue-rotate(120deg); }
   color: var(--sb-muted);
   text-align: center;
   font-size: 0.75em;
+}
+
+/* ── Animation controls (chart bottom + sidebar) ─────────────── */
+.chart-animation-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--sb-border);
+  flex-wrap: wrap;
+}
+
+.chart-anim-speed {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 120px;
+  font-size: 0.78em;
+  color: var(--sb-muted);
+}
+
+.chart-anim-speed input[type="range"] {
+  flex: 1;
+}
+
+.chart-anim-speed span:last-child {
+  min-width: 28px;
+  text-align: right;
+  color: var(--sb-text);
+}
+
+.anim-controls {
+  margin-top: 6px;
+}
+
+.anim-play-btn {
+  width: 100%;
+  justify-content: center;
+  margin-bottom: 2px;
 }
 
 /* ── Mouse position control ─────────────────────────────────── */

--- a/src/style.css
+++ b/src/style.css
@@ -95,6 +95,42 @@ body {
   grid-template-columns: 22em auto;
   height: 100vh;
   width: 100vw;
+  transition: grid-template-columns 0.2s ease;
+}
+
+.app-container.sidebar-hidden {
+  grid-template-columns: 0 auto;
+}
+
+.app-container.sidebar-hidden #menu {
+  overflow: hidden;
+  border-right: none;
+}
+
+.sidebar-toggle-btn {
+  position: absolute;
+  top: 50%;
+  left: 8px;
+  transform: translateY(-50%);
+  z-index: 1100;
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border);
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--sb-text);
+  font-size: 0.75em;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  padding: 0;
+  transition: left 0.2s ease;
+}
+
+.sidebar-toggle-btn:hover {
+  background: var(--sb-surface2);
 }
 
 /* ── Sidebar ────────────────────────────────────────────────── */

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,4 @@
+/* ── Design tokens ─────────────────────────────────────────── */
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -6,31 +7,25 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  --color-dark: rgb(0, 0, 8);
-  --background-light: #e0dbdb;
-  --border-dark: #2e1111;
-  --border-mid: #464141;
-  --link-color: #646cff;
-  --link-hover-color: #53f2ed;
 
-  color: var(--color-dark);
-  background-color: var(--background-light);
+  /* Sidebar palette */
+  --sb-bg:        #13151f;
+  --sb-surface:   #1c1f2e;
+  --sb-surface2:  #242840;
+  --sb-border:    #2c2f4a;
+  --sb-text:      #dde0f0;
+  --sb-muted:     #7880a8;
+  --sb-accent:    #4d9de0;
+  --sb-accent2:   #6aaee8;
+  --sb-green:     #3ec97a;
+  --sb-red:       #e05d6a;
+
+  color: var(--sb-text);
+  background-color: var(--sb-bg);
 }
 
-a {
-  font-weight: 500;
-  color: var(--link-color);
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: var(--link-hover-color);
-}
-
-h1 {
-  font-size: 2.2em;
-  line-height: 1.1;
-}
+a { font-weight: 500; color: var(--sb-accent); text-decoration: none; }
+a:hover { color: var(--sb-accent2); }
 
 body {
   margin: 0;
@@ -45,59 +40,316 @@ body {
   width: 100vw;
 }
 
+/* ── Layout ─────────────────────────────────────────────────── */
 .app-container {
   display: grid;
   grid-template-areas: "menu map";
-  grid-template-columns: 20em auto;
+  grid-template-columns: 22em auto;
   height: 100vh;
   width: 100vw;
 }
 
-
+/* ── Sidebar ────────────────────────────────────────────────── */
 #menu {
   grid-area: menu;
-  border: 1px solid var(--border-dark);
+  background: var(--sb-bg);
+  border-right: 1px solid var(--sb-border);
   display: flex;
   flex-direction: column;
-  margin: 1em;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--sb-border) transparent;
 }
 
-
-.menu-group {
+.sidebar-section {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--sb-border);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
+  gap: 8px;
 }
 
-
-#menu-content .menu-group>div,
-#menu-content .select-container {
-  /* This ensures that the divs inside the menu group take full width */
-  width: 100%;
-  /* Space out between menu items a little */
-  margin-bottom: 1em;
+.sidebar-section-label {
+  font-size: 0.68em;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--sb-muted);
+  margin-bottom: 2px;
 }
 
-#menu-content select,
-#menu-content input[type="range"],
-#menu-content input[type="text"] {
+.sidebar-section-label i {
+  margin-right: 5px;
+  opacity: 0.8;
+}
+
+/* ── Form controls ──────────────────────────────────────────── */
+.sidebar-select {
   width: 100%;
-  /* This makes sure that all form elements take up the full width available */
+  background: var(--sb-surface2);
+  color: var(--sb-text);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.85em;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%237880a8' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+  transition: border-color 0.15s;
+}
+
+.sidebar-select:hover,
+.sidebar-select:focus {
+  border-color: var(--sb-accent);
+  outline: none;
+}
+
+.sidebar-input {
+  width: 100%;
   box-sizing: border-box;
-  /* This ensures padding and borders are included in the width */
+  background: var(--sb-surface2);
+  color: var(--sb-text);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  font-size: 0.85em;
+  text-align: center;
+  transition: border-color 0.15s;
+}
+
+.sidebar-input:focus {
+  outline: none;
+  border-color: var(--sb-accent);
+}
+
+/* Range slider */
+.sidebar-range {
+  width: 100%;
+  accent-color: var(--sb-accent);
+  cursor: pointer;
+  height: 4px;
+  border-radius: 2px;
+}
+
+.slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.slider-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8em;
+  color: var(--sb-muted);
+}
+
+.slider-value {
+  color: var(--sb-text);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9em;
+  word-break: break-all;
+  max-width: 60%;
+  text-align: right;
+}
+
+/* Min/Max row */
+.minmax-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.minmax-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.minmax-label {
+  font-size: 0.72em;
+  color: var(--sb-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Colormap row with invert button */
+.colormap-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.colormap-row .sidebar-select {
+  flex: 1;
+}
+
+.invert-btn {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  background: var(--sb-surface2);
+  color: var(--sb-muted);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  font-size: 1em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.invert-btn:hover {
+  border-color: var(--sb-accent);
+  color: var(--sb-accent);
+}
+
+.invert-btn.active {
+  background: var(--sb-accent);
+  color: white;
+  border-color: var(--sb-accent);
+}
+
+/* Colorbar */
+.colorbar-img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+}
+
+/* ── Histogram ──────────────────────────────────────────────── */
+.histogram-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.histogram-chart-area {
+  height: 64px;
+  background: var(--sb-surface);
+  border-radius: 6px;
+  overflow: hidden;
+  padding: 2px;
+}
+
+.histogram-range {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72em;
+  color: var(--sb-muted);
+  padding: 0 2px;
+}
+
+.histogram-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.hist-btn {
+  flex: 1;
+  background: var(--sb-surface2);
+  color: var(--sb-accent);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  padding: 5px 6px;
+  font-size: 0.78em;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.hist-btn:hover {
+  background: var(--sb-accent);
+  color: white;
+  border-color: var(--sb-accent);
+}
+
+.histogram-loading {
+  height: 20px;
+  font-size: 0.8em;
+  color: var(--sb-muted);
   text-align: center;
 }
 
-#layer-slider-value {
-  /* Allow text to wrap */
-  /* Break long words if necessary */
-  word-break: break-all;
-  background: rgb(250, 250, 250);
+/* ── Masking section ────────────────────────────────────────── */
+.layer-mask-row {
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
+  background: rgba(255,255,255,0.03);
 }
 
-/* ********** */
-/* Map styles */
+.custom-mask-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.custom-mask-controls {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Toggle pill ────────────────────────────────────────────── */
+.toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toggle-pill {
+  background: var(--sb-surface2);
+  color: var(--sb-muted);
+  border: 1px solid var(--sb-border);
+  border-radius: 12px;
+  padding: 3px 12px;
+  font-size: 0.75em;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  letter-spacing: 0.05em;
+}
+
+.toggle-pill.active {
+  background: var(--sb-accent);
+  color: white;
+  border-color: var(--sb-accent);
+}
+
+/* ── Sidebar footer ─────────────────────────────────────────── */
+.sidebar-footer {
+  padding: 14px 16px;
+  margin-top: auto;
+  border-top: 1px solid var(--sb-border);
+}
+
+.chart-toggle-btn {
+  width: 100%;
+  background: var(--sb-accent);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 9px 14px;
+  font-size: 0.88em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.chart-toggle-btn:hover {
+  background: var(--sb-accent2);
+}
+
+/* ── Map ────────────────────────────────────────────────────── */
 .map-container {
   grid-area: map;
   position: relative;
@@ -110,50 +362,69 @@ body {
   height: 100%;
 }
 
-/* https://stackoverflow.com/questions/23567203/leaflet-changing-marker-color */
-img.huechange {
-  filter: hue-rotate(120deg);
-}
+img.huechange { filter: hue-rotate(120deg); }
 
-/* chart styles */
+/* ── Time Series Chart ──────────────────────────────────────── */
 #chart-container {
-  width: 35vw;
-  max-width: 500px;
-  height: 400px;
-  /* Make the chart fixed to the bottom right corner of the screen */
+  width: 38vw;
+  max-width: 560px;
+  min-width: 320px;
+  height: 420px;
   position: fixed;
   bottom: 20px;
   right: 20px;
-  /* But also give it some padding */
-  padding: 1rem;
-  /* Make the chart have a white background */
-  background-color: white;
-  /* Have it on top of the leaflet map but below point manager */
+  padding: 14px;
+  background: rgba(19, 21, 31, 0.95);
+  backdrop-filter: blur(8px);
   z-index: 3000;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--sb-border);
   display: flex;
   flex-direction: column;
+  color: var(--sb-text);
 }
 
 .chart-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid #eee;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--sb-border);
 }
 
 .chart-header h4 {
   margin: 0;
-  font-size: 1.1em;
+  font-size: 0.95em;
   font-weight: 600;
+  color: var(--sb-text);
+  letter-spacing: 0.02em;
 }
 
 .chart-controls {
   display: flex;
-  gap: 8px;
+  gap: 6px;
+}
+
+.chart-btn {
+  background: var(--sb-surface2);
+  color: var(--sb-accent);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 0.78em;
+  cursor: pointer;
+  transition: background 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.chart-btn:hover {
+  background: var(--sb-accent);
+  color: white;
+  border-color: var(--sb-accent);
 }
 
 .chart-content {
@@ -168,28 +439,31 @@ img.huechange {
   justify-content: center;
   align-items: center;
   height: 300px;
-  color: #666;
+  color: var(--sb-muted);
   text-align: center;
+  gap: 6px;
 }
 
 .chart-help {
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid #eee;
-  color: #666;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--sb-border);
+  color: var(--sb-muted);
   text-align: center;
+  font-size: 0.75em;
 }
 
+/* ── Mouse position control ─────────────────────────────────── */
 .leaflet-control-mouseposition {
-  background-color: rgba(255, 255, 255, 0.7);
-  box-shadow: 0 0 5px #bbb;
-  padding: 0 5px;
-  margin: 0;
-  color: #333;
-  font: 11px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+  background-color: rgba(19, 21, 31, 0.8);
+  box-shadow: 0 0 5px rgba(0,0,0,0.4);
+  padding: 2px 6px;
+  color: var(--sb-text);
+  font: 11px/1.5 "Inter", "Helvetica Neue", Arial, sans-serif;
+  border-radius: 4px;
 }
 
-/* Point Manager Panel Styles */
+/* ── Point Manager Panel ────────────────────────────────────── */
 .point-manager-toggle {
   position: fixed;
   top: 20px;
@@ -203,14 +477,15 @@ img.huechange {
   right: 20px;
   width: 300px;
   max-height: 60vh;
-  background-color: white;
-  border: 1px solid var(--border-dark);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  background: rgba(255, 255, 255, 0.97);
+  border: 1px solid var(--sb-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   z-index: 4000;
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  color: var(--sb-text);
 }
 
 .point-manager-header {
@@ -218,72 +493,71 @@ img.huechange {
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  background-color: #f5f5f5;
-  border-bottom: 1px solid var(--border-mid);
+  background: var(--sb-surface);
+  border-bottom: 1px solid var(--sb-border);
 }
 
 .point-manager-header h3 {
   margin: 0;
-  font-size: 1em;
+  font-size: 0.9em;
   font-weight: 600;
 }
 
 .point-manager-controls {
-  padding: 12px 16px;
-  border-bottom: 1px solid #eee;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--sb-border);
   display: flex;
-  gap: 8px;
+  gap: 6px;
 }
 
 .point-list {
   flex: 1;
   overflow-y: auto;
   max-height: 400px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--sb-border) transparent;
 }
 
 .no-points {
   padding: 20px;
   text-align: center;
-  color: #666;
+  color: var(--sb-muted);
 }
 
 .point-item {
-  padding: 12px 16px;
-  border-bottom: 1px solid #eee;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--sb-border);
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background 0.15s;
 }
 
-.point-item:hover {
-  background-color: #f8f9fa;
-}
-
+.point-item:hover { background: var(--sb-surface); }
 .point-item.selected {
-  background-color: #e3f2fd;
-  border-left: 4px solid #2196f3;
+  background: rgba(77, 157, 224, 0.12);
+  border-left: 3px solid var(--sb-accent);
 }
 
 .point-item-header {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .point-color-indicator {
-  width: 12px;
-  height: 12px;
+  width: 11px;
+  height: 11px;
   border-radius: 50%;
-  border: 2px solid white;
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+  border: 2px solid rgba(255,255,255,0.3);
   flex-shrink: 0;
 }
 
 .point-name-input {
   border: none;
   background: transparent;
+  color: var(--sb-text);
   font-weight: 500;
-  font-size: 0.9em;
+  font-size: 0.88em;
   padding: 2px 4px;
   border-radius: 3px;
   flex: 1;
@@ -291,22 +565,18 @@ img.huechange {
 
 .point-name-input:focus {
   outline: none;
-  background-color: white;
-  border: 1px solid #ccc;
-}
-
-.point-item-info {
-  margin-bottom: 8px;
+  background: var(--sb-surface2);
+  border: 1px solid var(--sb-border);
 }
 
 .point-coordinates {
-  color: #666;
-  font-size: 0.8em;
+  color: var(--sb-muted);
+  font-size: 0.78em;
 }
 
 .point-trend-info {
-  color: #2196f3;
-  font-size: 0.8em;
+  color: var(--sb-accent);
+  font-size: 0.78em;
   font-weight: 500;
 }
 
@@ -314,44 +584,119 @@ img.huechange {
   display: flex;
   gap: 4px;
   justify-content: flex-end;
+  margin-top: 4px;
 }
 
 .point-item-controls button {
-  padding: 4px 8px;
-  font-size: 0.8em;
-  min-width: auto;
+  padding: 3px 8px;
+  font-size: 0.76em;
+  background: var(--sb-surface2);
+  color: var(--sb-muted);
+  border: 1px solid var(--sb-border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.point-item-controls button:hover {
+  background: var(--sb-surface);
+  color: var(--sb-text);
 }
 
 .point-manager-help {
-  padding: 12px 16px;
-  background-color: #f8f9fa;
-  border-top: 1px solid #eee;
-  color: #666;
-  font-size: 0.8em;
-  line-height: 1.4;
+  padding: 10px 14px;
+  background: var(--sb-surface);
+  border-top: 1px solid var(--sb-border);
+  color: var(--sb-muted);
+  font-size: 0.76em;
+  line-height: 1.5;
 }
 
-/* Custom colored marker styles */
+/* ── Custom marker ──────────────────────────────────────────── */
 .custom-colored-marker {
   background: transparent !important;
   border: none !important;
 }
 
-/* Button utility classes */
-.button-warning {
-  background-color: #ff9800;
+/* ── Utility ────────────────────────────────────────────────── */
+.button-warning { background: var(--sb-green); color: #fff; border: none; border-radius: 5px; }
+.button-error   { background: var(--sb-red);   color: #fff; border: none; border-radius: 5px; }
+
+/* Override Pure CSS defaults for dark theme */
+.pure-button {
+  background: var(--sb-surface2);
+  color: var(--sb-accent);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+}
+
+.pure-button:hover {
+  background: var(--sb-accent);
   color: white;
 }
 
-.button-warning:hover {
-  background-color: #f57c00;
-}
-
-.button-error {
-  background-color: #f44336;
+.pure-button-primary {
+  background: var(--sb-accent);
   color: white;
+  border-color: var(--sb-accent);
 }
 
-.button-error:hover {
-  background-color: #d32f2f;
+.pure-button-primary:hover {
+  background: var(--sb-accent2);
+}
+
+/* ── Map toolbar ────────────────────────────────────────────── */
+.map-toolbar {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2000;
+  display: flex;
+  gap: 6px;
+  background: rgba(19, 21, 31, 0.9);
+  border: 1px solid var(--sb-border);
+  border-radius: 8px;
+  padding: 6px 8px;
+  backdrop-filter: blur(6px);
+}
+
+.map-tool-btn {
+  background: var(--sb-surface2);
+  color: var(--sb-muted);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
+  font-size: 0.9em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+
+.map-tool-btn:hover,
+.map-tool-btn.active {
+  background: var(--sb-accent);
+  color: white;
+  border-color: var(--sb-accent);
+}
+
+/* ── Profile panel ──────────────────────────────────────────── */
+.profile-panel {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 500px;
+  max-width: 90vw;
+  background: rgba(19, 21, 31, 0.95);
+  border: 1px solid var(--sb-border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  z-index: 3500;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  backdrop-filter: blur(8px);
+  color: var(--sb-text);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,6 @@ export interface AppState {
   bufferSamples: number;
   pickingEnabled: boolean;
   refEnabled: boolean;
-  showProfile: boolean;
   refBufferEnabled: boolean;
   refBufferRadius: number;
   showRefChart: boolean;
@@ -110,7 +109,6 @@ export type AppAction =
   | { type: 'SET_BUFFER_SAMPLES'; payload: number }
   | { type: 'TOGGLE_PICKING' }
   | { type: 'TOGGLE_REF_ENABLED' }
-  | { type: 'TOGGLE_PROFILE' }
   | { type: 'TOGGLE_REF_BUFFER' }
   | { type: 'SET_REF_BUFFER_RADIUS'; payload: number }
   | { type: 'TOGGLE_REF_CHART' };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface RasterGroup {
   latlon_bounds: [number, number, number, number];
   x_values: Array<number | string>;
   available_mask_vars: string[];
+  label?: string;
+  unit?: string;
 }
 
 export interface TimeSeriesPoint {
@@ -77,6 +79,8 @@ export interface AppState {
   refBufferEnabled: boolean;
   refBufferRadius: number;
   showRefChart: boolean;
+  isPlaying: boolean;
+  animationSpeed: number;
 }
 
 export type AppAction =
@@ -111,7 +115,10 @@ export type AppAction =
   | { type: 'TOGGLE_REF_ENABLED' }
   | { type: 'TOGGLE_REF_BUFFER' }
   | { type: 'SET_REF_BUFFER_RADIUS'; payload: number }
-  | { type: 'TOGGLE_REF_CHART' };
+  | { type: 'TOGGLE_REF_CHART' }
+  | { type: 'TOGGLE_PLAYING' }
+  | { type: 'SET_PLAYING'; payload: boolean }
+  | { type: 'SET_ANIMATION_SPEED'; payload: number };
 
 // Backward compatibility
 export type LegacyAppAction = { type: 'SET_TS_MARKER_POSITION'; payload: [number, number] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface RasterGroup {
   algorithm: string | null;
   latlon_bounds: [number, number, number, number];
   x_values: Array<number | string>;
+  available_mask_vars: string[];
 }
 
 export interface TimeSeriesPoint {
@@ -42,6 +43,13 @@ export interface BaseMapItem {
   attribution: string;
 }
 
+export interface LayerMask {
+  id: string;
+  dataset: string;
+  threshold: number;
+  mode: 'min' | 'max';  // 'min' = keep pixels >= threshold; 'max' = keep pixels <= threshold
+}
+
 export interface AppState {
   datasetInfo: { [key: string]: RasterGroup };
   timeSeriesPoints: TimeSeriesPoint[];
@@ -58,6 +66,18 @@ export interface AppState {
   showChart: boolean;
   selectedPointId: string | null;
   showTrends: boolean;
+  showResiduals: boolean;
+  layerMasks: LayerMask[];
+  customMaskPath: string | null;
+  bufferEnabled: boolean;
+  bufferRadius: number;
+  bufferSamples: number;
+  pickingEnabled: boolean;
+  refEnabled: boolean;
+  showProfile: boolean;
+  refBufferEnabled: boolean;
+  refBufferRadius: number;
+  showRefChart: boolean;
 }
 
 export type AppAction =
@@ -79,7 +99,21 @@ export type AppAction =
   | { type: 'SET_OPACITY'; payload: number }
   | { type: 'TOGGLE_CHART' }
   | { type: 'SET_SELECTED_POINT'; payload: string | null }
-  | { type: 'TOGGLE_TRENDS' };
+  | { type: 'TOGGLE_TRENDS' }
+  | { type: 'TOGGLE_RESIDUALS' }
+  | { type: 'ADD_LAYER_MASK'; payload: LayerMask }
+  | { type: 'REMOVE_LAYER_MASK'; payload: string }
+  | { type: 'UPDATE_LAYER_MASK'; payload: { id: string; updates: Partial<LayerMask> } }
+  | { type: 'SET_CUSTOM_MASK_PATH'; payload: string | null }
+  | { type: 'TOGGLE_BUFFER' }
+  | { type: 'SET_BUFFER_RADIUS'; payload: number }
+  | { type: 'SET_BUFFER_SAMPLES'; payload: number }
+  | { type: 'TOGGLE_PICKING' }
+  | { type: 'TOGGLE_REF_ENABLED' }
+  | { type: 'TOGGLE_PROFILE' }
+  | { type: 'TOGGLE_REF_BUFFER' }
+  | { type: 'SET_REF_BUFFER_RADIUS'; payload: number }
+  | { type: 'TOGGLE_REF_CHART' };
 
 // Backward compatibility
 export type LegacyAppAction = { type: 'SET_TS_MARKER_POSITION'; payload: [number, number] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,9 +52,15 @@ export interface LayerMask {
   mode: 'min' | 'max';  // 'min' = keep pixels >= threshold; 'max' = keep pixels <= threshold
 }
 
+export interface ChartWindow {
+  id: string;
+  dsNames: string[];  // datasets shown in this window; empty = follow currentDataset
+}
+
 export interface AppState {
   datasetInfo: { [key: string]: RasterGroup };
   timeSeriesPoints: TimeSeriesPoint[];
+  chartWindows: ChartWindow[];
   refMarkerPosition: [number, number];
   currentDataset: string;
   currentTimeIndex: number;
@@ -81,6 +87,11 @@ export interface AppState {
   showRefChart: boolean;
   isPlaying: boolean;
   animationSpeed: number;
+  markerSize: number;
+  dateRangeStart: string | null;
+  dateRangeEnd: string | null;
+  viewBounds: [number, number, number, number] | null; // [south, west, north, east]
+  showColorbar: boolean;
 }
 
 export type AppAction =
@@ -118,7 +129,15 @@ export type AppAction =
   | { type: 'TOGGLE_REF_CHART' }
   | { type: 'TOGGLE_PLAYING' }
   | { type: 'SET_PLAYING'; payload: boolean }
-  | { type: 'SET_ANIMATION_SPEED'; payload: number };
+  | { type: 'SET_ANIMATION_SPEED'; payload: number }
+  | { type: 'SET_MARKER_SIZE'; payload: number }
+  | { type: 'SET_DATE_RANGE_START'; payload: string | null }
+  | { type: 'SET_DATE_RANGE_END'; payload: string | null }
+  | { type: 'SET_VIEW_BOUNDS'; payload: [number, number, number, number] | null }
+  | { type: 'TOGGLE_COLORBAR' }
+  | { type: 'ADD_CHART_WINDOW'; payload: ChartWindow }
+  | { type: 'REMOVE_CHART_WINDOW'; payload: string }
+  | { type: 'SET_CHART_WINDOW_DS'; payload: { id: string; dsNames: string[] } };
 
 // Backward compatibility
 export type LegacyAppAction = { type: 'SET_TS_MARKER_POSITION'; payload: [number, number] };

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -68,13 +69,17 @@ def test_bowser_cli_run_command(tmp_path):
     proc = subprocess.Popen(
         ["bowser", "run", "-f", str(config_file), "--port", "8999"],
         cwd=Path(__file__).parent.parent,
+        start_new_session=True,  # put in its own process group
     )
 
     # Give it a moment to start up
     time.sleep(2)
 
-    # Kill the process (SIGKILL — SIGTERM alone may not exit within timeout on Linux)
-    proc.kill()
+    # Kill the entire process group (handles uvicorn worker children too)
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
     proc.wait(timeout=10)
 
     # Check it didn't crash immediately (returncode from kill is -9, not 1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -73,9 +73,9 @@ def test_bowser_cli_run_command(tmp_path):
     # Give it a moment to start up
     time.sleep(2)
 
-    # Kill the process
-    proc.terminate()
-    proc.wait(timeout=5)
+    # Kill the process (SIGKILL — SIGTERM alone may not exit within timeout on Linux)
+    proc.kill()
+    proc.wait(timeout=10)
 
-    # Check it didn't crash immediately
+    # Check it didn't crash immediately (returncode from kill is -9, not 1)
     assert proc.returncode != 1, "Server crashed on startup"


### PR DESCRIPTION
## Summary

### New map tools
- **MeasureTool**: click-to-measure polyline with cumulative distance display
- **ProfileTool**: draw a line on the map, extract raster values along it; draggable vertices; radius (m) input samples a buffer — chart shows bold median + faint random sample lines; orange corridor polygon drawn on map
- **RefPointChart**: floating chart of all pixels within the reference-point buffer (median + random samples ± 1σ fill)
- **Histogram**: value-distribution for the current time step with p2/p98 and p16/p84 markers; ±0 centering button

### Sidebar / UI additions
- Point-picking, re-referencing, and reference-buffer ON/OFF toggles
- **Reference Buffer**: radius slider; median within buffer used for tile shift and time-series re-referencing
- **Layer masking**: flexible multi-mask UI — pick any loaded dataset, choose ≥ or ≤ mode, set threshold in real data units (p2–p98 range fetched from `/dataset_range`); replaces fixed coherence/similarity/residual sliders
- **Dark/light theme toggle**: all chart colours, panel backgrounds, and mouse-position control use CSS custom properties; `useThemeVersion()` MutationObserver hook rebuilds Chart.js options on switch
- Colormap persistence per dataset in localStorage
- Radius circles: dashed `L.circle` rings around TS points and reference marker when buffer is active

### Backend
- `/profile`: new `radius` / `n_random` params; returns `{centre, median, samples}` for buffer mode
- `/dataset_range/{dataset_name}`: min/max/p2/p98 for mask threshold UI
- Generic `layer_masks` list replaces fixed masking params across tile and time-series endpoints; thresholds are absolute data-unit values
- Per-variable data-range cache to avoid repeated nanmin/nanmax on every tile request
- Reference buffer median re-referencing in both MD and COG modes
- `readers.py`: patch rasterio `dtype_fwd` for GDAL 3.12 Float16 (type code 15) at import time
- `utils.py`: register cfastie/rplumbo/schwarzwald `_r` reversed variants into `rio_tiler.cmap.data` **before** titiler imports — fixes 422 when invert toggle is active

### prepare-disp-s1 CLI
- **S3 path fix**: `Path.resolve()` on `s3://` mangled the double-slash so `/vsis3/` mapping never matched; S3 inputs now mapped directly without `resolve()` — **TODO: verify with a real S3 file that AWS env vars (`AWS_PROFILE`, `AWS_DEFAULT_REGION`) are set**
- Force `Float32` in `gdal.Translate` — Float64 VRTs break PNG tile rendering in titiler
- Inline `gdal.BuildOverviews()` replacing removed `add_overviews()` helper
- VRT glob results use `.resolve()` for absolute paths (portable across working dirs)
- CLI accepts directories as input and globs `*.nc` inside them
- New `prepare-amplitude` command: SLC complex GeoTIFF → 20·log10(|z|) Cloud-Optimised GeoTIFF

## Test plan
- [x] Toggle dark/light theme — chart axes, legend labels, panel backgrounds all switch
- [x] Draw a profile line, set radius > 0 — corridor polygon on map, median + sample lines in chart
- [x] Enable point/ref buffer — dashed radius circles appear and follow marker drag
- [x] Select cfastie/schwarzwald/rplumbo with invert active — tiles render (no 422)
- [x] Add a layer mask — slider range matches actual data values; masking visible on map
- [x] `prepare-disp-s1` with S3 NetCDF — `/vsis3/` VRT created correctly


<img width="1514" height="859" alt="image" src="https://github.com/user-attachments/assets/3c952e7c-3729-481d-befb-1ddbea3e5607" />

Custom masking on-the-fly
<img width="1508" height="860" alt="image" src="https://github.com/user-attachments/assets/fe91bc78-a13c-4c28-ad62-b9d91c48a5aa" />

