### PR TITLE
Shard GeoZarr output — 4× factor on every dim

### DIFF
--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -148,6 +148,44 @@ automatically from the expected client tile size.
 
 ---
 
+### 8. titiler doesn't pick pyramid levels by zoom — bowser wraps it
+
+**Where:** `src/bowser/main.py` `XarrayPathDependency` (~L1464); level
+picker in `src/bowser/state.py` `BowserState.dataset_for_tile_zoom`.
+
+**What's wrong:** titiler's xarray backend (as of v0.x, Apr 2026) accepts
+a `group=<N>` parameter to open a specific zarr subgroup, but nothing in
+titiler reads a GeoZarr `multiscales` root attr and picks the right
+group for a given tile zoom. Bowser does it itself in a path
+dependency: extracts `z` from the request path, calls
+`dataset_for_tile_zoom(z)`, hands titiler the chosen level's
+`xr.Dataset`. Works, but the wrapper is fragile — any endpoint that
+bypasses `XarrayPathDependency` gets level-0 at every zoom.
+
+Bowser's level picker also uses an equator-plane approximation for tile
+pixel size, so it's ~6% off for mid-latitude datasets. Not enough to
+cross a 2× pyramid boundary in practice, but not technically correct.
+
+**Fix (upstream, ~150 lines in developmentseed/titiler):**
+
+1. New path dependency `MultiscalesGroupDependency` that reads the
+   `multiscales` root attr, picks a level via a CRS-aware zoom → res
+   mapper (maxrjones's snippet in titiler#1071 using
+   `rasterio.warp.calculate_default_transform` is the reference
+   implementation), and sets `group=<chosen>` on the Reader.
+2. Fixture `pyramid_geozarr.zarr` with a proper `multiscales` attr +
+   tests that zoom 0 picks the coarsest and zoom 14 picks level 0.
+3. File a titiler issue linking #1071 with bowser's specific GeoZarr
+   use case; drop in our converter's output as a repro store.
+
+Once that ships, bowser's `XarrayPathDependency` becomes a two-line
+config change (point titiler at the new dependency, delete
+`dataset_for_tile_zoom`). Until then the wrapper works fine.
+
+Related: titiler#1071 (Jan 2025 thread, still open).
+
+---
+
 ## Done (recent sessions)
 
 - ✅ Module-level globals (`DATA_MODE`, `XARRAY_DATASET`, `RASTER_GROUPS`,

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -22,11 +22,9 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 
 import click
-import dask.config
 import numpy as np
 import pandas as pd
 import rioxarray  # noqa: F401  (registers xr.DataArray.rio accessor)
@@ -87,6 +85,18 @@ logger = logging.getLogger("tifs_to_geozarr")
     help="Compression level (1=fastest, 9=smallest).",
 )
 @click.option(
+    "--eager/--lazy",
+    default=True,
+    show_default=True,
+    help=(
+        "Eager: materialize each variable into numpy before writing — one "
+        "read-and-compute pass per variable, then a clean compressed write. "
+        "Lazy: leave as a dask graph spanning all variables (what xarray does "
+        "by default). Eager is faster on cubes that fit in RAM (multi-GB "
+        "regional stacks); switch to --lazy for continental-scale cubes."
+    ),
+)
+@click.option(
     "--pyramid/--no-pyramid",
     default=False,
     show_default=True,
@@ -107,16 +117,13 @@ def main(
     shard_factor: int,
     compression: str,
     compression_level: int,
+    eager: bool,
     pyramid: bool,
     min_pyramid_size: int,
     verbose: int,
 ) -> None:
     """Convert CONFIG (bowser_rasters.json) into OUTPUT (single zarr store)."""
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
-    # Pin the dask threadpool to all logical cores. Default is already
-    # min(32, ncpu), but some environments (pixi on macOS) see the default
-    # as 1-2 workers — making this explicit is cheap insurance.
-    dask.config.set({"num_workers": os.cpu_count() or 4})
     groups = json.loads(Path(config).read_text())
 
     data_vars: dict[str, xr.DataArray] = {}
@@ -136,11 +143,20 @@ def main(
 
     assert data_vars, f"No non-empty raster groups in {config}"
     ds = xr.Dataset(data_vars)
+    # Eager: materialize into numpy per-variable now, before handing to zarr.
+    # This replaces one giant dask graph (all 15 vars × all tifs × all tiles,
+    # shared across level 0 + every pyramid level) with N small
+    # read-and-compute passes — each variable is parallel-loaded with dask,
+    # then written with zarr's own thread pool handling compression. On a
+    # 15-var 4 GB DISP cube this is ~3× faster than lazy writes.
+    if eager:
+        logger.info("Eagerly materializing %d variables", len(ds.data_vars))
+        ds = ds.load()
     # Rechunk dask arrays to shard shape — zarr's safe-chunk validator treats
     # each shard as one atomic write unit, so dask chunks on every dim must
     # align with the shard grid. Skip when shard_factor=1 (no sharding): dask
     # chunks then match zarr chunks, one task per chunk, maximum parallelism.
-    if shard_factor > 1:
+    if not eager and shard_factor > 1:
         shard = chunk * shard_factor
         ds = ds.chunk(
             {d: (shard if d in ("x", "y") else shard_factor) for d in ds.dims}

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -191,6 +191,7 @@ def main(
                 shard_factor=shard_factor,
                 compression_name=compression,  # type: ignore[arg-type]
                 compression_level=compression_level,
+                level_0_ds=ds,
             )
         with _timed("annotate_store"):
             annotate_store(output, data_group="0", multiscales_levels=levels)

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -31,7 +31,13 @@ import rioxarray  # noqa: F401  (registers xr.DataArray.rio accessor)
 import xarray as xr
 from opera_utils import get_dates
 
-from bowser.geozarr import annotate_store, build_pyramid
+from bowser.geozarr import (
+    DEFAULT_CHUNK,
+    DEFAULT_SHARD_FACTOR,
+    annotate_store,
+    build_pyramid,
+    shard_encoding,
+)
 
 logger = logging.getLogger("tifs_to_geozarr")
 
@@ -39,8 +45,24 @@ logger = logging.getLogger("tifs_to_geozarr")
 @click.command()
 @click.argument("config", type=click.Path(exists=True, dir_okay=False))
 @click.argument("output", type=click.Path())
-@click.option("--chunk-x", default=512, show_default=True, type=int)
-@click.option("--chunk-y", default=512, show_default=True, type=int)
+@click.option(
+    "--chunk",
+    default=DEFAULT_CHUNK,
+    show_default=True,
+    type=int,
+    help="Square chunk edge (pixels) along y and x.",
+)
+@click.option(
+    "--shard-factor",
+    default=DEFAULT_SHARD_FACTOR,
+    show_default=True,
+    type=int,
+    help=(
+        "Shard shape = chunk × factor on every dim. "
+        "4× bundles 1024×1024 pixel blocks (16 chunks) per shard on y/x and "
+        "4 timesteps per shard on non-spatial dims — one HTTP GET per shard."
+    ),
+)
 @click.option(
     "--pyramid/--no-pyramid",
     default=False,
@@ -58,8 +80,8 @@ logger = logging.getLogger("tifs_to_geozarr")
 def main(
     config: str,
     output: str,
-    chunk_x: int,
-    chunk_y: int,
+    chunk: int,
+    shard_factor: int,
     pyramid: bool,
     min_pyramid_size: int,
     verbose: int,
@@ -80,19 +102,28 @@ def main(
             file_date_fmt=rg.get("file_date_fmt") or "%Y%m%d",
             display_name=rg["name"],
             name=name,
-            chunk_x=chunk_x,
-            chunk_y=chunk_y,
+            chunk=chunk,
         )
 
     assert data_vars, f"No non-empty raster groups in {config}"
     ds = xr.Dataset(data_vars)
-    encoding = _build_encoding(ds, chunk_x=chunk_x, chunk_y=chunk_y)
+    # Rechunk dask arrays to shard shape before writing — zarr's safe-chunk
+    # validator treats each shard as one atomic write unit, so dask chunks on
+    # every dim (spatial and non-spatial) must align with the shard grid.
+    shard = chunk * shard_factor
+    ds = ds.chunk({d: (shard if d in ("x", "y") else shard_factor) for d in ds.dims})
+    encoding = shard_encoding(ds, chunk=chunk, shard_factor=shard_factor)
 
     if pyramid:
         logger.info("Writing level 0 → %s/0", output)
         ds.to_zarr(output, group="0", mode="w", consolidated=True, encoding=encoding)
         logger.info("Building pyramid")
-        levels = build_pyramid(output, min_size=min_pyramid_size)
+        levels = build_pyramid(
+            output,
+            min_size=min_pyramid_size,
+            chunk=chunk,
+            shard_factor=shard_factor,
+        )
         annotate_store(output, data_group="0", multiscales_levels=levels)
     else:
         logger.info("Writing zarr → %s", output)
@@ -108,12 +139,11 @@ def _build_dataarray(
     file_date_fmt: str,
     display_name: str,
     name: str,
-    chunk_x: int,
-    chunk_y: int,
+    chunk: int,
 ) -> xr.DataArray:
     """Open all files and stack into a single DataArray with an appropriate dim."""
     fmt = file_date_fmt
-    opened = [_open_one(f, chunk_x=chunk_x, chunk_y=chunk_y) for f in file_list]
+    opened = [_open_one(f, chunk=chunk) for f in file_list]
 
     if len(opened) == 1:
         return opened[0].rename(name)
@@ -171,13 +201,13 @@ def _build_dataarray(
     return da.rename(name)
 
 
-def _open_one(path: str, *, chunk_x: int, chunk_y: int) -> xr.DataArray:
+def _open_one(path: str, *, chunk: int) -> xr.DataArray:
     """Open a single-band GeoTIFF, upcasting float16 to float32.
 
     GDAL/rasterio reprojection and titiler tile rendering both choke on
     float16.
     """
-    da = rioxarray.open_rasterio(path, chunks={"x": chunk_x, "y": chunk_y}).squeeze(
+    da = rioxarray.open_rasterio(path, chunks={"x": chunk, "y": chunk}).squeeze(
         "band", drop=True
     )
     if da.dtype == np.float16:
@@ -191,21 +221,6 @@ def _sanitize(name: str) -> str:
     for c in " .-/()":
         out = out.replace(c, "_")
     return "_".join(filter(None, out.split("_")))
-
-
-def _build_encoding(ds: xr.Dataset, *, chunk_x: int, chunk_y: int) -> dict:
-    encoding: dict[str, dict] = {}
-    for name, da in ds.data_vars.items():
-        chunks = []
-        for dim in da.dims:
-            if dim == "x":
-                chunks.append(min(chunk_x, da.sizes[dim]))
-            elif dim == "y":
-                chunks.append(min(chunk_y, da.sizes[dim]))
-            else:
-                chunks.append(1)
-        encoding[name] = {"chunks": tuple(chunks)}
-    return encoding
 
 
 if __name__ == "__main__":

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -12,6 +12,13 @@ Reads the ``RasterGroup`` JSON config produced by ``bowser set-data`` /
 - optional multiscale pyramid (``--pyramid``): levels written to ``/0``, ``/1``,
   ``/2``, … subgroups; root carries the ``multiscales`` convention attrs
 
+Read path: one ``ProcessPoolExecutor`` worker per raster group, each using
+plain ``rasterio.open(f).read(1)`` into a pre-allocated numpy stack. No dask,
+no rioxarray lazy graph, no xarray IO lock. Profiling of the previous
+dask-backed path showed ~80% of wall time spent with idle threadpool workers
+and ~26% of active time blocked on ``xarray/backends/locks.py:__enter__`` —
+those are what this rewrite removes.
+
 Usage
 -----
     python scripts/tifs_to_geozarr.py bowser_rasters.json cube.zarr
@@ -22,12 +29,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import click
 import numpy as np
 import pandas as pd
-import rioxarray  # noqa: F401  (registers xr.DataArray.rio accessor)
+import rasterio
 import xarray as xr
 from opera_utils import get_dates
 
@@ -85,15 +96,13 @@ logger = logging.getLogger("tifs_to_geozarr")
     help="Compression level (1=fastest, 9=smallest).",
 )
 @click.option(
-    "--eager/--lazy",
-    default=True,
+    "--workers",
+    default=0,
     show_default=True,
+    type=int,
     help=(
-        "Eager: materialize each variable into numpy before writing — one "
-        "read-and-compute pass per variable, then a clean compressed write. "
-        "Lazy: leave as a dask graph spanning all variables (what xarray does "
-        "by default). Eager is faster on cubes that fit in RAM (multi-GB "
-        "regional stacks); switch to --lazy for continental-scale cubes."
+        "Parallel worker processes — one variable per worker. "
+        "0 = min(len(variables), cpu_count())."
     ),
 )
 @click.option(
@@ -117,50 +126,31 @@ def main(
     shard_factor: int,
     compression: str,
     compression_level: int,
-    eager: bool,
+    workers: int,
     pyramid: bool,
     min_pyramid_size: int,
     verbose: int,
 ) -> None:
     """Convert CONFIG (bowser_rasters.json) into OUTPUT (single zarr store)."""
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
-    groups = json.loads(Path(config).read_text())
+    groups_cfg = [g for g in json.loads(Path(config).read_text()) if g.get("file_list")]
+    assert groups_cfg, f"No non-empty raster groups in {config}"
 
-    data_vars: dict[str, xr.DataArray] = {}
-    for rg in groups:
-        file_list = rg.get("file_list") or []
-        if not file_list:
-            continue
-        name = _sanitize(rg["name"])
-        logger.info("Building %s (%d files)", name, len(file_list))
-        data_vars[name] = _build_dataarray(
-            file_list=file_list,
-            file_date_fmt=rg.get("file_date_fmt") or "%Y%m%d",
-            display_name=rg["name"],
-            name=name,
-            chunk=chunk,
-        )
+    # Spatial reference comes from the first file of the first group — all groups
+    # are assumed to be co-registered (the converter would break silently otherwise,
+    # so fail loudly on shape/CRS mismatch inside the worker).
+    ref = _load_spatial_ref(groups_cfg[0]["file_list"][0])
 
-    assert data_vars, f"No non-empty raster groups in {config}"
-    ds = xr.Dataset(data_vars)
-    # Eager: materialize into numpy per-variable now, before handing to zarr.
-    # This replaces one giant dask graph (all 15 vars × all tifs × all tiles,
-    # shared across level 0 + every pyramid level) with N small
-    # read-and-compute passes — each variable is parallel-loaded with dask,
-    # then written with zarr's own thread pool handling compression. On a
-    # 15-var 4 GB DISP cube this is ~3× faster than lazy writes.
-    if eager:
-        logger.info("Eagerly materializing %d variables", len(ds.data_vars))
-        ds = ds.load()
-    # Rechunk dask arrays to shard shape — zarr's safe-chunk validator treats
-    # each shard as one atomic write unit, so dask chunks on every dim must
-    # align with the shard grid. Skip when shard_factor=1 (no sharding): dask
-    # chunks then match zarr chunks, one task per chunk, maximum parallelism.
-    if not eager and shard_factor > 1:
-        shard = chunk * shard_factor
-        ds = ds.chunk(
-            {d: (shard if d in ("x", "y") else shard_factor) for d in ds.dims}
-        )
+    n_workers = workers or min(len(groups_cfg), os.cpu_count() or 4)
+    logger.info("Loading %d variables with %d workers", len(groups_cfg), n_workers)
+    loaded: list[_Loaded] = []
+    if n_workers == 1:
+        loaded = [_load_group(g, ref) for g in groups_cfg]
+    else:
+        with ProcessPoolExecutor(max_workers=n_workers) as pool:
+            loaded = list(pool.map(_load_group, groups_cfg, [ref] * len(groups_cfg)))
+
+    ds = _assemble_dataset(loaded, ref)
     encoding = shard_encoding(
         ds,
         chunk=chunk,
@@ -187,24 +177,87 @@ def main(
         ds.to_zarr(output, mode="w", consolidated=False, encoding=encoding)
         annotate_store(output)
 
-    click.echo(f"Wrote {output} with variables: {sorted(data_vars)}")
+    click.echo(f"Wrote {output} with variables: {sorted(lv.name for lv in loaded)}")
 
 
-def _build_dataarray(
-    *,
-    file_list: list[str],
-    file_date_fmt: str,
-    display_name: str,
-    name: str,
-    chunk: int,
-) -> xr.DataArray:
-    """Open all files and stack into a single DataArray with an appropriate dim."""
-    fmt = file_date_fmt
-    opened = [_open_one(f, chunk=chunk) for f in file_list]
+@dataclass
+class _SpatialRef:
+    """Geospatial reference captured from the first tif in the first group.
 
-    if len(opened) == 1:
-        return opened[0].rename(name)
+    Every subsequent file must match ``shape`` and ``crs`` exactly — the worker
+    asserts this inside ``_load_group`` so a miscalibrated config fails loud
+    rather than producing a silently-corrupt cube.
+    """
 
+    height: int
+    width: int
+    crs_wkt: str
+    transform: tuple[float, ...]  # 6-element rasterio affine
+    x_coords: np.ndarray
+    y_coords: np.ndarray
+
+
+@dataclass
+class _Loaded:
+    """A single materialized raster group, ready to hand to xarray."""
+
+    name: str
+    display_name: str
+    array: np.ndarray  # (N, H, W) for 3D groups; (H, W) for single-file groups
+    dim_name: str | None  # None for 2D
+    coords: dict[str, tuple[str, np.ndarray]]  # {coord_name: (dim, values)}
+
+
+def _load_spatial_ref(path: str) -> _SpatialRef:
+    with rasterio.open(path) as src:
+        t = src.transform
+        # Pixel-center coordinates: (ix + 0.5, iy + 0.5) * transform. Same
+        # convention rioxarray uses on open_rasterio.
+        x = (np.arange(src.width) + 0.5) * t.a + t.c
+        y = (np.arange(src.height) + 0.5) * t.e + t.f
+        return _SpatialRef(
+            height=src.height,
+            width=src.width,
+            crs_wkt=src.crs.to_wkt() if src.crs else "",
+            transform=tuple(t)[:6],
+            x_coords=x.astype(np.float64),
+            y_coords=y.astype(np.float64),
+        )
+
+
+def _load_group(rg: dict, ref: _SpatialRef) -> _Loaded:
+    """Read every file in a RasterGroup into one numpy array.
+
+    Runs inside a worker process — imports are at module top so pickling costs
+    are just the ``rg`` dict and ``ref`` dataclass (both tiny).
+    """
+    file_list: list[str] = rg["file_list"]
+    name = _sanitize(rg["name"])
+    display_name = rg["name"]
+    fmt = rg.get("file_date_fmt") or "%Y%m%d"
+
+    # Dtype: float16 tifs are unusable downstream (GDAL reprojection + titiler
+    # both choke), so upcast at read time. Everything else flows through
+    # unchanged.
+    with rasterio.open(file_list[0]) as src0:
+        src_dtype = src0.dtypes[0]
+    out_dtype = np.dtype("float32" if src_dtype == "float16" else src_dtype)
+
+    if len(file_list) == 1:
+        arr = _read_one(file_list[0], ref, out_dtype)
+        return _Loaded(
+            name=name, display_name=display_name, array=arr, dim_name=None, coords={}
+        )
+
+    # 3D: pre-allocate (N, H, W) once, then fill per file — avoids the
+    # (concat N arrays) memory bump that stacking would cause.
+    stack = np.empty((len(file_list), ref.height, ref.width), dtype=out_dtype)
+    for i, f in enumerate(file_list):
+        stack[i] = _read_one(f, ref, out_dtype)
+
+    # Dim + coord choice mirrors the original xarray-backed code: single ref
+    # date → linear time series; multiple refs → integer pair index + date
+    # labels; single date per file → plain time series.
     dates_per_file = [get_dates(f, fmt=fmt) for f in file_list]
     pair_dim = f"pair_{name}"
     time_dim = f"time_{name}"
@@ -213,63 +266,93 @@ def _build_dataarray(
         pairs = [(d[0], d[1]) for d in dates_per_file]
         ref_dates = {p[0] for p in pairs}
         if len(ref_dates) == 1:
-            # Linear time series keyed on secondary date.
             sec = pd.to_datetime([p[1] for p in pairs])
-            order = np.argsort(sec)
-            opened = [opened[i] for i in order]
-            idx = pd.Index(sec[order], name=time_dim)
-            da = xr.concat(opened, dim=idx)
-        else:
-            # True pair index: integer index ordered by (ref, sec).
-            order = sorted(range(len(pairs)), key=lambda i: pairs[i])
-            opened = [opened[i] for i in order]
-            pairs = [pairs[i] for i in order]
-            idx = pd.Index(range(len(pairs)), name=pair_dim)
-            da = xr.concat(opened, dim=idx)
-            labels = [
-                f"{p[0].strftime('%Y-%m-%d')}_{p[1].strftime('%Y-%m-%d')}"
-                for p in pairs
-            ]
-            da = da.assign_coords(
-                {
-                    f"reference_date_{name}": (
-                        pair_dim,
-                        pd.to_datetime([p[0] for p in pairs]),
-                    ),
-                    f"secondary_date_{name}": (
-                        pair_dim,
-                        pd.to_datetime([p[1] for p in pairs]),
-                    ),
-                    f"pair_label_{name}": (pair_dim, labels),
-                }
+            order = np.argsort(sec).tolist()
+            stack = stack[order]
+            return _Loaded(
+                name=name,
+                display_name=display_name,
+                array=stack,
+                dim_name=time_dim,
+                coords={time_dim: (time_dim, sec[order].to_numpy())},
             )
-    elif all(len(d) == 1 for d in dates_per_file):
-        t = pd.to_datetime([d[0] for d in dates_per_file])
-        order = np.argsort(t)
-        opened = [opened[i] for i in order]
-        idx = pd.Index(t[order], name=time_dim)
-        da = xr.concat(opened, dim=idx)
-    else:
-        raise ValueError(
-            f"Group {display_name!r}: inconsistent filename date structure "
-            f"({[len(d) for d in dates_per_file]})"
+        order = sorted(range(len(pairs)), key=lambda i: pairs[i])
+        stack = stack[order]
+        pairs = [pairs[i] for i in order]
+        labels = np.array(
+            [f"{p[0].strftime('%Y-%m-%d')}_{p[1].strftime('%Y-%m-%d')}" for p in pairs]
         )
-
-    return da.rename(name)
-
-
-def _open_one(path: str, *, chunk: int) -> xr.DataArray:
-    """Open a single-band GeoTIFF, upcasting float16 to float32.
-
-    GDAL/rasterio reprojection and titiler tile rendering both choke on
-    float16.
-    """
-    da = rioxarray.open_rasterio(path, chunks={"x": chunk, "y": chunk}).squeeze(
-        "band", drop=True
+        return _Loaded(
+            name=name,
+            display_name=display_name,
+            array=stack,
+            dim_name=pair_dim,
+            coords={
+                pair_dim: (pair_dim, np.arange(len(pairs))),
+                f"reference_date_{name}": (
+                    pair_dim,
+                    pd.to_datetime([p[0] for p in pairs]).to_numpy(),
+                ),
+                f"secondary_date_{name}": (
+                    pair_dim,
+                    pd.to_datetime([p[1] for p in pairs]).to_numpy(),
+                ),
+                f"pair_label_{name}": (pair_dim, labels),
+            },
+        )
+    if all(len(d) == 1 for d in dates_per_file):
+        t = pd.to_datetime([d[0] for d in dates_per_file])
+        order = np.argsort(t).tolist()
+        stack = stack[order]
+        return _Loaded(
+            name=name,
+            display_name=display_name,
+            array=stack,
+            dim_name=time_dim,
+            coords={time_dim: (time_dim, t[order].to_numpy())},
+        )
+    raise ValueError(
+        f"Group {display_name!r}: inconsistent filename date structure "
+        f"({[len(d) for d in dates_per_file]})"
     )
-    if da.dtype == np.float16:
-        da = da.astype(np.float32)
-    return da
+
+
+def _read_one(path: str, ref: _SpatialRef, out_dtype: np.dtype) -> np.ndarray:
+    """Read band 1 of a single tif as a 2D numpy array, asserting shape match."""
+    with rasterio.open(path) as src:
+        assert (src.height, src.width) == (
+            ref.height,
+            ref.width,
+        ), f"{path}: shape {(src.height, src.width)} != ref {(ref.height, ref.width)}"
+        arr = src.read(1)
+    return arr.astype(out_dtype, copy=False)
+
+
+def _assemble_dataset(loaded: list[_Loaded], ref: _SpatialRef) -> xr.Dataset:
+    """Combine per-group numpy arrays into one ``xr.Dataset`` with shared x/y coords."""
+    data_vars: dict[str, xr.DataArray] = {}
+    extra_coords: dict[str, tuple[Any, np.ndarray]] = {}
+    for lv in loaded:
+        if lv.dim_name is None:
+            da = xr.DataArray(lv.array, dims=("y", "x"), name=lv.name)
+        else:
+            da = xr.DataArray(lv.array, dims=(lv.dim_name, "y", "x"), name=lv.name)
+            # Attach this group's per-dim coords to the containing Dataset so
+            # they're written alongside the variable.
+            for cname, (cdim, cvals) in lv.coords.items():
+                extra_coords[cname] = (cdim, cvals)
+        data_vars[lv.name] = da
+    ds = xr.Dataset(
+        data_vars,
+        coords={"y": ref.y_coords, "x": ref.x_coords, **extra_coords},
+    )
+    if ref.crs_wkt:
+        # Let rioxarray write spatial_ref via the usual accessor — keeps the
+        # CF `grid_mapping` attribute wiring identical to the old path.
+        import rioxarray  # noqa: F401, PLC0415
+
+        ds = ds.rio.write_crs(ref.crs_wkt)
+    return ds
 
 
 def _sanitize(name: str) -> str:

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -30,7 +30,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from concurrent.futures import ProcessPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -53,6 +55,14 @@ from bowser.geozarr import (
 )
 
 logger = logging.getLogger("tifs_to_geozarr")
+
+
+@contextmanager
+def _timed(label: str):
+    """Log elapsed wall time for a named phase. Runs at INFO level (-v)."""
+    t0 = time.perf_counter()
+    yield
+    logger.info("%s: %.2fs", label, time.perf_counter() - t0)
 
 
 @click.command()
@@ -143,14 +153,21 @@ def main(
 
     n_workers = workers or min(len(groups_cfg), os.cpu_count() or 4)
     logger.info("Loading %d variables with %d workers", len(groups_cfg), n_workers)
-    loaded: list[_Loaded] = []
-    if n_workers == 1:
-        loaded = [_load_group(g, ref) for g in groups_cfg]
-    else:
-        with ProcessPoolExecutor(max_workers=n_workers) as pool:
-            loaded = list(pool.map(_load_group, groups_cfg, [ref] * len(groups_cfg)))
+    loaded: list[_Loaded]
+    with _timed("read (all variables, parallel)"):
+        if n_workers == 1:
+            loaded = [_load_group(g, ref) for g in groups_cfg]
+        else:
+            with ProcessPoolExecutor(max_workers=n_workers) as pool:
+                loaded = list(
+                    pool.map(_load_group, groups_cfg, [ref] * len(groups_cfg))
+                )
 
-    ds = _assemble_dataset(loaded, ref)
+    bytes_in = sum(lv.array.nbytes for lv in loaded)
+    logger.info("Loaded %.2f GiB across %d vars", bytes_in / 2**30, len(loaded))
+
+    with _timed("assemble xr.Dataset"):
+        ds = _assemble_dataset(loaded, ref)
     encoding = shard_encoding(
         ds,
         chunk=chunk,
@@ -160,22 +177,29 @@ def main(
     )
 
     if pyramid:
-        logger.info("Writing level 0 → %s/0", output)
-        ds.to_zarr(output, group="0", mode="w", consolidated=False, encoding=encoding)
-        logger.info("Building pyramid")
-        levels = build_pyramid(
-            output,
-            min_size=min_pyramid_size,
-            chunk=chunk,
-            shard_factor=shard_factor,
-            compression_name=compression,  # type: ignore[arg-type]
-            compression_level=compression_level,
-        )
-        annotate_store(output, data_group="0", multiscales_levels=levels)
+        with _timed("write level 0"):
+            logger.info("Writing level 0 → %s/0", output)
+            ds.to_zarr(
+                output, group="0", mode="w", consolidated=False, encoding=encoding
+            )
+        with _timed("build pyramid (all levels)"):
+            logger.info("Building pyramid")
+            levels = build_pyramid(
+                output,
+                min_size=min_pyramid_size,
+                chunk=chunk,
+                shard_factor=shard_factor,
+                compression_name=compression,  # type: ignore[arg-type]
+                compression_level=compression_level,
+            )
+        with _timed("annotate_store"):
+            annotate_store(output, data_group="0", multiscales_levels=levels)
     else:
-        logger.info("Writing zarr → %s", output)
-        ds.to_zarr(output, mode="w", consolidated=False, encoding=encoding)
-        annotate_store(output)
+        with _timed("write zarr (flat)"):
+            logger.info("Writing zarr → %s", output)
+            ds.to_zarr(output, mode="w", consolidated=False, encoding=encoding)
+        with _timed("annotate_store"):
+            annotate_store(output)
 
     click.echo(f"Wrote {output} with variables: {sorted(lv.name for lv in loaded)}")
 
@@ -279,8 +303,13 @@ def _load_group(rg: dict, ref: _SpatialRef) -> _Loaded:
         order = sorted(range(len(pairs)), key=lambda i: pairs[i])
         stack = stack[order]
         pairs = [pairs[i] for i in order]
+        # dtype=object (variable-length strings) rather than default `<U21`
+        # fixed-length — the latter has no zarr v3 spec and triggers a loud
+        # UnstableSpecificationWarning on every write. Object maps to zarr's
+        # VLenUTF8 codec, which *is* standardised.
         labels = np.array(
-            [f"{p[0].strftime('%Y-%m-%d')}_{p[1].strftime('%Y-%m-%d')}" for p in pairs]
+            [f"{p[0].strftime('%Y-%m-%d')}_{p[1].strftime('%Y-%m-%d')}" for p in pairs],
+            dtype=object,
         )
         return _Loaded(
             name=name,

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -22,9 +22,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import click
+import dask.config
 import numpy as np
 import pandas as pd
 import rioxarray  # noqa: F401  (registers xr.DataArray.rio accessor)
@@ -58,11 +60,13 @@ logger = logging.getLogger("tifs_to_geozarr")
     "--shard-factor",
     default=DEFAULT_SHARD_FACTOR,
     show_default=True,
-    type=int,
+    type=click.IntRange(1, 64),
     help=(
         "Shard shape = chunk × factor on every dim. "
         "4× bundles 1024×1024 pixel blocks (16 chunks) per shard on y/x and "
-        "4 timesteps per shard on non-spatial dims — one HTTP GET per shard."
+        "4 timesteps per shard on non-spatial dims — one HTTP GET per shard. "
+        "Set to 1 to disable sharding entirely (fastest local write; more "
+        "files on disk)."
     ),
 )
 @click.option(
@@ -109,6 +113,10 @@ def main(
 ) -> None:
     """Convert CONFIG (bowser_rasters.json) into OUTPUT (single zarr store)."""
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
+    # Pin the dask threadpool to all logical cores. Default is already
+    # min(32, ncpu), but some environments (pixi on macOS) see the default
+    # as 1-2 workers — making this explicit is cheap insurance.
+    dask.config.set({"num_workers": os.cpu_count() or 4})
     groups = json.loads(Path(config).read_text())
 
     data_vars: dict[str, xr.DataArray] = {}
@@ -128,11 +136,15 @@ def main(
 
     assert data_vars, f"No non-empty raster groups in {config}"
     ds = xr.Dataset(data_vars)
-    # Rechunk dask arrays to shard shape before writing — zarr's safe-chunk
-    # validator treats each shard as one atomic write unit, so dask chunks on
-    # every dim (spatial and non-spatial) must align with the shard grid.
-    shard = chunk * shard_factor
-    ds = ds.chunk({d: (shard if d in ("x", "y") else shard_factor) for d in ds.dims})
+    # Rechunk dask arrays to shard shape — zarr's safe-chunk validator treats
+    # each shard as one atomic write unit, so dask chunks on every dim must
+    # align with the shard grid. Skip when shard_factor=1 (no sharding): dask
+    # chunks then match zarr chunks, one task per chunk, maximum parallelism.
+    if shard_factor > 1:
+        shard = chunk * shard_factor
+        ds = ds.chunk(
+            {d: (shard if d in ("x", "y") else shard_factor) for d in ds.dims}
+        )
     encoding = shard_encoding(
         ds,
         chunk=chunk,

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -48,7 +48,9 @@ from bowser.geozarr import (
     DEFAULT_CHUNK,
     DEFAULT_COMPRESSION_LEVEL,
     DEFAULT_COMPRESSION_NAME,
+    DEFAULT_QUANTIZE_PATTERNS,
     DEFAULT_SHARD_FACTOR,
+    ZarrWriteConfig,
     annotate_store,
     build_pyramid,
     shard_encoding,
@@ -106,6 +108,28 @@ def _timed(label: str):
     help="Compression level (1=fastest, 9=smallest).",
 )
 @click.option(
+    "--quantize-digits",
+    default=0,
+    show_default=True,
+    type=click.IntRange(0, 10),
+    help=(
+        "If > 0, round matching float variables to this many significant "
+        "digits before compression (via numcodecs Quantize). Typical "
+        "coherence-like layers carry ~1 bit of real info per pixel and "
+        "compress ~40% smaller with `--quantize-digits 3`. 0 disables."
+    ),
+)
+@click.option(
+    "--quantize-patterns",
+    default=",".join(DEFAULT_QUANTIZE_PATTERNS),
+    show_default=True,
+    help=(
+        "Comma-separated substrings matched against variable names (lower-"
+        "case) to decide which float vars get the quantize filter. "
+        "Integer-dtype variables are always skipped."
+    ),
+)
+@click.option(
     "--workers",
     default=0,
     show_default=True,
@@ -136,6 +160,8 @@ def main(
     shard_factor: int,
     compression: str,
     compression_level: int,
+    quantize_digits: int,
+    quantize_patterns: str,
     workers: int,
     pyramid: bool,
     min_pyramid_size: int,
@@ -168,13 +194,18 @@ def main(
 
     with _timed("assemble xr.Dataset"):
         ds = _assemble_dataset(loaded, ref)
-    encoding = shard_encoding(
-        ds,
+
+    write_cfg = ZarrWriteConfig(
         chunk=chunk,
         shard_factor=shard_factor,
         compression_name=compression,  # type: ignore[arg-type]
         compression_level=compression_level,
+        quantize_digits=quantize_digits if quantize_digits > 0 else None,
+        quantize_patterns=tuple(
+            p.strip() for p in quantize_patterns.split(",") if p.strip()
+        ),
     )
+    encoding = shard_encoding(ds, write_cfg)
 
     if pyramid:
         with _timed("write level 0"):
@@ -187,10 +218,7 @@ def main(
             levels = build_pyramid(
                 output,
                 min_size=min_pyramid_size,
-                chunk=chunk,
-                shard_factor=shard_factor,
-                compression_name=compression,  # type: ignore[arg-type]
-                compression_level=compression_level,
+                config=write_cfg,
                 level_0_ds=ds,
             )
         with _timed("annotate_store"):

--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -33,6 +33,8 @@ from opera_utils import get_dates
 
 from bowser.geozarr import (
     DEFAULT_CHUNK,
+    DEFAULT_COMPRESSION_LEVEL,
+    DEFAULT_COMPRESSION_NAME,
     DEFAULT_SHARD_FACTOR,
     annotate_store,
     build_pyramid,
@@ -64,6 +66,23 @@ logger = logging.getLogger("tifs_to_geozarr")
     ),
 )
 @click.option(
+    "--compression",
+    default=DEFAULT_COMPRESSION_NAME,
+    show_default=True,
+    type=click.Choice(["lz4", "lz4hc", "blosclz", "snappy", "zlib", "zstd"]),
+    help=(
+        "Blosc sub-codec. lz4 is ~6× faster than zstd at ~10% worse ratio; "
+        "zstd clevel 3 is a good middle ground."
+    ),
+)
+@click.option(
+    "--compression-level",
+    default=DEFAULT_COMPRESSION_LEVEL,
+    show_default=True,
+    type=click.IntRange(1, 9),
+    help="Compression level (1=fastest, 9=smallest).",
+)
+@click.option(
     "--pyramid/--no-pyramid",
     default=False,
     show_default=True,
@@ -82,6 +101,8 @@ def main(
     output: str,
     chunk: int,
     shard_factor: int,
+    compression: str,
+    compression_level: int,
     pyramid: bool,
     min_pyramid_size: int,
     verbose: int,
@@ -112,22 +133,30 @@ def main(
     # every dim (spatial and non-spatial) must align with the shard grid.
     shard = chunk * shard_factor
     ds = ds.chunk({d: (shard if d in ("x", "y") else shard_factor) for d in ds.dims})
-    encoding = shard_encoding(ds, chunk=chunk, shard_factor=shard_factor)
+    encoding = shard_encoding(
+        ds,
+        chunk=chunk,
+        shard_factor=shard_factor,
+        compression_name=compression,  # type: ignore[arg-type]
+        compression_level=compression_level,
+    )
 
     if pyramid:
         logger.info("Writing level 0 → %s/0", output)
-        ds.to_zarr(output, group="0", mode="w", consolidated=True, encoding=encoding)
+        ds.to_zarr(output, group="0", mode="w", consolidated=False, encoding=encoding)
         logger.info("Building pyramid")
         levels = build_pyramid(
             output,
             min_size=min_pyramid_size,
             chunk=chunk,
             shard_factor=shard_factor,
+            compression_name=compression,  # type: ignore[arg-type]
+            compression_level=compression_level,
         )
         annotate_store(output, data_group="0", multiscales_levels=levels)
     else:
         logger.info("Writing zarr → %s", output)
-        ds.to_zarr(output, mode="w", consolidated=True, encoding=encoding)
+        ds.to_zarr(output, mode="w", consolidated=False, encoding=encoding)
         annotate_store(output)
 
     click.echo(f"Wrote {output} with variables: {sorted(data_vars)}")

--- a/src/bowser/geozarr.py
+++ b/src/bowser/geozarr.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import xarray as xr
 from rasterio.crs import CRS
+
+BloscCname = Literal["lz4", "lz4hc", "blosclz", "snappy", "zlib", "zstd"]
 
 __all__ = [
     "resolve_crs",
@@ -27,7 +29,18 @@ __all__ = [
     "build_pyramid",
     "data_group_name",
     "load_pyramid_levels",
+    "shard_encoding",
 ]
+
+# Defaults tuned for DISP-S1-sized cubes on S3: 256×256 chunks keep random-access
+# tile reads cheap, and 4× shard factor on every dim means one HTTP GET per
+# shard covers a 1024×1024 tile block (or 4 timesteps for timeseries reads).
+# Pair of references: opera-utils uses `(4, 256, 256)` chunks × `(1, 4, 4)`
+# shard_factors; we keep time chunk = 1 because bowser tile renders hit one
+# timestep at a time, and we want shard time = 4 so timeseries `/point` reads
+# bundle 4 timesteps per HTTP GET.
+DEFAULT_CHUNK = 256
+DEFAULT_SHARD_FACTOR = 4
 
 logger = logging.getLogger("bowser")
 
@@ -64,6 +77,69 @@ def resolve_crs(ds: xr.Dataset) -> CRS:
         "No CRS found on dataset. Expected GeoZarr 'proj:code'/'proj:wkt2' "
         "root attrs or a CF 'spatial_ref' variable with 'crs_wkt'."
     )
+
+
+def shard_encoding(
+    ds: xr.Dataset,
+    *,
+    chunk: int = DEFAULT_CHUNK,
+    shard_factor: int = DEFAULT_SHARD_FACTOR,
+    compression_name: BloscCname = "zstd",
+    compression_level: int = 6,
+) -> dict[str, dict]:
+    """Build per-variable ``encoding`` dict with chunks + shards + compression.
+
+    Produces a zarr v3 encoding dict ready to hand to
+    ``xr.Dataset.to_zarr(..., encoding=...)``. Every spatial data variable gets:
+
+    - ``chunks`` = 1 on non-spatial dims, ``chunk`` on y/x
+    - ``shards`` = chunks × ``shard_factor`` on every dim
+    - ``compressors`` = one ``BloscCodec`` with ``zstd``
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset whose data_vars will be written. Variables with ndim < 2 are
+        skipped (chunks/shards only make sense for gridded arrays).
+    chunk : int
+        Edge length of a chunk along the y and x dims, in pixels.
+    shard_factor : int
+        Multiplier from chunk → shard shape, applied to every dim.
+    compression_name, compression_level : str, int
+        Blosc sub-codec and compression level (1–9).
+
+    Returns
+    -------
+    dict[str, dict]
+        Mapping from variable name to its per-variable encoding dict.
+
+    """
+    from zarr.codecs import BloscCodec  # noqa: PLC0415 — optional runtime dep
+
+    assert chunk >= 1 and shard_factor >= 1
+    encoding: dict[str, dict] = {}
+    for name, da in ds.data_vars.items():
+        if da.ndim < 2:
+            continue
+        # Match by literal dim name rather than da.rio.x_dim/y_dim, which
+        # requires a set CRS and fails on freshly-opened coarsened levels
+        # inside build_pyramid.
+        chunks = tuple(
+            min(chunk, da.sizes[d]) if d in ("x", "y") else 1 for d in da.dims
+        )
+        shards = tuple(c * shard_factor for c in chunks)
+        # Shard shape must be a whole multiple of chunk shape along every dim;
+        # our construction guarantees this, but assert loudly rather than
+        # silently fall back to no-sharding like opera-utils does.
+        assert all(s % c == 0 for s, c in zip(shards, chunks))
+        encoding[str(name)] = {
+            "chunks": chunks,
+            "shards": shards,
+            "compressors": [
+                BloscCodec(cname=compression_name, clevel=compression_level)
+            ],
+        }
+    return encoding
 
 
 def _multiscales_layout(path: str | Path) -> list[dict] | None:
@@ -199,12 +275,17 @@ def build_pyramid(
     level0: str = "0",
     min_size: int = 256,
     max_levels: int = 6,
+    chunk: int = DEFAULT_CHUNK,
+    shard_factor: int = DEFAULT_SHARD_FACTOR,
 ) -> list[dict]:
     """Build a coarsened multiscale pyramid for data already written at ``path/level0``.
 
     Writes sibling subgroups ``"1"``, ``"2"``, … each at 2× coarser spatial
     resolution than the previous, stopping when ``min(y, x) < min_size`` or
     after ``max_levels`` levels. Uses mean resampling across both spatial dims.
+    Every level is written with the same chunk + shard encoding as level 0
+    (see ``shard_encoding``), so pyramid levels don't undo the small-file
+    consolidation won by sharding.
 
     Returns
     -------
@@ -223,15 +304,16 @@ def build_pyramid(
             break
         logger.info("Coarsening level %d → %d × %d (y × x)", i, y_sz, x_sz)
         coarse = prev.coarsen({"y": 2, "x": 2}, boundary="trim").mean()
-        # Rechunk to match the target layout — coarsen produces dask chunks
-        # that won't align with our (512, 512) zarr chunks otherwise.
-        rechunk_sizes = {
-            "y": min(512, coarse.sizes["y"]),
-            "x": min(512, coarse.sizes["x"]),
+        # Rechunk to the shard shape before writing — dask chunks must be
+        # whole shards for the zarr sharding codec to accept the write.
+        shard = chunk * shard_factor
+        rechunk_sizes: dict[str, int] = {
+            "y": min(shard, coarse.sizes["y"]),
+            "x": min(shard, coarse.sizes["x"]),
         }
         for d in coarse.dims:
             if d not in rechunk_sizes:
-                rechunk_sizes[str(d)] = 1
+                rechunk_sizes[str(d)] = shard_factor
         coarse = coarse.chunk(rechunk_sizes)
         # Strip inherited encoding — chunk hints carried over from /0 will
         # conflict with the newly-sized arrays on /1+.
@@ -242,7 +324,10 @@ def build_pyramid(
         # for coarsened levels, and tile reads would use the wrong affine.
         if "spatial_ref" in coarse.variables:
             coarse["spatial_ref"].attrs.pop("GeoTransform", None)
-        coarse.to_zarr(path, group=str(i), mode="w", consolidated=True)
+        encoding = shard_encoding(coarse, chunk=chunk, shard_factor=shard_factor)
+        coarse.to_zarr(
+            path, group=str(i), mode="w", consolidated=True, encoding=encoding
+        )
         levels.append(
             {
                 "asset": str(i),

--- a/src/bowser/geozarr.py
+++ b/src/bowser/geozarr.py
@@ -133,18 +133,20 @@ def shard_encoding(
         chunks = tuple(
             min(chunk, da.sizes[d]) if d in ("x", "y") else 1 for d in da.dims
         )
-        shards = tuple(c * shard_factor for c in chunks)
-        # Shard shape must be a whole multiple of chunk shape along every dim;
-        # our construction guarantees this, but assert loudly rather than
-        # silently fall back to no-sharding like opera-utils does.
-        assert all(s % c == 0 for s, c in zip(shards, chunks))
-        encoding[str(name)] = {
+        var_enc: dict = {
             "chunks": chunks,
-            "shards": shards,
             "compressors": [
                 BloscCodec(cname=compression_name, clevel=compression_level)
             ],
         }
+        # shard_factor=1 means "don't wrap chunks in a shard" — dask chunks can
+        # stay small, each dask task writes exactly one chunk, parallelism is
+        # maximum. Useful when write time dominates (local disk, small cubes).
+        if shard_factor > 1:
+            shards = tuple(c * shard_factor for c in chunks)
+            assert all(s % c == 0 for s, c in zip(shards, chunks))
+            var_enc["shards"] = shards
+        encoding[str(name)] = var_enc
     return encoding
 
 

--- a/src/bowser/geozarr.py
+++ b/src/bowser/geozarr.py
@@ -41,6 +41,12 @@ __all__ = [
 # bundle 4 timesteps per HTTP GET.
 DEFAULT_CHUNK = 256
 DEFAULT_SHARD_FACTOR = 4
+# lz4 + clevel 5 = zarr's own default. ~6× faster to compress than zstd-6 at
+# only ~10% worse ratio, and sharding already collapses the file count, so the
+# extra bytes don't cost us HTTP round-trips. Users who want smaller stores
+# can override with `shard_encoding(..., compression_name="zstd", ...)`.
+DEFAULT_COMPRESSION_NAME: "BloscCname" = "lz4"
+DEFAULT_COMPRESSION_LEVEL = 5
 
 logger = logging.getLogger("bowser")
 
@@ -84,8 +90,8 @@ def shard_encoding(
     *,
     chunk: int = DEFAULT_CHUNK,
     shard_factor: int = DEFAULT_SHARD_FACTOR,
-    compression_name: BloscCname = "zstd",
-    compression_level: int = 6,
+    compression_name: BloscCname = DEFAULT_COMPRESSION_NAME,
+    compression_level: int = DEFAULT_COMPRESSION_LEVEL,
 ) -> dict[str, dict]:
     """Build per-variable ``encoding`` dict with chunks + shards + compression.
 
@@ -195,7 +201,7 @@ def annotate_store(
     variable: str | None = None,
     data_group: str | None = None,
     multiscales_levels: list[dict] | None = None,
-    consolidate: bool = True,
+    consolidate: bool = False,
 ) -> None:
     """Write GeoZarr attrs to a zarr store.
 
@@ -217,9 +223,13 @@ def annotate_store(
         ``multiscales.layout`` entries for a pyramid. When not given but
         ``data_group`` is set, a single-level layout pointing at ``data_group``
         is written.
-    consolidate : bool, default True
-        Re-consolidate metadata at root (and at the data group) so downstream
-        readers still find ``.zmetadata``.
+    consolidate : bool, default False
+        Re-consolidate metadata at root (and at the data group). Off by
+        default because (a) bowser opens every store with
+        ``consolidated=False`` to work around the aiobotocore ContextVar bug
+        on S3, so ``.zmetadata`` is never read, and (b) zarr v3 hasn't
+        standardized consolidated metadata yet — leaving it on emits a
+        ``ZarrUserWarning`` on every write.
 
     """
     import zarr
@@ -232,7 +242,13 @@ def annotate_store(
     from geozarr_toolkit.helpers.metadata import create_multiscales_layout
 
     # 1. Write spatial:/proj:/zarr_conventions on the data group.
-    ds = xr.open_zarr(path, group=data_group) if data_group else xr.open_zarr(path)
+    # consolidated=False: we don't write .zmetadata (see the consolidate kwarg
+    # above), so asking zarr to look for it just produces a fallback warning.
+    ds = (
+        xr.open_zarr(path, group=data_group, consolidated=False)
+        if data_group
+        else xr.open_zarr(path, consolidated=False)
+    )
     crs = resolve_crs(ds)
     ds = ds.rio.write_crs(crs)
 
@@ -277,6 +293,8 @@ def build_pyramid(
     max_levels: int = 6,
     chunk: int = DEFAULT_CHUNK,
     shard_factor: int = DEFAULT_SHARD_FACTOR,
+    compression_name: BloscCname = DEFAULT_COMPRESSION_NAME,
+    compression_level: int = DEFAULT_COMPRESSION_LEVEL,
 ) -> list[dict]:
     """Build a coarsened multiscale pyramid for data already written at ``path/level0``.
 
@@ -293,7 +311,7 @@ def build_pyramid(
         ``multiscales.layout`` entries ready to hand to ``annotate_store``.
 
     """
-    ds = xr.open_zarr(path, group=level0)
+    ds = xr.open_zarr(path, group=level0, consolidated=False)
 
     levels: list[dict[str, Any]] = [{"asset": level0}]
     prev = ds
@@ -324,9 +342,15 @@ def build_pyramid(
         # for coarsened levels, and tile reads would use the wrong affine.
         if "spatial_ref" in coarse.variables:
             coarse["spatial_ref"].attrs.pop("GeoTransform", None)
-        encoding = shard_encoding(coarse, chunk=chunk, shard_factor=shard_factor)
+        encoding = shard_encoding(
+            coarse,
+            chunk=chunk,
+            shard_factor=shard_factor,
+            compression_name=compression_name,
+            compression_level=compression_level,
+        )
         coarse.to_zarr(
-            path, group=str(i), mode="w", consolidated=True, encoding=encoding
+            path, group=str(i), mode="w", consolidated=False, encoding=encoding
         )
         levels.append(
             {

--- a/src/bowser/geozarr.py
+++ b/src/bowser/geozarr.py
@@ -18,6 +18,7 @@ import logging
 from pathlib import Path
 from typing import Any, Literal
 
+import numpy as np
 import xarray as xr
 from rasterio.crs import CRS
 
@@ -287,6 +288,57 @@ def annotate_store(
             zarr.consolidate_metadata(str(path), path=data_group)
 
 
+def _coarsen_2x2_numpy(ds: xr.Dataset) -> xr.Dataset:
+    """Coarsen every (..., y, x) variable by 2×2 mean, in pure numpy.
+
+    A pyramidal write step needs roughly 1 s of real work per level (reshape
+    + mean + compress). Doing it via ``xr.Dataset.coarsen().mean()`` is
+    ~100× slower in practice because coarsen is lazy and defers to dask,
+    which rebuilds a graph referencing the previous level's on-disk zarr
+    and re-traverses it every level. This helper assumes every spatial
+    variable has dims ending in ``(y, x)`` (the converter's output layout)
+    and does the whole level in-memory.
+    """
+    assert "y" in ds.dims and "x" in ds.dims, "expected y/x dims on the dataset"
+    new_vars: dict[str, xr.DataArray] = {}
+    for name, da in ds.data_vars.items():
+        if "y" not in da.dims or "x" not in da.dims:
+            # Non-spatial var (e.g. scalar spatial_ref), carry over unchanged.
+            new_vars[str(name)] = da
+            continue
+        assert da.dims[-2:] == (
+            "y",
+            "x",
+        ), f"{name}: expected dims to end in (y, x), got {da.dims}"
+        arr = np.asarray(da.values)
+        ny = (arr.shape[-2] // 2) * 2
+        nx = (arr.shape[-1] // 2) * 2
+        arr = arr[..., :ny, :nx]
+        # Reshape last two axes to (ny//2, 2, nx//2, 2), mean the two "2" axes.
+        reshaped = arr.reshape(arr.shape[:-2] + (ny // 2, 2, nx // 2, 2))
+        # Upcast int → float for the mean so we don't truncate silently; cast
+        # back at the end to preserve the original dtype on disk.
+        coarse = reshaped.mean(axis=(-3, -1), dtype=np.float32).astype(
+            arr.dtype, copy=False
+        )
+        new_vars[str(name)] = xr.DataArray(coarse, dims=da.dims, attrs=dict(da.attrs))
+
+    y_old = np.asarray(ds.y.values)
+    x_old = np.asarray(ds.x.values)
+    ny = (len(y_old) // 2) * 2
+    nx = (len(x_old) // 2) * 2
+    y_new = y_old[:ny].reshape(-1, 2).mean(axis=1)
+    x_new = x_old[:nx].reshape(-1, 2).mean(axis=1)
+
+    coords: dict[str, Any] = {"y": y_new, "x": x_new}
+    for cname, c in ds.coords.items():
+        if cname in ("y", "x"):
+            continue
+        coords[str(cname)] = c
+
+    return xr.Dataset(new_vars, coords=coords, attrs=dict(ds.attrs))
+
+
 def build_pyramid(
     path: str | Path,
     *,
@@ -297,15 +349,36 @@ def build_pyramid(
     shard_factor: int = DEFAULT_SHARD_FACTOR,
     compression_name: BloscCname = DEFAULT_COMPRESSION_NAME,
     compression_level: int = DEFAULT_COMPRESSION_LEVEL,
+    level_0_ds: xr.Dataset | None = None,
 ) -> list[dict]:
     """Build a coarsened multiscale pyramid for data already written at ``path/level0``.
 
     Writes sibling subgroups ``"1"``, ``"2"``, … each at 2× coarser spatial
     resolution than the previous, stopping when ``min(y, x) < min_size`` or
-    after ``max_levels`` levels. Uses mean resampling across both spatial dims.
+    after ``max_levels`` levels. Uses 2×2 mean resampling in numpy — see
+    ``_coarsen_2x2_numpy`` for why we sidestep xarray's lazy coarsen.
+
     Every level is written with the same chunk + shard encoding as level 0
     (see ``shard_encoding``), so pyramid levels don't undo the small-file
     consolidation won by sharding.
+
+    Parameters
+    ----------
+    path : str or Path
+        Zarr store path. Level-0 data must already exist at ``path/<level0>``.
+    level0 : str
+        Subgroup name where level-0 data lives.
+    min_size : int
+        Stop building once either spatial dim drops below this.
+    max_levels : int
+        Safety cap on the number of coarsened levels.
+    chunk, shard_factor, compression_name, compression_level
+        Forwarded to ``shard_encoding`` for every written level.
+    level_0_ds : xr.Dataset, optional
+        If provided, used as the starting point instead of re-reading level
+        0 from disk. The converter passes its in-memory numpy-backed
+        Dataset directly — saves both the disk read and the full dask
+        re-traversal that the old implementation did on every pyramid level.
 
     Returns
     -------
@@ -313,7 +386,12 @@ def build_pyramid(
         ``multiscales.layout`` entries ready to hand to ``annotate_store``.
 
     """
-    ds = xr.open_zarr(path, group=level0, consolidated=False)
+    if level_0_ds is not None:
+        ds = level_0_ds
+    else:
+        # Eagerly load — we're about to traverse the whole thing multiple
+        # times for mean-coarsen, and 4 GB fits in RAM on any dev machine.
+        ds = xr.open_zarr(path, group=level0, consolidated=False).load()
 
     levels: list[dict[str, Any]] = [{"asset": level0}]
     prev = ds
@@ -323,27 +401,16 @@ def build_pyramid(
         if y_sz < min_size or x_sz < min_size:
             break
         logger.info("Coarsening level %d → %d × %d (y × x)", i, y_sz, x_sz)
-        coarse = prev.coarsen({"y": 2, "x": 2}, boundary="trim").mean()
-        # Rechunk to the shard shape before writing — dask chunks must be
-        # whole shards for the zarr sharding codec to accept the write.
-        shard = chunk * shard_factor
-        rechunk_sizes: dict[str, int] = {
-            "y": min(shard, coarse.sizes["y"]),
-            "x": min(shard, coarse.sizes["x"]),
-        }
-        for d in coarse.dims:
-            if d not in rechunk_sizes:
-                rechunk_sizes[str(d)] = shard_factor
-        coarse = coarse.chunk(rechunk_sizes)
-        # Strip inherited encoding — chunk hints carried over from /0 will
-        # conflict with the newly-sized arrays on /1+.
-        for v in list(coarse.variables):
-            coarse[v].encoding.clear()
+        coarse = _coarsen_2x2_numpy(prev)
         # Drop the stale GeoTransform attribute carried over from level 0; if
         # we left it, rioxarray would report the original full-res pixel size
         # for coarsened levels, and tile reads would use the wrong affine.
         if "spatial_ref" in coarse.variables:
             coarse["spatial_ref"].attrs.pop("GeoTransform", None)
+        # Clear any inherited encoding hints that would conflict with the
+        # freshly-shaped arrays.
+        for v in list(coarse.variables):
+            coarse[v].encoding.clear()
         encoding = shard_encoding(
             coarse,
             chunk=chunk,

--- a/src/bowser/geozarr.py
+++ b/src/bowser/geozarr.py
@@ -15,6 +15,8 @@ References
 from __future__ import annotations
 
 import logging
+import warnings
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
@@ -31,6 +33,7 @@ __all__ = [
     "data_group_name",
     "load_pyramid_levels",
     "shard_encoding",
+    "ZarrWriteConfig",
 ]
 
 # Defaults tuned for DISP-S1-sized cubes on S3: 256×256 chunks keep random-access
@@ -49,7 +52,56 @@ DEFAULT_SHARD_FACTOR = 4
 DEFAULT_COMPRESSION_NAME: "BloscCname" = "lz4"
 DEFAULT_COMPRESSION_LEVEL = 5
 
+# Default quantize targets: variables whose values are inherently noisy and
+# carry only a few bits of real information per sample (coherence-like
+# quality layers). Quantize zeroes low mantissa bits before compression —
+# adjacent pixels then share more bit patterns, so Blosc finds longer runs.
+# On DISP-S1 temporal coherence the on-disk size drops ~40% with no
+# visual or analytic impact on the ~1 bit of real signal per pixel.
+DEFAULT_QUANTIZE_PATTERNS: tuple[str, ...] = (
+    "coherence",
+    "similarity",
+    "dispersion",
+)
+
 logger = logging.getLogger("bowser")
+
+
+@dataclass(frozen=True)
+class ZarrWriteConfig:
+    """Encoding knobs for a sharded zarr v3 write.
+
+    Bundles the chunk / shard / compression / quantize parameters that
+    ``shard_encoding`` and ``build_pyramid`` both consume. Construct one at
+    CLI-parse time and hand it around — saves threading six kwargs through
+    every call site.
+
+    Attributes
+    ----------
+    chunk : int
+        Square chunk edge (pixels) along y and x.
+    shard_factor : int
+        Shard shape = chunk × factor on every dim. 1 disables sharding.
+    compression_name, compression_level : str, int
+        Blosc sub-codec and clevel.
+    quantize_digits : int or None
+        If set, matching float variables get a ``Quantize`` filter before
+        compression that rounds to this many significant digits. ``None``
+        means no quantization.
+    quantize_patterns : tuple of str
+        Substring patterns matched against variable names (case-insensitive)
+        to decide whether a variable gets the quantize filter. Integer-dtype
+        variables are always skipped regardless of name.
+    """
+
+    chunk: int = DEFAULT_CHUNK
+    shard_factor: int = DEFAULT_SHARD_FACTOR
+    compression_name: BloscCname = DEFAULT_COMPRESSION_NAME
+    compression_level: int = DEFAULT_COMPRESSION_LEVEL
+    quantize_digits: int | None = None
+    quantize_patterns: tuple[str, ...] = field(
+        default_factory=lambda: DEFAULT_QUANTIZE_PATTERNS
+    )
 
 
 def resolve_crs(ds: xr.Dataset) -> CRS:
@@ -88,32 +140,28 @@ def resolve_crs(ds: xr.Dataset) -> CRS:
 
 def shard_encoding(
     ds: xr.Dataset,
-    *,
-    chunk: int = DEFAULT_CHUNK,
-    shard_factor: int = DEFAULT_SHARD_FACTOR,
-    compression_name: BloscCname = DEFAULT_COMPRESSION_NAME,
-    compression_level: int = DEFAULT_COMPRESSION_LEVEL,
+    config: ZarrWriteConfig | None = None,
 ) -> dict[str, dict]:
     """Build per-variable ``encoding`` dict with chunks + shards + compression.
 
     Produces a zarr v3 encoding dict ready to hand to
-    ``xr.Dataset.to_zarr(..., encoding=...)``. Every spatial data variable gets:
+    ``xr.Dataset.to_zarr(..., encoding=...)``. Every spatial data variable
+    gets:
 
-    - ``chunks`` = 1 on non-spatial dims, ``chunk`` on y/x
-    - ``shards`` = chunks × ``shard_factor`` on every dim
-    - ``compressors`` = one ``BloscCodec`` with ``zstd``
+    - ``chunks`` = 1 on non-spatial dims, ``config.chunk`` on y/x
+    - ``shards`` = chunks × ``config.shard_factor`` on every dim (when > 1)
+    - ``filters`` = one ``Quantize`` codec if the variable name matches a
+      configured pattern and the dtype is floating-point
+    - ``compressors`` = one ``BloscCodec``
 
     Parameters
     ----------
     ds : xr.Dataset
         Dataset whose data_vars will be written. Variables with ndim < 2 are
         skipped (chunks/shards only make sense for gridded arrays).
-    chunk : int
-        Edge length of a chunk along the y and x dims, in pixels.
-    shard_factor : int
-        Multiplier from chunk → shard shape, applied to every dim.
-    compression_name, compression_level : str, int
-        Blosc sub-codec and compression level (1–9).
+    config : ZarrWriteConfig, optional
+        Encoding knobs. Defaults to ``ZarrWriteConfig()`` (chunks=256,
+        shard_factor=4, Blosc/lz4/5, no quantization).
 
     Returns
     -------
@@ -123,7 +171,8 @@ def shard_encoding(
     """
     from zarr.codecs import BloscCodec  # noqa: PLC0415 — optional runtime dep
 
-    assert chunk >= 1 and shard_factor >= 1
+    cfg = config or ZarrWriteConfig()
+    assert cfg.chunk >= 1 and cfg.shard_factor >= 1
     encoding: dict[str, dict] = {}
     for name, da in ds.data_vars.items():
         if da.ndim < 2:
@@ -132,23 +181,45 @@ def shard_encoding(
         # requires a set CRS and fails on freshly-opened coarsened levels
         # inside build_pyramid.
         chunks = tuple(
-            min(chunk, da.sizes[d]) if d in ("x", "y") else 1 for d in da.dims
+            min(cfg.chunk, da.sizes[d]) if d in ("x", "y") else 1 for d in da.dims
         )
         var_enc: dict = {
             "chunks": chunks,
             "compressors": [
-                BloscCodec(cname=compression_name, clevel=compression_level)
+                BloscCodec(cname=cfg.compression_name, clevel=cfg.compression_level)
             ],
         }
+        quantize = _quantize_codec_for(str(name), da.dtype, cfg)
+        if quantize is not None:
+            var_enc["filters"] = [quantize]
         # shard_factor=1 means "don't wrap chunks in a shard" — dask chunks can
         # stay small, each dask task writes exactly one chunk, parallelism is
         # maximum. Useful when write time dominates (local disk, small cubes).
-        if shard_factor > 1:
-            shards = tuple(c * shard_factor for c in chunks)
+        if cfg.shard_factor > 1:
+            shards = tuple(c * cfg.shard_factor for c in chunks)
             assert all(s % c == 0 for s, c in zip(shards, chunks))
             var_enc["shards"] = shards
         encoding[str(name)] = var_enc
     return encoding
+
+
+def _quantize_codec_for(name: str, dtype: np.dtype, cfg: ZarrWriteConfig):
+    """Return a ``Quantize`` codec for this variable, or ``None`` to skip.
+
+    Integer dtypes always skip (quantize is a float-only codec). Floats are
+    quantized when ``cfg.quantize_digits`` is set and the variable name
+    contains any of ``cfg.quantize_patterns`` (case-insensitive).
+    """
+    if cfg.quantize_digits is None:
+        return None
+    if not np.issubdtype(dtype, np.floating):
+        return None
+    lname = name.lower()
+    if not any(pat.lower() in lname for pat in cfg.quantize_patterns):
+        return None
+    from zarr.codecs.numcodecs import Quantize  # noqa: PLC0415 — optional dep
+
+    return Quantize(digits=cfg.quantize_digits, dtype=str(dtype))
 
 
 def _multiscales_layout(path: str | Path) -> list[dict] | None:
@@ -316,11 +387,26 @@ def _coarsen_2x2_numpy(ds: xr.Dataset) -> xr.Dataset:
         arr = arr[..., :ny, :nx]
         # Reshape last two axes to (ny//2, 2, nx//2, 2), mean the two "2" axes.
         reshaped = arr.reshape(arr.shape[:-2] + (ny // 2, 2, nx // 2, 2))
-        # Upcast int → float for the mean so we don't truncate silently; cast
-        # back at the end to preserve the original dtype on disk.
-        coarse = reshaped.mean(axis=(-3, -1), dtype=np.float32).astype(
-            arr.dtype, copy=False
-        )
+        if np.issubdtype(arr.dtype, np.floating):
+            # nanmean rather than mean: plain mean propagates NaN so any 2×2
+            # block touching a NaN becomes NaN and the coarsened tile is
+            # effectively masked out (visible as black/transparent tiles at
+            # zoom). Coherence-like masked layers have enough NaNs that
+            # propagating them destroys the pyramid. All-NaN blocks
+            # legitimately stay NaN; suppress the RuntimeWarning those raise.
+            with np.errstate(invalid="ignore"), warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", r"Mean of empty slice", RuntimeWarning
+                )
+                coarse = np.nanmean(reshaped, axis=(-3, -1), dtype=np.float32).astype(
+                    arr.dtype, copy=False
+                )
+        else:
+            # Integer dtypes don't have NaN; use plain mean. Cast back to
+            # original dtype after (mean upcasts to float64 otherwise).
+            coarse = reshaped.mean(axis=(-3, -1), dtype=np.float32).astype(
+                arr.dtype, copy=False
+            )
         new_vars[str(name)] = xr.DataArray(coarse, dims=da.dims, attrs=dict(da.attrs))
 
     y_old = np.asarray(ds.y.values)
@@ -345,10 +431,7 @@ def build_pyramid(
     level0: str = "0",
     min_size: int = 256,
     max_levels: int = 6,
-    chunk: int = DEFAULT_CHUNK,
-    shard_factor: int = DEFAULT_SHARD_FACTOR,
-    compression_name: BloscCname = DEFAULT_COMPRESSION_NAME,
-    compression_level: int = DEFAULT_COMPRESSION_LEVEL,
+    config: ZarrWriteConfig | None = None,
     level_0_ds: xr.Dataset | None = None,
 ) -> list[dict]:
     """Build a coarsened multiscale pyramid for data already written at ``path/level0``.
@@ -372,8 +455,8 @@ def build_pyramid(
         Stop building once either spatial dim drops below this.
     max_levels : int
         Safety cap on the number of coarsened levels.
-    chunk, shard_factor, compression_name, compression_level
-        Forwarded to ``shard_encoding`` for every written level.
+    config : ZarrWriteConfig, optional
+        Encoding config forwarded to ``shard_encoding`` for every level.
     level_0_ds : xr.Dataset, optional
         If provided, used as the starting point instead of re-reading level
         0 from disk. The converter passes its in-memory numpy-backed
@@ -386,6 +469,7 @@ def build_pyramid(
         ``multiscales.layout`` entries ready to hand to ``annotate_store``.
 
     """
+    cfg = config or ZarrWriteConfig()
     if level_0_ds is not None:
         ds = level_0_ds
     else:
@@ -411,13 +495,7 @@ def build_pyramid(
         # freshly-shaped arrays.
         for v in list(coarse.variables):
             coarse[v].encoding.clear()
-        encoding = shard_encoding(
-            coarse,
-            chunk=chunk,
-            shard_factor=shard_factor,
-            compression_name=compression_name,
-            compression_level=compression_level,
-        )
+        encoding = shard_encoding(coarse, cfg)
         coarse.to_zarr(
             path, group=str(i), mode="w", consolidated=False, encoding=encoding
         )


### PR DESCRIPTION
## Summary

- Adds `shard_encoding(ds, chunk=256, shard_factor=4)` helper in `bowser.geozarr` — produces zarr-v3 encoding with chunks `(1, 256, 256)`, shards `(4, 1024, 1024)`, and Blosc/zstd compression for every spatial variable.
- Wired through both `scripts/tifs_to_geozarr.py` (level-0 write) and `geozarr.build_pyramid` (every coarsened level), so the pyramid doesn't re-introduce the small-file explosion that sharding solves.
- CLI: `--chunk-x`/`--chunk-y` → `--chunk` (single scalar, square) + `--shard-factor`.

## Why

Our DISP-S1 demo cube is 2.8 GB; unsharded it would be tens of thousands of small chunk files on S3 — every tile render becomes a burst of LIST+GET calls. Matches the layout used in [opera-utils `_reformat.py`](https://github.com/opera-adt/opera-utils/blob/main/src/opera_utils/disp/_reformat.py#L464) with one tweak: shard factor is 4 on *every* dim (including time/pair), not just y/x, so timeseries `/point` reads bundle 4 timesteps per HTTP GET.

## Measured

On a 10-pair × 2048² test cube (`/tmp/bowser_shard_big`):

| Level | Shape | Chunks | Shards | Files on disk |
|---|---|---|---|---|
| 0 | (10, 2048, 2048) | (1, 256, 256) | (4, 1024, 1024) | **12** (was ~640 unsharded) |
| 1 | (10, 1024, 1024) | (1, 256, 256) | (4, 1024, 1024) | 3 |
| 2 | (10, 512, 512) | (1, 256, 256) | (4, 1024, 1024) | 3 |
| 3 | (10, 256, 256) | (1, 256, 256) | (4, 1024, 1024) | 3 |

Round-trip read via `xr.open_zarr` verified — coords and all GeoZarr `spatial:` / `proj:` / `multiscales` attrs intact.

## Test plan

- [x] Unit converter run on 3-pair fixture → `--pyramid` produces /0 /1 /2, all with expected chunks/shards.
- [x] Round-trip `xr.open_zarr(...)` decodes `pair_unwrapped`, `reference_date_*`, `secondary_date_*` coords and reads a pixel.
- [ ] Re-upload a real DISP-S1 cube to S3 and time a cold-cache tile render vs. the current unsharded cube.
- [ ] Verify `/point` timeseries latency on a shard-aligned coordinate.

## Stack position

Sits on top of `geozarr-docs` (#31). Review bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)