### PR TITLE
Dataset catalog + `bowser register` CLI + `/catalog` endpoint

### DIFF
--- a/src/bowser/catalog.py
+++ b/src/bowser/catalog.py
@@ -1,0 +1,129 @@
+"""Dataset catalog for bowser.
+
+A catalog is a TOML file listing one or more GeoZarr stores that bowser
+can serve. Each entry points at any fsspec-compatible URI — local path,
+``s3://``, ``file://``, or ``http(s)://`` — so the same catalog works
+whether the data lives on disk or in object storage.
+
+Schema (TOML)::
+
+    [[dataset]]
+    id = "mexico-city"
+    name = "Mexico City subsidence (Jun–Aug 2024)"
+    uri = "s3://bowser-demo-data/mexico_city/cube.zarr"
+    bbox = [-99.063, 19.331, -99.017, 19.374]  # lon_min, lat_min, lon_max, lat_max
+    description = "DISP-S1 demo from the Capella workflow"
+
+Notes
+-----
+- We keep the format minimal on purpose. A STAC Collection view of a
+  GeoZarr pyramid is not yet standardised; if it lands, migrating is a
+  matter of adding a compatibility loader here. See TECH_DEBT.md.
+- ``id`` is the routing key used by the server; it must be URL-safe.
+- ``bbox`` is in WGS84 lon/lat order to match the frontend map.
+
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+__all__ = ["CatalogEntry", "load_catalog", "save_catalog", "entry_is_valid_id"]
+
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+@dataclass
+class CatalogEntry:
+    """One dataset in the catalog.
+
+    Attributes
+    ----------
+    id : str
+        Routing key. Lowercase, digits, ``_`` and ``-`` only; must start
+        with an alphanumeric.
+    name : str
+        Human-readable title for the picker UI.
+    uri : str
+        Any fsspec-compatible URI to the zarr store:
+        ``s3://bucket/path.zarr``, ``/abs/path/cube.zarr``, ``file://…``,
+        ``http(s)://…``.
+    bbox : tuple[float, float, float, float]
+        ``(lon_min, lat_min, lon_max, lat_max)`` in WGS84.
+    description : str
+        Free-form text shown in the picker tooltip.
+    """
+
+    id: str
+    name: str
+    uri: str
+    bbox: tuple[float, float, float, float]
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if not entry_is_valid_id(self.id):
+            raise ValueError(f"catalog id {self.id!r} must match ^[a-z0-9][a-z0-9_-]*$")
+        if len(self.bbox) != 4:
+            raise ValueError(f"bbox must have 4 floats, got {self.bbox!r}")
+        self.bbox = tuple(float(x) for x in self.bbox)  # type: ignore[assignment]
+
+    def to_dict(self) -> dict:
+        """Return the entry as a dict suitable for JSON serialisation."""
+        d = asdict(self)
+        d["bbox"] = list(d["bbox"])
+        return d
+
+
+def entry_is_valid_id(entry_id: str) -> bool:
+    """Return ``True`` if ``entry_id`` is a valid catalog routing key."""
+    return bool(_ID_RE.fullmatch(entry_id))
+
+
+def load_catalog(path: str | Path) -> list[CatalogEntry]:
+    """Load a catalog from a TOML file.
+
+    Returns an empty list if the file does not exist so callers can
+    treat an absent catalog as "no datasets yet" rather than an error.
+    """
+    p = Path(path)
+    if not p.exists():
+        return []
+    raw = tomllib.loads(p.read_text())
+    entries = [CatalogEntry(**d) for d in raw.get("dataset", [])]
+    _assert_unique_ids(entries)
+    return entries
+
+
+def save_catalog(entries: list[CatalogEntry], path: str | Path) -> None:
+    r"""Write ``entries`` to a TOML catalog file, overwriting any prior content.
+
+    String values are serialised via ``json.dumps`` (with ``ensure_ascii=True``
+    so BIDI/control chars get ``\\uXXXX`` escapes). TOML basic-string escape
+    rules are a superset of JSON's for the characters we care about, so the
+    output round-trips through ``tomllib.loads`` cleanly — including names
+    with quotes, backslashes, tabs, newlines, or any other control char.
+    """
+    _assert_unique_ids(entries)
+    lines = []
+    for e in entries:
+        lines.append("[[dataset]]")
+        lines.append(f"id = {json.dumps(e.id)}")
+        lines.append(f"name = {json.dumps(e.name)}")
+        lines.append(f"uri = {json.dumps(e.uri)}")
+        lines.append(f"bbox = [{', '.join(f'{v:.10g}' for v in e.bbox)}]")
+        if e.description:
+            lines.append(f"description = {json.dumps(e.description)}")
+        lines.append("")
+    Path(path).write_text("\n".join(lines))
+
+
+def _assert_unique_ids(entries: list[CatalogEntry]) -> None:
+    from collections import Counter  # noqa: PLC0415
+
+    dupes = [eid for eid, count in Counter(e.id for e in entries).items() if count > 1]
+    if dupes:
+        raise ValueError(f"duplicate catalog ids: {sorted(dupes)}")

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -913,3 +913,92 @@ def setup_nisar_gunw(nisar_dir: str, output: str):
         raster_groups.append(rg)
 
     _dump_raster_groups(raster_groups, output=output)
+
+
+@cli_app.command()
+@click.argument("dataset_id")
+@click.option(
+    "--uri",
+    required=True,
+    help="fsspec URI to the zarr store (s3://, /abs/path, file://, http(s)://).",
+)
+@click.option("--name", default=None, help="Human-readable title; defaults to the id.")
+@click.option(
+    "--description", default="", help="Free-form text shown in the picker tooltip."
+)
+@click.option(
+    "--bbox",
+    nargs=4,
+    type=float,
+    default=None,
+    help="lon_min lat_min lon_max lat_max (WGS84). If omitted, read from the store.",
+)
+@click.option(
+    "--catalog",
+    "catalog_path",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    default=Path("bowser_catalog.toml"),
+    show_default=True,
+    help="Path to the catalog TOML file; created if missing.",
+)
+def register(
+    dataset_id: str,
+    uri: str,
+    name: str | None,
+    description: str,
+    bbox: tuple[float, ...] | None,
+    catalog_path: Path,
+):
+    r"""Add a dataset entry to a catalog TOML file.
+
+    DATASET_ID is the routing key (lowercase, digits, _ or -). Example:
+
+        bowser register mexico-city \\
+            --uri s3://bowser-demo-data/mexico_city/cube.zarr \\
+            --name "Mexico City subsidence" \\
+            --bbox -99.063 19.331 -99.017 19.374
+    """
+    from .catalog import CatalogEntry, load_catalog, save_catalog
+
+    entries = load_catalog(catalog_path)
+    if any(e.id == dataset_id for e in entries):
+        raise click.ClickException(
+            f"dataset id {dataset_id!r} already in {catalog_path}"
+        )
+
+    if bbox is None:
+        bbox = _sniff_bbox(uri)
+        click.echo(f"Inferred bbox from store: {bbox}")
+
+    entries.append(
+        CatalogEntry(
+            id=dataset_id,
+            name=name or dataset_id,
+            uri=uri,
+            bbox=(bbox[0], bbox[1], bbox[2], bbox[3]),
+            description=description,
+        )
+    )
+    save_catalog(entries, catalog_path)
+    click.echo(f"Wrote {len(entries)} entries to {catalog_path}")
+
+
+def _sniff_bbox(uri: str) -> tuple[float, float, float, float]:
+    """Open a zarr just long enough to grab its WGS84 bbox."""
+    import rioxarray  # noqa: F401, PLC0415  (registers .rio accessor)
+    import xarray as xr  # noqa: PLC0415
+    from pyproj import Transformer  # noqa: PLC0415
+
+    from .geozarr import data_group_name, resolve_crs  # noqa: PLC0415
+
+    group = data_group_name(uri)
+    ds = xr.open_zarr(uri, group=group) if group else xr.open_zarr(uri)
+    crs = resolve_crs(ds)
+    ds = ds.rio.write_crs(crs)
+    minx, miny, maxx, maxy = ds.rio.bounds()
+    if ds.rio.crs.to_epsg() == 4326:
+        return (float(minx), float(miny), float(maxx), float(maxy))
+    tr = Transformer.from_crs(ds.rio.crs, 4326, always_xy=True)
+    lon_min, lat_min = tr.transform(minx, miny)
+    lon_max, lat_max = tr.transform(maxx, maxy)
+    return (float(lon_min), float(lat_min), float(lon_max), float(lat_max))

--- a/src/bowser/config.py
+++ b/src/bowser/config.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     BOWSER_STACK_DATA_FILE: str = ""
     # Multi-dataset catalog file (TOML). When set, bowser can run without a
     # single default dataset — every request must carry ``?dataset=<id>``.
-    # Catalog schema + registry live in later layers; we define the setting
-    # here so ``BowserState.load`` can fall through to "catalog-only" mode.
+    # Schema + registry live in this PR layer; the catalog-only branch of
+    # ``BowserState.load`` was introduced in the previous layer.
     BOWSER_CATALOG_FILE: str = ""
 
     # --- UI ---

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -319,6 +319,22 @@ async def get_config():
     return {"title": settings.BOWSER_TITLE}
 
 
+@app.get("/catalog")
+async def get_catalog():
+    """Return the registered dataset catalog as JSON for the picker UI.
+
+    Entries come from the TOML file at ``BOWSER_CATALOG_FILE`` (if set) —
+    each with ``{id, name, uri, bbox, description}``. Returns an empty list
+    when no catalog is configured or the file is missing.
+    """
+    from .catalog import load_catalog  # noqa: PLC0415
+
+    if not settings.BOWSER_CATALOG_FILE:
+        return {"datasets": []}
+    entries = load_catalog(settings.BOWSER_CATALOG_FILE)
+    return {"datasets": [e.to_dict() for e in entries]}
+
+
 @app.get("/variables")
 async def get_variables():
     """Get available variables (only for MD mode)."""


### PR DESCRIPTION
**Stacks on #25.** Base is \`geozarr\` (not \`main\`); review #25 first.

## Summary

Groundwork for the upcoming multi-dataset picker UI (layer 3+ of this stack). No behaviour change for anyone not opting in.

- **`bowser.catalog`** — new module. `CatalogEntry` dataclass + `load_catalog` / `save_catalog` for TOML files. Schema is minimal and STAC-adjacent (`id`, `name`, `uri`, `bbox`, `description`).
  - `uri` accepts any fsspec-compatible target — `s3://bucket/path.zarr`, `/abs/path/cube.zarr`, `file://…`, `http(s)://…` — so local and cloud datasets use the same codepath.
  - `id` is the routing key the server will dispatch on in layer 3; constrained to `^[a-z0-9][a-z0-9_-]*$` so it's URL-safe.
  - Left open: if/when STAC Collections get a standard view over GeoZarr pyramids, migrating is adding a compatibility loader here. Tracked in `TECH_DEBT.md`.
- **`bowser register`** CLI — appends an entry to a catalog TOML file; auto-sniffs the WGS84 bbox from the store if `--bbox` isn't passed (reprojects from the native CRS when needed).
- **`GET /catalog`** — reads `BOWSER_CATALOG_FILE` and returns `{datasets: [...]}`. Returns `{datasets: []}` when the catalog is absent, so callers treat "no catalog configured" as success-with-empty, not error.
- **`Settings`** gains `BOWSER_CATALOG_FILE: str = ""`.

## Verified

```bash
$ bowser register mexico-city --uri /tmp/cube.zarr --name "Mexico City subsidence" --catalog /tmp/test_catalog.toml
Inferred bbox from store: (-99.06276139881109, 19.330434383664112, -99.01725118871379, 19.373543548303225)
Wrote 1 entries to /tmp/test_catalog.toml

$ BOWSER_CATALOG_FILE=/tmp/test_catalog.toml bowser run --stack-file /tmp/cube.zarr &
$ curl http://localhost:8765/catalog
{"datasets":[{"id":"mexico-city","name":"Mexico City subsidence","uri":"/tmp/cube.zarr","bbox":[-99.0627614,19.33043438,-99.01725119,19.37354355],"description":""}]}
```

Auto-bbox reprojected from EPSG:32614 to WGS84 correctly (matches the original GeoTIFF `latlon_bounds`).

## Next in the stack

1. [#25] GeoZarr conventions + converter + pyramid + state — this is the base.
2. **This PR** — catalog + register + endpoint.
3. [next] Dockerfile + EC2 bootstrap so we can run bowser against an S3 catalog.
4. [after] `DatasetRegistry` + per-request dataset routing for multi-user serving.
5. [finally] Picker frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)