### PR TITLE
README: pixi-based setup + GeoZarr quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,32 @@ server and rendered by titiler in the browser.
 
 ## Quickstart
 
-1. Install [`pixi`](https://pixi.sh).
-2. `pixi global install bowser-insar`
-3. Point it at a GeoZarr cube:
-   ```bash
-   bowser run --stack-file example-cube.zarr
-   ```
+Zero-install — run the latest release against a GeoZarr cube:
+
+```bash
+uvx --from bowser-insar bowser run --stack-file example-cube.zarr
+```
 
 Open the `http://127.0.0.1:8000` link that bowser prints.
 
+> **Heads up — GDAL drivers.** The PyPI wheel is enough for GeoZarr cubes
+> and plain GeoTIFFs. For NetCDF/HDF5 inputs (DISP-S1 `.nc`, the VRT
+> legacy path) install the conda-forge build of GDAL — the `gdal` PyPI
+> package has no wheels and rasterio's bundled GDAL doesn't ship those
+> drivers. `pixi` is the easiest way:
+>
+> ```bash
+> pixi global install bowser-insar
+> ```
+
 ## Install in another project
 
-`pixi` is the supported path because bowser reads a few formats (NetCDF,
-HDF5) that need the conda-forge build of GDAL — the `gdal` PyPI package
-has no wheels, and rasterio's bundled GDAL doesn't include those drivers.
-
 ```bash
-# Recommended: full GDAL via conda-forge
-pixi add bowser-insar
+# GeoZarr / GeoTIFF only
+pip install bowser-insar       # or: uv add bowser-insar
 
-# pip works for the pure GeoZarr / GeoTIFF workflow only
-pip install bowser-insar
+# Full format support (NetCDF, HDF5, VRT) via conda-forge GDAL
+pixi add bowser-insar
 ```
 
 ## Quickstart: dolphin workflow

--- a/README.md
+++ b/README.md
@@ -1,164 +1,143 @@
 # Bowser
 
-## Quickstart
-
-1. Install [`uv`](https://docs.astral.sh/uv/#installation)
-2. Run `uvx --with bowser-insar --stack-file example-stack.zarr`
+Map-based viewer for InSAR time-series outputs — GeoZarr cubes, dolphin
+workflow directories, or loose GeoTIFFs — served through a local FastAPI
+server and rendered by titiler in the browser.
 
 ![](docs/demo-timeseries.jpg)
 
-## Install
+## Quickstart
+
+1. Install [`pixi`](https://pixi.sh).
+2. `pixi global install bowser-insar`
+3. Point it at a GeoZarr cube:
+   ```bash
+   bowser run --stack-file example-cube.zarr
+   ```
+
+Open the `http://127.0.0.1:8000` link that bowser prints.
+
+## Install in another project
+
+`pixi` is the supported path because bowser reads a few formats (NetCDF,
+HDF5) that need the conda-forge build of GDAL — the `gdal` PyPI package
+has no wheels, and rasterio's bundled GDAL doesn't include those drivers.
 
 ```bash
-pip install bowser-insar`
+# Recommended: full GDAL via conda-forge
+pixi add bowser-insar
+
+# pip works for the pure GeoZarr / GeoTIFF workflow only
+pip install bowser-insar
 ```
+
+## Quickstart: dolphin workflow
+
+`bowser setup-dolphin` scans a dolphin work directory and writes a
+`bowser_rasters.json` describing every raster group it finds. `bowser run`
+then serves them.
 
 ```bash
-uv add bowser-insar
+bowser setup-dolphin work/
+bowser run
 ```
 
-For local development, clone and create a conda environment:
-```bash
-git clone git@github.com:opera-adt/bowser.git && cd bowser
-mamba env create
-conda activate bowser-env
-pip install .
-```
-
-## Quickstart for dolphin
-
-- `bowser setup-dolphin` is preconfigured to make a JSON file pointing to the outputs inside `work_directory` of dolphin
-- `bowser run` starts the web server on `localhost`:
-
-```
-$ bowser setup-dolphin work/
-Reading raster metadata: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 236.13it/s]
-Reading raster metadata: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 95.74it/s]
-Reading raster metadata: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 266.77it/s]
-Reading raster metadata: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 100.49it/s]
-Reading raster metadata: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 94.88it/s]
-
-$ bowser run
-INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
-INFO:     Started parent process [99855]
-...
-```
-
-Click on the `http://127.0.0.1:8000` link to open the map.
-
-
-**Note for running over ssh**: you will need to run an ssh command creating a tunnel from your local computer to wherever the `bowser` server is.
-For example, if you machine is `myserver`, you would run in a local terminal
+If you're running over ssh, tunnel the port back to your laptop:
 
 ```bash
 ssh -N -L 8000:localhost:8000 myserver
 ```
 
-after starting the web server.
+## Quickstart: DISP-S1 → GeoZarr cube
+
+The recommended path for DISP-S1 products is to convert them once into a
+single pyramidal GeoZarr cube, then serve that. The converter handles the
+reference-date bookkeeping for `unwrapped`-style pair indices, builds the
+multiscale pyramid, and writes GeoZarr convention attributes so titiler
+can pick the right overview per tile zoom.
+
+```bash
+# 1. prepare per-band GeoTIFFs and a bowser_rasters.json
+bowser setup-disp-s1 /path/to/disp-s1/outputs
+
+# 2. convert to a single sharded GeoZarr cube with pyramid
+pixi run -e writer python scripts/tifs_to_geozarr.py \
+    --pyramid bowser_rasters.json cube.zarr
+
+# 3. serve
+bowser run --stack-file cube.zarr
+```
+
+For a **multi-dataset catalog** (pick from a map of bounding boxes at
+startup) and an **EC2 deployment** serving cubes from a private S3 bucket,
+see [`deploy/README.md`](deploy/README.md) — it covers the
+`bowser register` CLI, the Docker image, and the EC2 bootstrap script
+end-to-end.
 
 ## Running in Jupyter
 
 ```python
 from bowser._widget import make_bowser_widget
 
-# Automatically starts server and creates widget
 widget = make_bowser_widget(rasters_file="bowser_rasters.json")
 widget
 ```
 
-## Quickstart for DISP-S1 NetCDFs
+## CLI Usage
 
-Until GDAL puts work into the NetCDF driver, reading remote HDF5/NetCDF files has very poor support. Additionally, there is no standard overview format as there is with GeoTIFFs, so `titiler` is very unhappy.
+```
+$ bowser --help
+Commands:
+  prepare-amplitude      Convert complex SLC GeoTIFFs to amplitude-in-dB.
+  prepare-disp-s1        Create VRTs pointing into DISP-S1 NetCDFs.
+  prepare-nisar-gunw     Create VRTs pointing into NISAR GUNW NetCDFs.
+  register               Add a dataset entry to a catalog TOML file.
+  run                    Run the web server.
+  set-data               Specify what raster data to use (interactive).
+  setup-aligned-disp-s1  Write bowser_rasters.json for aligned DISP-S1.
+  setup-disp-s1          Write bowser_rasters.json for DISP-S1 outputs.
+  setup-dolphin          Write bowser_rasters.json for a dolphin run.
+  setup-hyp3             Write bowser_rasters.json for HyP3 Gamma.
+  setup-nisar-gunw       Write bowser_rasters.json for NISAR GUNW.
+```
 
-We can get around this to some degree by creating [VRTs](https://gdal.org/drivers/raster/vrt.html) and [making external overviews](https://gdal.org/programs/gdaladdo.html) pointing at these VRTs.
+## Developer setup
 
-1. Download the NetCDFs (hopefully on some server which has fast access to the S3 bucket).
-2. Run `bowser prepare-disp-s1` to create VRT files pointing in the `.nc` files, one per dataset we wish to browse.
-3. Run `bowser setup-disp-s1` to make a JSON file containing all the file metadata, so the browser knows where to look.
-4. `bowser run`
+```bash
+git clone git@github.com:opera-adt/bowser.git && cd bowser
+pixi install            # default env: runtime deps
+pixi install -e writer  # optional env: includes geozarr-toolkit for the converter
+pixi run bowser run
+```
 
-In detail:
+Frontend (TypeScript + Vite):
 
-1. Download
-I use [`s5cmd`](https://github.com/peak/s5cmd) for faster copying, but the `aws` CLI tool works too:
+```bash
+npm install
+npm run build   # rebuilds src/bowser/dist/ after .tsx / CSS changes
+```
+
+`src/bowser/dist/` is checked in so non-frontend users can `pip install`
+without Node.
+
+## Legacy workflows
+
+### DISP-S1 via VRTs (pre-GeoZarr)
+
+The older path is to make a GDAL VRT per NetCDF variable and let bowser
+read through those. This predates `scripts/tifs_to_geozarr.py` and has
+two drawbacks: remote NetCDF/HDF5 reads are slow (no standard overview
+format), and VRTs require a conda-forge GDAL with the NetCDF driver.
+
+Kept working, but prefer the GeoZarr path above for new setups.
 
 ```bash
 mkdir my_disp_files; cd my_disp-files
-s5cmd --numworkers 4 cp 's3://opera-bucket/OPERA_L3_DISP-S1_IW_F11115*/OPERA_L3_DISP-S1_IW_F11115*.nc' .
-```
-
-2. Extract VRTS
-
-```bash
+s5cmd --numworkers 4 cp 's3://opera-bucket/OPERA_L3_DISP-S1_IW_F11115*/*.nc' .
 bowser prepare-disp-s1 -o vrts *.nc
-```
-
-3. Create `bowser_rasters.json` metadata
-
-```bash
 bowser setup-disp-s1 vrts
-```
-
-4. Run
-
-```bash
 bowser run
 ```
-
-If this is on a server instead of your laptop, you'll need (on your laptop)
-
-```
-ssh -N -L 8000:localhost:8000 myserver
-```
-for whatever port pops up after `bowser run`
-
-
-## CLI Usage
-
-```bash
-$ bowser --help
-Usage: bowser [OPTIONS] COMMAND [ARGS]...
-
-  CLI for bowser.
-
-Options:
-  --help  Show this message and exit.
-
-Commands:
-  addo           Add compressed GDAL overviews to files.
-  run            Run the web server.
-  set-data       Specify what raster data to use.
-  setup-dolphin  Set up output data configuration for a dolphin workflow.
-```
-
-To manually specify a raster/set of rasters, use the interactive `bowser set-data`
-
-## Developer Setup
-
-`npm` is used to manage javascript dependencies.
-
-`npm install` will install all dependencies.
-
-### Making changes to the UI
-
-After making `.tsx`, HTML or CSS changes, **you must run** `npm run build` to build the project:
-
-```bash
-$ npm run build
-
-> bowser-js@0.0.0 build
-> tsc && vite build
-
-vite v5.4.19 building for production...
-✓ 391 modules transformed.
-src/bowser/dist/index.html      0.85 kB │ gzip:   0.51 kB
-src/bowser/dist/index.css      25.68 kB │ gzip:   9.13 kB
-src/bowser/dist/index.js    1,086.17 kB │ gzip: 241.12 kB
-```
-
-This updates the `dist` directory, which is served when you run `bowser run ...`.
-
-Currently the `dist/` HTML and CSS files are checked in to git for easier deployment for non-javascript users.
 
 ## License
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -148,7 +148,7 @@ automatically from the expected client tile size.
 
 ---
 
-### 8. titiler doesn't pick pyramid levels by zoom — bowser wraps it
+### 9. titiler doesn't pick pyramid levels by zoom — bowser wraps it
 
 **Where:** `src/bowser/main.py` `XarrayPathDependency` (~L1464); level
 picker in `src/bowser/state.py` `BowserState.dataset_for_tile_zoom`.
@@ -183,6 +183,45 @@ config change (point titiler at the new dependency, delete
 `dataset_for_tile_zoom`). Until then the wrapper works fine.
 
 Related: titiler#1071 (Jan 2025 thread, still open).
+
+---
+
+### 10. `src/bowser/dist/index.js` is checked into git
+
+**Where:** `src/bowser/dist/` — built output of `npm run build` against
+the `src/components/*.tsx` + CSS source.
+
+**What's wrong:** Every frontend PR carries a ~1 MB minified-JS diff on
+top of the actual `.tsx` changes, merge conflicts in `dist/` are common
+on parallel frontend work, and there are two sources of truth — someone
+forgetting to run `npm run build` ships stale JS. The `Rebuild frontend
+bundle` commit recurs in history.
+
+**Why it's here anyway:** pip-installable without needing Node.js on the
+user's machine, simpler Docker image, one-step install. The trade-off
+was pragmatic, not accidental.
+
+**Fix options:**
+
+1. **pixi task + CI build-and-commit.** Add nodejs as a conda-forge dep
+   under a pixi feature, define `pixi run build-frontend`, gitignore
+   `src/bowser/dist/`, and have a GitHub Actions workflow rebuild dist/
+   and commit it on release tags.
+   ```toml
+   [tool.pixi.feature.frontend.dependencies]
+   nodejs = ">=20"
+
+   [tool.pixi.feature.frontend.tasks]
+   build-frontend = "npm ci && npm run build"
+   ```
+2. **Build at wheel-packaging time.** Move dist/ out of git; use
+   `hatch-jupyter-builder` or `setuptools-js-build` so `python -m build`
+   runs `npm run build` before assembling the wheel. Publishes clean
+   wheels, keeps source tree clean. More setup up front, but closest to
+   the modern Python-frontend packaging norm.
+
+Revisit when frontend contribution volume increases or when the next
+`Rebuild frontend bundle` merge conflict costs >30 min.
 
 ---
 


### PR DESCRIPTION
Audit + rewrite of the up-front docs after the #25-#32 stack merged.

## What changed

- **Quickstart leads with `uvx --from bowser-insar bowser run`.** The PyPI wheel is enough for GeoZarr cubes and plain GeoTIFFs — no global install needed. A sidebar note points to pixi for the cases that actually need conda-forge GDAL (NetCDF/HDF5 drivers — the `gdal` PyPI package has no wheels, and rasterio's bundled GDAL doesn't ship those drivers).
- **Dev setup uses pixi.** `environment.yml` still exists in the repo and `mamba env create` still works, but it's drifted from `pyproject.toml` (missing `python-multipart`, `s3fs`, `aiobotocore`, `starlette>=0.40.0,<1.0.0`, `rich`), and the `[tool.pixi.*]` config in `pyproject.toml` is now the source of truth for environments (runtime, `writer`, `widget`, `test`, `all`). Open question: refresh `environment.yml` to match, or delete it?
- **New section: "Quickstart: DISP-S1 → GeoZarr cube"** — covers `scripts/tifs_to_geozarr.py --pyramid` + `bowser run --stack-file`, which is the recommended path post-stack.
- **Pointer to `deploy/README.md`** for the multi-dataset catalog + EC2 story from #26-#29.
- **Refreshed `bowser --help` output** to match the current CLI (`register`, `prepare-amplitude`, `setup-hyp3`, etc. — the stale list was missing these).
- **Legacy workflows section at the bottom** keeps the VRT-over-NetCDF walkthrough but labels it clearly as pre-GeoZarr with a note that it needs conda-forge GDAL.

## Test plan

- [ ] Render the README on GitHub, spot-check that each command is runnable end-to-end
- [ ] `uvx --from bowser-insar bowser run --stack-file <cube.zarr>` on a clean machine
- [ ] `pixi global install bowser-insar` on a clean machine; `bowser run` against a NetCDF-backed stack works
- [ ] `tifs_to_geozarr.py` command shown is the current signature (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)