### PR TITLE
Fix map drift toward the equator on zoom-out

### DIFF
--- a/scripts/tifs_to_geozarr.py
+++ b/scripts/tifs_to_geozarr.py
@@ -83,8 +83,8 @@ def _timed(label: str):
     show_default=True,
     type=click.IntRange(1, 64),
     help=(
-        "Shard shape = chunk × factor on every dim. "
-        "4× bundles 1024×1024 pixel blocks (16 chunks) per shard on y/x and "
+        "Shard shape = chunk x factor on every dim. "
+        "4x bundles 1024x1024 pixel blocks (16 chunks) per shard on y/x and "
         "4 timesteps per shard on non-spatial dims — one HTTP GET per shard. "
         "Set to 1 to disable sharding entirely (fastest local write; more "
         "files on disk)."
@@ -96,7 +96,7 @@ def _timed(label: str):
     show_default=True,
     type=click.Choice(["lz4", "lz4hc", "blosclz", "snappy", "zlib", "zstd"]),
     help=(
-        "Blosc sub-codec. lz4 is ~6× faster than zstd at ~10% worse ratio; "
+        "Blosc sub-codec. lz4 is ~6x faster than zstd at ~10% worse ratio; "
         "zstd clevel 3 is a good middle ground."
     ),
 )
@@ -146,6 +146,16 @@ def _timed(label: str):
     help="Write level-0 data to /0 and build coarsened /1, /2, … overview groups.",
 )
 @click.option(
+    "--los-dir",
+    default=None,
+    type=click.Path(exists=True, file_okay=False),
+    help=(
+        "Directory containing ``heading_angle.json`` and ``los_enu.json`` for the "
+        "stack. When provided, the heading/incidence/ENU values are copied into "
+        "the zarr root attrs so the bowser UI can draw the LOS geometry icon."
+    ),
+)
+@click.option(
     "--min-pyramid-size",
     default=256,
     show_default=True,
@@ -165,6 +175,7 @@ def main(
     workers: int,
     pyramid: bool,
     min_pyramid_size: int,
+    los_dir: str | None,
     verbose: int,
 ) -> None:
     """Convert CONFIG (bowser_rasters.json) into OUTPUT (single zarr store)."""
@@ -230,7 +241,48 @@ def main(
         with _timed("annotate_store"):
             annotate_store(output)
 
+    if los_dir:
+        _write_los_attrs(output, Path(los_dir))
+
     click.echo(f"Wrote {output} with variables: {sorted(lv.name for lv in loaded)}")
+
+
+def _write_los_attrs(zarr_path: str, los_dir: Path) -> None:
+    """Merge ``heading_angle.json`` + ``los_enu.json`` from ``los_dir`` into root attrs.
+
+    Keys written match the DISP-S1 JSON schema so the bowser backend can read
+    them verbatim from ``ds.attrs`` (see ``_los_metadata_from_attrs`` in
+    ``bowser/main.py``).
+    """
+    import zarr  # noqa: PLC0415
+
+    attrs: dict[str, Any] = {}
+    heading = los_dir / "heading_angle.json"
+    if heading.exists():
+        attrs["heading_angle_deg"] = json.loads(heading.read_text())[
+            "heading_angle_deg"
+        ]
+    los = los_dir / "los_enu.json"
+    if los.exists():
+        data = json.loads(los.read_text())
+        attrs["incidence_angle_deg"] = data["incidence_angle_deg"]
+        attrs["los_enu_ground_to_satellite"] = data["los_enu_ground_to_satellite"]
+        # azimuth_angle_deg is present but not used by the UI — copy through anyway
+        if "azimuth_angle_deg" in data:
+            attrs["azimuth_angle_deg"] = data["azimuth_angle_deg"]
+
+    if not attrs:
+        logger.warning("No LOS JSON files found in %s", los_dir)
+        return
+
+    root = zarr.open_group(zarr_path, mode="r+")
+    root.attrs.update(attrs)
+    # Pyramid stores are opened by xarray at the data subgroup (e.g. /0); mirror
+    # the attrs there so ds.attrs sees them regardless of how it's opened.
+    for name in list(root.group_keys()):
+        if name.isdigit():
+            root[name].attrs.update(attrs)
+    logger.info("Stashed LOS metadata in %s: %s", zarr_path, sorted(attrs))
 
 
 @dataclass

--- a/src/bowser/dist/index.js
+++ b/src/bowser/dist/index.js
@@ -7061,7 +7061,8 @@ const initialState = {
   dateRangeStart: null,
   dateRangeEnd: null,
   viewBounds: null,
-  showColorbar: false
+  showColorbar: false,
+  showLosIndicator: false
 };
 function appReducer(state, action) {
   switch (action.type) {
@@ -7230,6 +7231,8 @@ function appReducer(state, action) {
       return { ...state, viewBounds: action.payload };
     case "TOGGLE_COLORBAR":
       return { ...state, showColorbar: !state.showColorbar };
+    case "TOGGLE_LOS_INDICATOR":
+      return { ...state, showLosIndicator: !state.showLosIndicator };
     case "ADD_CHART_WINDOW":
       return { ...state, chartWindows: [...state.chartWindows, action.payload] };
     case "REMOVE_CHART_WINDOW":
@@ -30292,7 +30295,7 @@ function ControlPanel({ title }) {
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Speed" }),
             /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "slider-value", children: [
               (1e3 / state.animationSpeed).toFixed(1),
-              "×"
+              "x"
             ] })
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -30401,6 +30404,17 @@ function ControlPanel({ title }) {
             className: `toggle-pill${state.showColorbar ? " active" : ""}`,
             onClick: () => dispatch({ type: "TOGGLE_COLORBAR" }),
             children: state.showColorbar ? "ON" : "OFF"
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "toggle-row", style: { marginTop: 4 }, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.82em", color: "var(--sb-muted)" }, children: "LOS geometry" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            className: `toggle-pill${state.showLosIndicator ? " active" : ""}`,
+            onClick: () => dispatch({ type: "TOGGLE_LOS_INDICATOR" }),
+            children: state.showLosIndicator ? "ON" : "OFF"
           }
         )
       ] })
@@ -30682,12 +30696,15 @@ function ControlPanel({ title }) {
             onClick: () => {
               const firstDataset = Object.keys(state.datasetInfo)[0];
               const range = datasetRanges[firstDataset];
-              dispatch({ type: "ADD_LAYER_MASK", payload: {
-                id: `mask_${Date.now()}`,
-                dataset: firstDataset,
-                threshold: range ? range.p2 ?? range.min : 0.5,
-                mode: "min"
-              } });
+              dispatch({
+                type: "ADD_LAYER_MASK",
+                payload: {
+                  id: `mask_${Date.now()}`,
+                  dataset: firstDataset,
+                  threshold: range ? range.p2 ?? range.min : 0.5,
+                  mode: "min"
+                }
+              });
             },
             children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: "fa-solid fa-plus", style: { marginRight: 5 } }),
@@ -38795,6 +38812,525 @@ function ColormapBar() {
     }
   );
 }
+const DEG = Math.PI / 180;
+const LOOK_COLOR = "#2E7FE8";
+const FLIGHT_COLOR = "#F39C12";
+const ENU_ASC = { east: -0.615, north: -0.117 };
+const ENU_DESC = { east: 0.615, north: -0.117 };
+function bearing(east, north) {
+  return (Math.atan2(east, north) / DEG + 360) % 360;
+}
+function deriveDirection(heading) {
+  return Math.cos(heading * DEG) > 0 ? "ascending" : "descending";
+}
+function deriveLooking(heading, lookEast, lookNorth) {
+  const fE = Math.sin(heading * DEG);
+  const fN = Math.cos(heading * DEG);
+  const cross = fE * lookNorth - fN * lookEast;
+  return cross > 0 ? "left" : "right";
+}
+function geometryFromMetadata(m2) {
+  const heading = m2.heading_deg;
+  const direction = deriveDirection(heading);
+  const los = m2.los_enu_ground_to_sat;
+  if (!los) {
+    throw new Error("LosMetadata without los_enu_ground_to_sat is unsupported");
+  }
+  const lookE = -los.east;
+  const lookN = -los.north;
+  return {
+    heading,
+    incidence: m2.incidence_deg,
+    incidenceNear: m2.incidence_deg_near,
+    incidenceFar: m2.incidence_deg_far,
+    direction,
+    look: bearing(lookE, lookN),
+    looking: deriveLooking(heading, lookE, lookN)
+  };
+}
+function geometryFromManual(direction, looking, incidence) {
+  const base = direction === "ascending" ? ENU_ASC : ENU_DESC;
+  const east = looking === "right" ? base.east : -base.east;
+  const look = bearing(-east, -base.north);
+  const heading = (look + (looking === "right" ? -90 : 90) + 360) % 360;
+  return { heading, look, incidence, direction, looking };
+}
+function SatelliteGlyph({
+  cx,
+  cy,
+  scale = 1,
+  rotation = 0,
+  color: color2 = "currentColor"
+}) {
+  const bodyW = 5 * scale;
+  const bodyH = 8 * scale;
+  const panelW = 6 * scale;
+  const panelH = 3 * scale;
+  const gap = 0.5 * scale;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("g", { transform: `translate(${cx} ${cy}) rotate(${rotation})`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "rect",
+      {
+        x: -bodyW / 2 - panelW - gap,
+        y: -panelH / 2,
+        width: panelW,
+        height: panelH,
+        fill: color2,
+        stroke: color2,
+        strokeWidth: 0.3
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "rect",
+      {
+        x: bodyW / 2 + gap,
+        y: -panelH / 2,
+        width: panelW,
+        height: panelH,
+        fill: color2,
+        stroke: color2,
+        strokeWidth: 0.3
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: -bodyW / 2 - panelW / 2 - gap,
+        y1: -panelH / 2,
+        x2: -bodyW / 2 - panelW / 2 - gap,
+        y2: panelH / 2,
+        stroke: "white",
+        strokeWidth: 0.5
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: bodyW / 2 + panelW / 2 + gap,
+        y1: -panelH / 2,
+        x2: bodyW / 2 + panelW / 2 + gap,
+        y2: panelH / 2,
+        stroke: "white",
+        strokeWidth: 0.5
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("rect", { x: -bodyW / 2, y: -bodyH / 2, width: bodyW, height: bodyH, fill: color2 })
+  ] });
+}
+function FlightCompass({ geom }) {
+  const size = 110;
+  const cx = size / 2;
+  const cy = size / 2;
+  const r2 = 36;
+  const arrowLen = r2 * 0.82;
+  const lookX = cx + arrowLen * Math.sin(geom.look * DEG);
+  const lookY = cy - arrowLen * Math.cos(geom.look * DEG);
+  const flightX = cx + arrowLen * Math.sin(geom.heading * DEG);
+  const flightY = cy - arrowLen * Math.cos(geom.heading * DEG);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("svg", { width: size, height: size, viewBox: `0 0 ${size} ${size}`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("defs", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "marker",
+        {
+          id: "losArrowLook",
+          viewBox: "0 0 10 10",
+          refX: "8",
+          refY: "5",
+          markerWidth: "5",
+          markerHeight: "5",
+          orient: "auto-start-reverse",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M0,0 L10,5 L0,10 z", fill: LOOK_COLOR })
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "marker",
+        {
+          id: "losArrowFlight",
+          viewBox: "0 0 10 10",
+          refX: "8",
+          refY: "5",
+          markerWidth: "5",
+          markerHeight: "5",
+          orient: "auto-start-reverse",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: "M0,0 L10,5 L0,10 z", fill: FLIGHT_COLOR })
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx, cy, r: r2, fill: "none", stroke: "currentColor", strokeWidth: 1.2 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: cx, y1: cy - r2, x2: cx, y2: cy - r2 + 4, stroke: "currentColor", strokeWidth: 1 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: cx, y1: cy + r2, x2: cx, y2: cy + r2 - 4, stroke: "currentColor", strokeWidth: 1 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: cx - r2, y1: cy, x2: cx - r2 + 4, y2: cy, stroke: "currentColor", strokeWidth: 1 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("line", { x1: cx + r2, y1: cy, x2: cx + r2 - 4, y2: cy, stroke: "currentColor", strokeWidth: 1 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("text", { x: cx, y: cy - r2 - 3, textAnchor: "middle", fontSize: 8, fill: "currentColor", children: "0" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("text", { x: cx + r2 + 3, y: cy + 3, textAnchor: "start", fontSize: 8, fill: "currentColor", children: "90" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("text", { x: cx, y: cy + r2 + 9, textAnchor: "middle", fontSize: 8, fill: "currentColor", children: "180" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("text", { x: cx - r2 - 3, y: cy + 3, textAnchor: "end", fontSize: 8, fill: "currentColor", children: "270" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: cx,
+        y1: cy,
+        x2: flightX,
+        y2: flightY,
+        stroke: FLIGHT_COLOR,
+        strokeWidth: 1.8,
+        markerEnd: "url(#losArrowFlight)"
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SatelliteGlyph, { cx, cy, scale: 1.1, rotation: geom.heading }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: cx,
+        y1: cy,
+        x2: lookX,
+        y2: lookY,
+        stroke: LOOK_COLOR,
+        strokeWidth: 1.8,
+        markerEnd: "url(#losArrowLook)"
+      }
+    )
+  ] });
+}
+function SideView({ geom, showPolarity }) {
+  const w2 = 150;
+  const h = 100;
+  const satX = w2 / 2;
+  const groundY = h - 18;
+  const reachBudget = w2 / 2 - 18;
+  const maxInc = Math.max(geom.incidence, geom.incidenceFar ?? 0);
+  const H2 = Math.min(60, reachBudget / Math.tan(maxInc * DEG));
+  const satY = groundY - H2;
+  const sign2 = Math.sin(geom.look * DEG) >= 0 ? 1 : -1;
+  const tipFor = (incDeg) => satX + sign2 * H2 * Math.tan(incDeg * DEG);
+  const centerTipX = tipFor(geom.incidence);
+  const nearTipX = geom.incidenceNear !== void 0 ? tipFor(geom.incidenceNear) : null;
+  const farTipX = geom.incidenceFar !== void 0 ? tipFor(geom.incidenceFar) : null;
+  const extentX = Math.max(
+    Math.abs(centerTipX - satX),
+    nearTipX !== null ? Math.abs(nearTipX - satX) : 0,
+    farTipX !== null ? Math.abs(farTipX - satX) : 0
+  );
+  const gHalf = Math.max(40, extentX + 18);
+  const gLeft = satX - gHalf;
+  const gRight = satX + gHalf;
+  const arcR = 12;
+  const inc = geom.incidence;
+  const arcStart = 90 * DEG;
+  const arcEnd = (90 + sign2 * inc) * DEG;
+  const gax1 = centerTipX + arcR * Math.cos(arcStart);
+  const gay1 = groundY - arcR * Math.sin(arcStart);
+  const gax2 = centerTipX + arcR * Math.cos(arcEnd);
+  const gay2 = groundY - arcR * Math.sin(arcEnd);
+  const sweep = sign2 > 0 ? 0 : 1;
+  const arcPath = `M ${gax1} ${gay1} A ${arcR} ${arcR} 0 0 ${sweep} ${gax2} ${gay2}`;
+  const midA = (90 + sign2 * inc / 2) * DEG;
+  const labR = arcR + 7;
+  const labX = centerTipX + labR * Math.cos(midA);
+  const labY = groundY - labR * Math.sin(midA) + 3;
+  const incLabel = `${Math.round(inc)}°`;
+  const slantDx = centerTipX - satX;
+  const slantDy = groundY - satY;
+  const slantLen = Math.hypot(slantDx, slantDy);
+  const nx = -slantDy / slantLen;
+  const ny = slantDx / slantLen;
+  const off = 8;
+  const plusX = satX + 0.3 * slantDx + sign2 * off * nx;
+  const plusY = satY + 0.3 * slantDy + sign2 * off * ny;
+  const minusX = satX + 0.75 * slantDx + sign2 * off * nx;
+  const minusY = satY + 0.75 * slantDy + sign2 * off * ny;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("svg", { width: w2, height: h, viewBox: `0 0 ${w2} ${h}`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: gLeft,
+        y1: groundY,
+        x2: gRight,
+        y2: groundY,
+        stroke: "currentColor",
+        strokeWidth: 1.2
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: satX,
+        y1: satY,
+        x2: satX,
+        y2: groundY,
+        stroke: "currentColor",
+        strokeWidth: 0.8,
+        strokeDasharray: "2 2"
+      }
+    ),
+    nearTipX !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: satX,
+        y1: satY,
+        x2: nearTipX,
+        y2: groundY,
+        stroke: LOOK_COLOR,
+        strokeOpacity: 0.55,
+        strokeWidth: 1
+      }
+    ),
+    farTipX !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: satX,
+        y1: satY,
+        x2: farTipX,
+        y2: groundY,
+        stroke: LOOK_COLOR,
+        strokeOpacity: 0.55,
+        strokeWidth: 1
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "line",
+      {
+        x1: satX,
+        y1: satY,
+        x2: centerTipX,
+        y2: groundY,
+        stroke: LOOK_COLOR,
+        strokeWidth: 1.4
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SatelliteGlyph, { cx: satX, cy: satY, scale: 1.2, rotation: 90 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("path", { d: arcPath, fill: "none", stroke: "currentColor", strokeWidth: 0.8 }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("text", { x: labX, y: labY, textAnchor: "middle", fontSize: 9, fill: "currentColor", children: incLabel }),
+    showPolarity && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "text",
+        {
+          x: plusX,
+          y: plusY,
+          textAnchor: "middle",
+          fontSize: 11,
+          fontWeight: "bold",
+          fill: LOOK_COLOR,
+          children: "+"
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "text",
+        {
+          x: minusX,
+          y: minusY,
+          textAnchor: "middle",
+          fontSize: 11,
+          fontWeight: "bold",
+          fill: LOOK_COLOR,
+          children: "−"
+        }
+      )
+    ] })
+  ] });
+}
+function LosIndicator() {
+  const { state, dispatch } = useAppContext();
+  const [manualOn, setManualOn] = reactExports.useState(false);
+  const [direction, setDirection] = reactExports.useState("ascending");
+  const [looking, setLooking] = reactExports.useState("right");
+  const [incidence, setIncidence] = reactExports.useState(37);
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 280,
+    defaultHeight: 210,
+    initialRight: 400,
+    initialBottom: 40,
+    minWidth: 240,
+    minHeight: 180
+  });
+  const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : void 0;
+  const meta = dsInfo == null ? void 0 : dsInfo.los_metadata;
+  const geom = reactExports.useMemo(() => {
+    if (meta) return geometryFromMetadata(meta);
+    if (manualOn) return geometryFromManual(direction, looking, incidence);
+    return null;
+  }, [meta, manualOn, direction, looking, incidence]);
+  const showPolarity = !!(dsInfo == null ? void 0 : dsInfo.uses_spatial_ref);
+  if (!state.showLosIndicator) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      ref: panelRef,
+      style: {
+        ...panelStyle,
+        position: "fixed",
+        background: "var(--sb-surface)",
+        border: "1px solid var(--sb-border)",
+        borderRadius: 10,
+        boxShadow: "0 4px 20px rgba(0,0,0,0.4)",
+        backdropFilter: "blur(8px)",
+        zIndex: 3200,
+        display: "flex",
+        flexDirection: "column",
+        userSelect: "none",
+        color: "var(--sb-text)"
+      },
+      onMouseDown: (e) => e.stopPropagation(),
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            onMouseDown: onDragMouseDown,
+            style: {
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "4px 8px",
+              height: 26,
+              cursor: "grab",
+              borderBottom: "1px solid var(--sb-border)",
+              boxSizing: "border-box"
+            },
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { fontSize: "0.72em", color: "var(--sb-muted)" }, children: "LOS geometry" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  onMouseDown: (e) => e.stopPropagation(),
+                  onClick: () => dispatch({ type: "TOGGLE_LOS_INDICATOR" }),
+                  title: "Close",
+                  style: {
+                    background: "none",
+                    border: "none",
+                    color: "var(--sb-muted)",
+                    cursor: "pointer",
+                    padding: "1px 5px",
+                    fontSize: "0.85em"
+                  },
+                  children: "✕"
+                }
+              )
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { padding: 8, display: "flex", flexDirection: "column", gap: 6 }, children: [
+          geom ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", gap: 8, justifyContent: "space-around", alignItems: "center" }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", flexDirection: "column", alignItems: "center" }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx(FlightCompass, { geom }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { fontSize: "0.7em", marginTop: 2 }, children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { color: LOOK_COLOR }, children: "Look" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { color: "var(--sb-muted)" }, children: [
+                    " ",
+                    geom.look.toFixed(1),
+                    "°"
+                  ] }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { color: "var(--sb-muted)" }, children: " · " }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { style: { color: FLIGHT_COLOR }, children: "Flight" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { style: { color: "var(--sb-muted)" }, children: [
+                    " ",
+                    geom.heading.toFixed(1),
+                    "°"
+                  ] })
+                ] })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", flexDirection: "column", alignItems: "center" }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SideView, { geom, showPolarity }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { fontSize: "0.7em", color: "var(--sb-muted)", marginTop: 2 }, children: [
+                  "Incidence ",
+                  geom.incidenceNear !== void 0 && geom.incidenceFar !== void 0 ? `${geom.incidenceNear.toFixed(1)}°–${geom.incidenceFar.toFixed(1)}°` : `${geom.incidence.toFixed(1)}°`
+                ] })
+              ] })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: {
+              fontSize: "0.72em",
+              textAlign: "center",
+              borderTop: "1px solid var(--sb-border)",
+              paddingTop: 4,
+              textTransform: "capitalize"
+            }, children: [
+              geom.direction,
+              " · ",
+              geom.looking,
+              "-looking"
+            ] })
+          ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { textAlign: "center", padding: "8px 4px" }, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { style: { fontSize: "0.78em", color: "var(--sb-muted)", marginBottom: 8 }, children: "No LOS metadata for this dataset." }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                className: "toggle-pill",
+                style: { fontSize: "0.75em" },
+                onClick: () => setManualOn(true),
+                children: "Enter manually"
+              }
+            )
+          ] }),
+          manualOn && !meta && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { borderTop: "1px solid var(--sb-border)", paddingTop: 6, display: "flex", flexDirection: "column", gap: 4 }, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", gap: 4 }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  className: `toggle-pill${direction === "ascending" ? " active" : ""}`,
+                  style: { flex: 1, justifyContent: "center", fontSize: "0.75em" },
+                  onClick: () => setDirection("ascending"),
+                  children: "Ascending"
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  className: `toggle-pill${direction === "descending" ? " active" : ""}`,
+                  style: { flex: 1, justifyContent: "center", fontSize: "0.75em" },
+                  onClick: () => setDirection("descending"),
+                  children: "Descending"
+                }
+              )
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", gap: 4 }, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  className: `toggle-pill${looking === "right" ? " active" : ""}`,
+                  style: { flex: 1, justifyContent: "center", fontSize: "0.75em" },
+                  onClick: () => setLooking("right"),
+                  children: "Right-looking"
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  className: `toggle-pill${looking === "left" ? " active" : ""}`,
+                  style: { flex: 1, justifyContent: "center", fontSize: "0.75em" },
+                  onClick: () => setLooking("left"),
+                  children: "Left-looking"
+                }
+              )
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { style: { display: "flex", justifyContent: "space-between", fontSize: "0.72em", color: "var(--sb-muted)" }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Incidence" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+                  incidence,
+                  "°"
+                ] })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "range",
+                  min: 15,
+                  max: 60,
+                  step: 1,
+                  value: incidence,
+                  className: "sidebar-range",
+                  onChange: (e) => setIncidence(parseInt(e.target.value)),
+                  onMouseDown: (e) => e.stopPropagation()
+                }
+              )
+            ] })
+          ] })
+        ] }),
+        resizeGrip
+      ]
+    }
+  );
+}
 function AppContent() {
   const { state, dispatch } = useAppContext();
   const { fetchDatasets, fetchDataMode, fetchConfig } = useApi();
@@ -38841,6 +39377,7 @@ function AppContent() {
       /* @__PURE__ */ jsxRuntimeExports.jsx(PointManagerPanel, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(RefPointChart, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(ColormapBar, {}),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(LosIndicator, {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx(ProfileChart, {}),
       state.showChart && state.chartWindows.map((w2) => /* @__PURE__ */ jsxRuntimeExports.jsx(TimeSeriesChart, { windowId: w2.id }, w2.id))
     ] })

--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -268,6 +268,64 @@ def _reference_date(labels: list[str], dim: str) -> str | None:
     return refs.pop() if len(refs) == 1 else None
 
 
+def _los_metadata_from_attrs(attrs: dict) -> dict | None:
+    """Pull LOS metadata from xarray/zarr attrs, returning a JSON-serializable dict.
+
+    Recognizes both the legacy schema (scalar ``incidence_angle_deg`` + flat
+    ``{east, north, up}`` ENU) and the per-swath schema with
+    ``{near, center, far}`` sub-dicts for incidence and ENU.
+    """
+    heading = attrs.get("heading_angle_deg")
+    incidence = attrs.get("incidence_angle_deg")
+    if heading is None or incidence is None:
+        return None
+
+    def _enu_dict(d: Any) -> dict | None:
+        if isinstance(d, dict) and {"east", "north", "up"}.issubset(d):
+            return {
+                "east": float(d["east"]),
+                "north": float(d["north"]),
+                "up": float(d["up"]),
+            }
+        return None
+
+    # Incidence can be a scalar or a {near, center, far} dict.
+    if isinstance(incidence, dict) and "center" in incidence:
+        inc_center = float(incidence["center"])
+        inc_near = float(incidence["near"]) if "near" in incidence else None
+        inc_far = float(incidence["far"]) if "far" in incidence else None
+    else:
+        inc_center = float(incidence)
+        inc_near = inc_far = None
+
+    result: dict = {
+        "heading_deg": float(heading),
+        "incidence_deg": inc_center,
+    }
+    if inc_near is not None:
+        result["incidence_deg_near"] = inc_near
+    if inc_far is not None:
+        result["incidence_deg_far"] = inc_far
+
+    los = attrs.get("los_enu_ground_to_satellite") or attrs.get("los_enu_ground_to_sat")
+    if isinstance(los, dict):
+        if "center" in los:
+            center = _enu_dict(los.get("center"))
+            near = _enu_dict(los.get("near"))
+            far = _enu_dict(los.get("far"))
+            if center is not None:
+                result["los_enu_ground_to_sat"] = center
+            if near is not None:
+                result["los_enu_ground_to_sat_near"] = near
+            if far is not None:
+                result["los_enu_ground_to_sat_far"] = far
+        else:
+            flat = _enu_dict(los)
+            if flat is not None:
+                result["los_enu_ground_to_sat"] = flat
+    return result
+
+
 def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
     """Create dataset info structure from Xarray Dataset."""
     bounds = ds.rio.bounds()
@@ -283,6 +341,7 @@ def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
         f"latlon_bounds: {latlon_bounds}, bounds: {bounds}, ds.rio.crs: {ds.rio.crs}"
     )
 
+    los_metadata = _los_metadata_from_attrs(dict(ds.attrs))
     dataset_info = {}
     skip_spatial_reference = not settings.BOWSER_USE_SPATIAL_REFERENCE_DISP
     for var_name, var in ds.data_vars.items():
@@ -323,6 +382,7 @@ def create_xarray_dataset_info(ds: xr.Dataset) -> dict:
             "available_mask_vars": available_mask_vars,
             "label": attrs.get("long_name", var_name),
             "unit": attrs.get("units", ""),
+            "los_metadata": los_metadata,
         }
 
     return dataset_info
@@ -344,6 +404,9 @@ def create_rastergroup_dataset_info(raster_groups: dict) -> dict:
             "latlon_bounds": list(rg.latlon_bounds),
             "x_values": rg.x_values,
             "reference_date": rg.reference_date,
+            "los_metadata": (
+                rg.los_metadata.model_dump() if rg.los_metadata is not None else None
+            ),
         }
     return dataset_info
 

--- a/src/bowser/state.py
+++ b/src/bowser/state.py
@@ -51,6 +51,7 @@ def _open_md(uri: str) -> tuple[xr.Dataset, Transformer, list["PyramidLevel"]]:
 
     logger.info(f"Loading MD dataset from {uri}")
     levels: list[PyramidLevel] = []
+    root_attrs: dict = {}
     if uri.endswith(".zarr") or "://" in uri:
         group = data_group_name(uri)
         if group is not None:
@@ -58,10 +59,19 @@ def _open_md(uri: str) -> tuple[xr.Dataset, Transformer, list["PyramidLevel"]]:
             px = [round(lv.pixel_size_m, 3) for lv in levels]
             logger.info(f"Pyramid detected: {len(levels)} level(s), px(m): {px}")
             ds = levels[0].dataset
+            # Pyramid data lives in a subgroup; pull in root attrs so metadata
+            # written to the store root (LOS geometry etc) is still visible.
+            import zarr  # noqa: PLC0415
+
+            root_attrs = dict(zarr.open_group(uri, mode="r").attrs)
         else:
             ds = xr.open_zarr(uri, consolidated=False)
     else:
         ds = xr.open_dataset(uri)
+
+    # Root attrs take lower precedence than any attrs already on the opened group.
+    if root_attrs:
+        ds.attrs = {**root_attrs, **ds.attrs}
 
     crs = resolve_crs(ds)
     if "spatial_ref" in ds.variables and "time" in ds.spatial_ref.dims:

--- a/src/bowser/titiler.py
+++ b/src/bowser/titiler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 import os
 from enum import Enum
 from glob import glob
@@ -15,6 +17,8 @@ from titiler.core.algorithm import BaseAlgorithm
 
 from .readers import RasterStackReader
 from .utils import list_bucket
+
+logger = logging.getLogger(__name__)
 
 # TODO: Prep COGS with
 #  for f in `ls ig*[0-9].tif`; do
@@ -98,6 +102,120 @@ class Shift(BaseAlgorithm):
         )
 
 
+class LosEnu(BaseModel):
+    """Ground-to-satellite unit vector in local ENU components."""
+
+    east: float
+    north: float
+    up: float
+
+
+class LosMetadata(BaseModel):
+    """Satellite viewing geometry for an InSAR stack.
+
+    Incidence angle and the ground-to-satellite ENU vector each take three
+    samples across the swath (near/center/far). Near and far are optional;
+    ``center`` is the required reference value. The UI draws near↔far as the
+    swath extent in the side-view icon.
+
+    Attributes
+    ----------
+    heading_deg
+        Ground-track heading, degrees clockwise from geographic north.
+    incidence_deg
+        Center-swath incidence angle (degrees).
+    incidence_deg_near, incidence_deg_far
+        Near-range and far-range incidence angles (degrees).
+    los_enu_ground_to_sat
+        Center-swath unit vector from ground to satellite in local ENU.
+    los_enu_ground_to_sat_near, los_enu_ground_to_sat_far
+        Near-range and far-range ENU vectors.
+    """
+
+    heading_deg: float
+    incidence_deg: float
+    incidence_deg_near: float | None = None
+    incidence_deg_far: float | None = None
+    los_enu_ground_to_sat: LosEnu | None = None
+    los_enu_ground_to_sat_near: LosEnu | None = None
+    los_enu_ground_to_sat_far: LosEnu | None = None
+
+
+def _swath_triple(v: Any) -> tuple[Any, Any, Any]:
+    """Normalize either a scalar/flat-dict or a ``{near, center, far}`` dict.
+
+    Returns ``(center, near, far)``. For the old schema (scalar incidence or
+    flat ENU dict like ``{east, north, up}``), near/far are ``None``. For the
+    new swath schema, pulls the three samples out.
+    """
+    if isinstance(v, dict) and "center" in v:
+        return v["center"], v.get("near"), v.get("far")
+    return v, None, None
+
+
+def load_los_metadata(directory: str | Path) -> LosMetadata | None:
+    """Load LOS metadata from ``heading_angle.json`` and ``los_enu.json``.
+
+    Reads the two JSONs from ``directory``. Accepts both the legacy scalar
+    schema and the new per-swath schema (``{near, center, far}`` for
+    incidence and ENU). Returns ``None`` if neither file exists.
+    """
+    d = Path(directory)
+    if not d.is_dir():
+        return None
+
+    heading_path = d / "heading_angle.json"
+    los_path = d / "los_enu.json"
+
+    if not heading_path.exists() and not los_path.exists():
+        return None
+
+    heading_deg: float | None = None
+    if heading_path.exists():
+        with heading_path.open() as f:
+            heading_deg = json.load(f)["heading_angle_deg"]
+
+    incidence_center: float | None = None
+    incidence_near: float | None = None
+    incidence_far: float | None = None
+    los_center: LosEnu | None = None
+    los_near: LosEnu | None = None
+    los_far: LosEnu | None = None
+
+    if los_path.exists():
+        with los_path.open() as f:
+            data = json.load(f)
+
+        inc_c, inc_n, inc_f = _swath_triple(data["incidence_angle_deg"])
+        incidence_center = float(inc_c)
+        incidence_near = float(inc_n) if inc_n is not None else None
+        incidence_far = float(inc_f) if inc_f is not None else None
+
+        los_c, los_n, los_f = _swath_triple(data["los_enu_ground_to_satellite"])
+        los_center = LosEnu(**los_c)
+        los_near = LosEnu(**los_n) if los_n is not None else None
+        los_far = LosEnu(**los_f) if los_f is not None else None
+
+    if heading_deg is None or incidence_center is None:
+        logger.warning(
+            "Incomplete LOS metadata in %s (heading=%s, incidence=%s) — skipping",
+            d,
+            heading_deg,
+            incidence_center,
+        )
+        return None
+
+    return LosMetadata(
+        heading_deg=heading_deg,
+        incidence_deg=incidence_center,
+        incidence_deg_near=incidence_near,
+        incidence_deg_far=incidence_far,
+        los_enu_ground_to_sat=los_center,
+        los_enu_ground_to_sat_near=los_near,
+        los_enu_ground_to_sat_far=los_far,
+    )
+
+
 class RasterGroup(BaseModel):
     """A group of rasters to view."""
 
@@ -109,6 +227,7 @@ class RasterGroup(BaseModel):
     algorithm: str | None = None
     mask_min_value: float = 0.1
     file_date_fmt: str | None = "%Y%m%d"
+    los_metadata: LosMetadata | None = None
     _reader: RasterStackReader
     _disable_tqdm: bool = True
 
@@ -150,7 +269,7 @@ class RasterGroup(BaseModel):
             return np.arange(len(self.file_list)).tolist()
 
         # For time series plotting, use the last date (secondary/end date)
-        x_values = [k[-1].strftime("%Y-%m-%d") for k in dates]  # type: ignore[misc]
+        x_values = [k[-1].strftime("%Y-%m-%d") for k in dates]  # type: ignore[misc, index]
 
         # If secondary dates have duplicates (e.g., interferograms with varying
         # reference dates), use full "ref_secondary" date pair labels instead.
@@ -165,12 +284,12 @@ class RasterGroup(BaseModel):
 
     @computed_field
     def reference_date(self) -> str | None:
-        """Common reference date if all files share the same first date."""
+        """Return the common reference date when all files share a first date."""
         dates = self._reader.dates
         if not dates or any(not d for d in dates):
             return None
         # Check for multi-date filenames (e.g., interferograms)
-        if not all(len(d) > 1 for d in dates):  # type: ignore[arg-type]
+        if not all(len(d) > 1 for d in dates):  # type: ignore[arg-type, union-attr]
             return None
         first_dates = {d[0] for d in dates}  # type: ignore[index]
         if len(first_dates) == 1:

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,6 +7,7 @@ import TimeSeriesChart from './TimeSeriesChart';
 import PointManagerPanel from './PointManagerPanel';
 import RefPointChart from './RefPointChart';
 import ColormapBar from './ColormapBar';
+import LosIndicator from './LosIndicator';
 import { ProfileProvider, ProfileChart } from './ProfileTool';
 import '../style.css';
 
@@ -65,6 +66,7 @@ function AppContent() {
         <PointManagerPanel />
         <RefPointChart />
         <ColormapBar />
+        <LosIndicator />
         <ProfileChart />
         {state.showChart && state.chartWindows.map(w => (
           <TimeSeriesChart key={w.id} windowId={w.id} />

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -83,7 +83,7 @@ export default function ControlPanel({ title }: { title: string }) {
     const n = parseFloat(draftBounds.n);
     const e = parseFloat(draftBounds.e);
     if ([s, w, n, e].some(isNaN)) return;
-    dispatch({ type: 'SET_VIEW_BOUNDS', payload: [s, w, n, e] });
+    dispatch({ type: 'APPLY_VIEW_BOUNDS', payload: [s, w, n, e] });
   };
 
   useEffect(() => {
@@ -397,7 +397,7 @@ export default function ControlPanel({ title }: { title: string }) {
           {state.currentDataset && state.datasetInfo[state.currentDataset] && (
             <button className="chart-btn" style={{ flex: 1 }} onClick={() => {
               const b = state.datasetInfo[state.currentDataset].latlon_bounds;
-              dispatch({ type: 'SET_VIEW_BOUNDS', payload: [b[1], b[0], b[3], b[2]] });
+              dispatch({ type: 'APPLY_VIEW_BOUNDS', payload: [b[1], b[0], b[3], b[2]] });
             }}>
               <i className="fa-solid fa-arrows-to-circle"></i> Dataset
             </button>

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -133,7 +133,7 @@ export default function ControlPanel({ title }: { title: string }) {
     const info = state.datasetInfo[ds];
     if (!info?.uses_spatial_ref) return;
     setRefValues(ds);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.refBufferEnabled, state.refBufferRadius]);
 
   const commitVmin = useCallback(() => {
@@ -175,7 +175,7 @@ export default function ControlPanel({ title }: { title: string }) {
     dispatch({ type: 'SET_REF_MARKER_POSITION', payload: [lat, lon] });
     const ds = state.currentDataset;
     if (ds && state.datasetInfo[ds]?.uses_spatial_ref) setRefValues(ds);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftRefLat, draftRefLon, state.currentDataset, state.datasetInfo, dispatch]);
 
   const currentDatasetInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : null;
@@ -251,7 +251,7 @@ export default function ControlPanel({ title }: { title: string }) {
                 </button>
                 <div className="slider-label" style={{ marginTop: 4 }}>
                   <span>Speed</span>
-                  <span className="slider-value">{(1000 / state.animationSpeed).toFixed(1)}×</span>
+                  <span className="slider-value">{(1000 / state.animationSpeed).toFixed(1)}x</span>
                 </div>
                 <input type="range" className="sidebar-range"
                   min="100" max="2000" step="100"
@@ -320,6 +320,13 @@ export default function ControlPanel({ title }: { title: string }) {
             className={`toggle-pill${state.showColorbar ? ' active' : ''}`}
             onClick={() => dispatch({ type: 'TOGGLE_COLORBAR' })}
           >{state.showColorbar ? 'ON' : 'OFF'}</button>
+        </div>
+        <div className="toggle-row" style={{ marginTop: 4 }}>
+          <span style={{ fontSize: '0.82em', color: 'var(--sb-muted)' }}>LOS geometry</span>
+          <button
+            className={`toggle-pill${state.showLosIndicator ? ' active' : ''}`}
+            onClick={() => dispatch({ type: 'TOGGLE_LOS_INDICATOR' })}
+          >{state.showLosIndicator ? 'ON' : 'OFF'}</button>
         </div>
       </div>
 
@@ -442,7 +449,7 @@ export default function ControlPanel({ title }: { title: string }) {
           <>
             {state.layerMasks.map(mask => {
               const range = datasetRanges[mask.dataset];
-              const rMin = range?.p2  ?? range?.min ?? 0;
+              const rMin = range?.p2 ?? range?.min ?? 0;
               const rMax = range?.p98 ?? range?.max ?? 1;
               const step = rMax - rMin > 0 ? parseFloat(((rMax - rMin) / 200).toPrecision(2)) : 0.01;
               return (
@@ -503,10 +510,12 @@ export default function ControlPanel({ title }: { title: string }) {
                 onClick={() => {
                   const firstDataset = Object.keys(state.datasetInfo)[0];
                   const range = datasetRanges[firstDataset];
-                  dispatch({ type: 'ADD_LAYER_MASK', payload: {
-                    id: `mask_${Date.now()}`, dataset: firstDataset,
-                    threshold: range ? (range.p2 ?? range.min) : 0.5, mode: 'min',
-                  }});
+                  dispatch({
+                    type: 'ADD_LAYER_MASK', payload: {
+                      id: `mask_${Date.now()}`, dataset: firstDataset,
+                      threshold: range ? (range.p2 ?? range.min) : 0.5, mode: 'min',
+                    }
+                  });
                 }}>
                 <i className="fa-solid fa-plus" style={{ marginRight: 5 }}></i>Add layer mask
               </button>

--- a/src/components/LosIndicator.tsx
+++ b/src/components/LosIndicator.tsx
@@ -1,0 +1,424 @@
+import { useMemo, useState } from 'react';
+import { useAppContext } from '../context/AppContext';
+import { useDraggableResizable } from '../hooks/useDraggableResizable';
+import { LosMetadata } from '../types';
+
+type Direction = 'ascending' | 'descending';
+type Looking = 'right' | 'left';
+
+const DEG = Math.PI / 180;
+
+const LOOK_COLOR = '#2E7FE8';   // blue — satellite look arrow + label
+const FLIGHT_COLOR = '#F39C12'; // orange — flight direction arrow + label
+
+// Canonical Sentinel-1 look vectors used only when the user picks manual mode.
+// Kept for right/left-looking asc/desc; not used as a silent fallback.
+const ENU_ASC = { east: -0.615, north: -0.117 };
+const ENU_DESC = { east: 0.615, north: -0.117 };
+
+interface Geometry {
+  /** Flight bearing, deg clockwise from north */
+  heading: number;
+  /** Look bearing (satellite -> ground, ground-projected), deg clockwise from north */
+  look: number;
+  /** Center-swath incidence angle. */
+  incidence: number;
+  /** Near-range incidence. Optional — absent for the legacy scalar schema. */
+  incidenceNear?: number;
+  /** Far-range incidence. */
+  incidenceFar?: number;
+  direction: Direction;
+  looking: Looking;
+}
+
+function bearing(east: number, north: number): number {
+  return ((Math.atan2(east, north) / DEG) + 360) % 360;
+}
+
+function deriveDirection(heading: number): Direction {
+  return Math.cos(heading * DEG) > 0 ? 'ascending' : 'descending';
+}
+
+function deriveLooking(heading: number, lookEast: number, lookNorth: number): Looking {
+  const fE = Math.sin(heading * DEG);
+  const fN = Math.cos(heading * DEG);
+  const cross = fE * lookNorth - fN * lookEast;
+  return cross > 0 ? 'left' : 'right';
+}
+
+function geometryFromMetadata(m: LosMetadata): Geometry {
+  const heading = m.heading_deg;
+  const direction = deriveDirection(heading);
+  // ENU is required to say anything about the look vector; without it we refuse
+  // to guess (prior behavior silently assumed right-looking).
+  const los = m.los_enu_ground_to_sat;
+  if (!los) {
+    throw new Error('LosMetadata without los_enu_ground_to_sat is unsupported');
+  }
+  const lookE = -los.east;
+  const lookN = -los.north;
+  return {
+    heading,
+    incidence: m.incidence_deg,
+    incidenceNear: m.incidence_deg_near,
+    incidenceFar: m.incidence_deg_far,
+    direction,
+    look: bearing(lookE, lookN),
+    looking: deriveLooking(heading, lookE, lookN),
+  };
+}
+
+function geometryFromManual(direction: Direction, looking: Looking, incidence: number): Geometry {
+  const base = direction === 'ascending' ? ENU_ASC : ENU_DESC;
+  const east = looking === 'right' ? base.east : -base.east;
+  const look = bearing(-east, -base.north);
+  const heading = (look + (looking === 'right' ? -90 : 90) + 360) % 360;
+  return { heading, look, incidence, direction, looking };
+}
+
+/** Satellite glyph: body + two solar panels. Points "up" (north) at rotation=0. */
+function SatelliteGlyph({
+  cx, cy, scale = 1, rotation = 0, color = 'currentColor',
+}: { cx: number; cy: number; scale?: number; rotation?: number; color?: string }) {
+  const bodyW = 5 * scale;
+  const bodyH = 8 * scale;
+  const panelW = 6 * scale;
+  const panelH = 3 * scale;
+  const gap = 0.5 * scale;
+  return (
+    <g transform={`translate(${cx} ${cy}) rotate(${rotation})`}>
+      <rect x={-bodyW / 2 - panelW - gap} y={-panelH / 2} width={panelW} height={panelH}
+        fill={color} stroke={color} strokeWidth={0.3} />
+      <rect x={bodyW / 2 + gap} y={-panelH / 2} width={panelW} height={panelH}
+        fill={color} stroke={color} strokeWidth={0.3} />
+      <line x1={-bodyW / 2 - panelW / 2 - gap} y1={-panelH / 2}
+        x2={-bodyW / 2 - panelW / 2 - gap} y2={panelH / 2}
+        stroke="white" strokeWidth={0.5} />
+      <line x1={bodyW / 2 + panelW / 2 + gap} y1={-panelH / 2}
+        x2={bodyW / 2 + panelW / 2 + gap} y2={panelH / 2}
+        stroke="white" strokeWidth={0.5} />
+      <rect x={-bodyW / 2} y={-bodyH / 2} width={bodyW} height={bodyH} fill={color} />
+    </g>
+  );
+}
+
+/** Flight-direction compass: bearing ticks, satellite, flight + look arrows. */
+function FlightCompass({ geom }: { geom: Geometry }) {
+  const size = 110;
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = 36;
+  const arrowLen = r * 0.82;
+  // Look arrow tip
+  const lookX = cx + arrowLen * Math.sin(geom.look * DEG);
+  const lookY = cy - arrowLen * Math.cos(geom.look * DEG);
+  // Flight arrow tip
+  const flightX = cx + arrowLen * Math.sin(geom.heading * DEG);
+  const flightY = cy - arrowLen * Math.cos(geom.heading * DEG);
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <defs>
+        <marker id="losArrowLook" viewBox="0 0 10 10" refX="8" refY="5"
+          markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill={LOOK_COLOR} />
+        </marker>
+        <marker id="losArrowFlight" viewBox="0 0 10 10" refX="8" refY="5"
+          markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill={FLIGHT_COLOR} />
+        </marker>
+      </defs>
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke="currentColor" strokeWidth={1.2} />
+      <line x1={cx} y1={cy - r} x2={cx} y2={cy - r + 4} stroke="currentColor" strokeWidth={1} />
+      <line x1={cx} y1={cy + r} x2={cx} y2={cy + r - 4} stroke="currentColor" strokeWidth={1} />
+      <line x1={cx - r} y1={cy} x2={cx - r + 4} y2={cy} stroke="currentColor" strokeWidth={1} />
+      <line x1={cx + r} y1={cy} x2={cx + r - 4} y2={cy} stroke="currentColor" strokeWidth={1} />
+      <text x={cx} y={cy - r - 3} textAnchor="middle" fontSize={8} fill="currentColor">0</text>
+      <text x={cx + r + 3} y={cy + 3} textAnchor="start" fontSize={8} fill="currentColor">90</text>
+      <text x={cx} y={cy + r + 9} textAnchor="middle" fontSize={8} fill="currentColor">180</text>
+      <text x={cx - r - 3} y={cy + 3} textAnchor="end" fontSize={8} fill="currentColor">270</text>
+      {/* Flight arrow drawn under the satellite so the body covers the tail. */}
+      <line x1={cx} y1={cy} x2={flightX} y2={flightY}
+        stroke={FLIGHT_COLOR} strokeWidth={1.8} markerEnd="url(#losArrowFlight)" />
+      <SatelliteGlyph cx={cx} cy={cy} scale={1.1} rotation={geom.heading} />
+      <line x1={cx} y1={cy} x2={lookX} y2={lookY}
+        stroke={LOOK_COLOR} strokeWidth={1.8} markerEnd="url(#losArrowLook)" />
+    </svg>
+  );
+}
+
+/**
+ * Side-view incidence diagram. Draws the swath (near + far slants) when the
+ * metadata carries near/far incidence values; falls back to the single center
+ * slant otherwise.
+ *
+ * The incidence-angle arc is drawn at the *ground* end of the center slant —
+ * geometrically, incidence is the angle at the target between local vertical
+ * and the line back to the satellite. Under a flat-earth assumption this
+ * equals the look angle at the sensor, which is what we draw with.
+ */
+function SideView({ geom, showPolarity }: { geom: Geometry; showPolarity: boolean }) {
+  const w = 150;
+  const h = 100;
+  const satX = w / 2;
+  const groundY = h - 18;
+  // Shrink altitude when incidence is steep so the ground tip always leaves
+  // room for the arc label near the viewBox edge. Under a flat-earth diagram
+  // the horizontal reach is H·tan(inc) — cap it to keep the label readable.
+  // The satellite visually sits lower for grazing angles, which matches the
+  // physical intuition too.
+  const reachBudget = w / 2 - 18;
+  const maxInc = Math.max(geom.incidence, geom.incidenceFar ?? 0);
+  const H = Math.min(60, reachBudget / Math.tan(maxInc * DEG));
+  const satY = groundY - H;
+  // Side the look points to: +1 = east half of compass, -1 = west half.
+  const sign = Math.sin(geom.look * DEG) >= 0 ? 1 : -1;
+
+  const tipFor = (incDeg: number) => satX + sign * H * Math.tan(incDeg * DEG);
+  const centerTipX = tipFor(geom.incidence);
+  const nearTipX = geom.incidenceNear !== undefined ? tipFor(geom.incidenceNear) : null;
+  const farTipX = geom.incidenceFar !== undefined ? tipFor(geom.incidenceFar) : null;
+
+  const extentX = Math.max(
+    Math.abs(centerTipX - satX),
+    nearTipX !== null ? Math.abs(nearTipX - satX) : 0,
+    farTipX !== null ? Math.abs(farTipX - satX) : 0,
+  );
+  const gHalf = Math.max(40, extentX + 18);
+  const gLeft = satX - gHalf;
+  const gRight = satX + gHalf;
+
+  // Incidence arc at the ground end of the center slant.
+  // Local vertical at ground = "up" in SVG (math angle 90° → -y). The slant
+  // back to the satellite sits at math angle 90° + sign*incidence.
+  const arcR = 12;
+  const inc = geom.incidence;
+  const arcStart = 90 * DEG;                         // local up
+  const arcEnd = (90 + sign * inc) * DEG;            // toward satellite
+  const gax1 = centerTipX + arcR * Math.cos(arcStart);
+  const gay1 = groundY - arcR * Math.sin(arcStart);
+  const gax2 = centerTipX + arcR * Math.cos(arcEnd);
+  const gay2 = groundY - arcR * Math.sin(arcEnd);
+  // Sweep picks the short arc that stays *inside* the angle (between local up
+  // and the slant). In SVG user units (y-down): sign=+1 → tip right of sat →
+  // toward-sat is at ~10 o'clock of tip → CCW short arc → sweep=0.
+  // sign=-1 → toward-sat at ~2 o'clock → CW short arc → sweep=1.
+  const sweep = sign > 0 ? 0 : 1;
+  const arcPath = `M ${gax1} ${gay1} A ${arcR} ${arcR} 0 0 ${sweep} ${gax2} ${gay2}`;
+  const midA = (90 + sign * inc / 2) * DEG;
+  const labR = arcR + 7;
+  const labX = centerTipX + labR * Math.cos(midA);
+  const labY = groundY - labR * Math.sin(midA) + 3;
+
+  // Keep the in-SVG arc label compact (center value only). The swath range
+  // goes in the caption below the icon.
+  const incLabel = `${Math.round(inc)}°`;
+
+  // +/- along the center slant: + near satellite (toward), − near ground (away).
+  const slantDx = centerTipX - satX;
+  const slantDy = groundY - satY;
+  const slantLen = Math.hypot(slantDx, slantDy);
+  const nx = -slantDy / slantLen;
+  const ny = slantDx / slantLen;
+  const off = 8;
+  const plusX = satX + 0.3 * slantDx + sign * off * nx;
+  const plusY = satY + 0.3 * slantDy + sign * off * ny;
+  const minusX = satX + 0.75 * slantDx + sign * off * nx;
+  const minusY = satY + 0.75 * slantDy + sign * off * ny;
+
+  return (
+    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`}>
+      {/* ground */}
+      <line x1={gLeft} y1={groundY} x2={gRight} y2={groundY}
+        stroke="currentColor" strokeWidth={1.2} />
+      {/* nadir dashed */}
+      <line x1={satX} y1={satY} x2={satX} y2={groundY}
+        stroke="currentColor" strokeWidth={0.8} strokeDasharray="2 2" />
+      {/* swath edges (lighter) */}
+      {nearTipX !== null && (
+        <line x1={satX} y1={satY} x2={nearTipX} y2={groundY}
+          stroke={LOOK_COLOR} strokeOpacity={0.55} strokeWidth={1} />
+      )}
+      {farTipX !== null && (
+        <line x1={satX} y1={satY} x2={farTipX} y2={groundY}
+          stroke={LOOK_COLOR} strokeOpacity={0.55} strokeWidth={1} />
+      )}
+      {/* center slant */}
+      <line x1={satX} y1={satY} x2={centerTipX} y2={groundY}
+        stroke={LOOK_COLOR} strokeWidth={1.4} />
+      {/* satellite */}
+      <SatelliteGlyph cx={satX} cy={satY} scale={1.2} rotation={90} />
+      {/* incidence arc at ground + label */}
+      <path d={arcPath} fill="none" stroke="currentColor" strokeWidth={0.8} />
+      <text x={labX} y={labY} textAnchor="middle" fontSize={9} fill="currentColor">
+        {incLabel}
+      </text>
+      {showPolarity && (
+        <>
+          <text x={plusX} y={plusY} textAnchor="middle" fontSize={11}
+            fontWeight="bold" fill={LOOK_COLOR}>+</text>
+          <text x={minusX} y={minusY} textAnchor="middle" fontSize={11}
+            fontWeight="bold" fill={LOOK_COLOR}>−</text>
+        </>
+      )}
+    </svg>
+  );
+}
+
+export default function LosIndicator() {
+  const { state, dispatch } = useAppContext();
+  const [manualOn, setManualOn] = useState(false);
+  const [direction, setDirection] = useState<Direction>('ascending');
+  const [looking, setLooking] = useState<Looking>('right');
+  const [incidence, setIncidence] = useState(37);
+
+  const { panelRef, panelStyle, onDragMouseDown, resizeGrip } = useDraggableResizable({
+    defaultWidth: 280,
+    defaultHeight: 210,
+    initialRight: 400,
+    initialBottom: 40,
+    minWidth: 240,
+    minHeight: 180,
+  });
+
+  const dsInfo = state.currentDataset ? state.datasetInfo[state.currentDataset] : undefined;
+  const meta = dsInfo?.los_metadata;
+
+  const geom = useMemo<Geometry | null>(() => {
+    if (meta) return geometryFromMetadata(meta);
+    if (manualOn) return geometryFromManual(direction, looking, incidence);
+    return null;
+  }, [meta, manualOn, direction, looking, incidence]);
+
+  // Polarity annotation only makes sense for signed LOS data (displacement,
+  // velocity). Coherence/amplitude have no toward/away meaning.
+  const showPolarity = !!dsInfo?.uses_spatial_ref;
+
+  if (!state.showLosIndicator) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      style={{
+        ...panelStyle,
+        position: 'fixed',
+        background: 'var(--sb-surface)',
+        border: '1px solid var(--sb-border)',
+        borderRadius: 10,
+        boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+        backdropFilter: 'blur(8px)',
+        zIndex: 3200,
+        display: 'flex',
+        flexDirection: 'column',
+        userSelect: 'none',
+        color: 'var(--sb-text)',
+      }}
+      onMouseDown={e => e.stopPropagation()}
+    >
+      <div
+        onMouseDown={onDragMouseDown}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '4px 8px', height: 26, cursor: 'grab',
+          borderBottom: '1px solid var(--sb-border)', boxSizing: 'border-box',
+        }}
+      >
+        <span style={{ fontSize: '0.72em', color: 'var(--sb-muted)' }}>LOS geometry</span>
+        <button
+          onMouseDown={e => e.stopPropagation()}
+          onClick={() => dispatch({ type: 'TOGGLE_LOS_INDICATOR' })}
+          title="Close"
+          style={{
+            background: 'none', border: 'none', color: 'var(--sb-muted)',
+            cursor: 'pointer', padding: '1px 5px', fontSize: '0.85em',
+          }}
+        >✕</button>
+      </div>
+
+      <div style={{ padding: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {geom ? (
+          <>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'space-around', alignItems: 'center' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <FlightCompass geom={geom} />
+                <div style={{ fontSize: '0.7em', marginTop: 2 }}>
+                  <span style={{ color: LOOK_COLOR }}>Look</span>
+                  <span style={{ color: 'var(--sb-muted)' }}> {geom.look.toFixed(1)}°</span>
+                  <span style={{ color: 'var(--sb-muted)' }}> · </span>
+                  <span style={{ color: FLIGHT_COLOR }}>Flight</span>
+                  <span style={{ color: 'var(--sb-muted)' }}> {geom.heading.toFixed(1)}°</span>
+                </div>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <SideView geom={geom} showPolarity={showPolarity} />
+                <div style={{ fontSize: '0.7em', color: 'var(--sb-muted)', marginTop: 2 }}>
+                  Incidence {(geom.incidenceNear !== undefined && geom.incidenceFar !== undefined)
+                    ? `${geom.incidenceNear.toFixed(1)}°–${geom.incidenceFar.toFixed(1)}°`
+                    : `${geom.incidence.toFixed(1)}°`}
+                </div>
+              </div>
+            </div>
+            <div style={{
+              fontSize: '0.72em', textAlign: 'center',
+              borderTop: '1px solid var(--sb-border)', paddingTop: 4,
+              textTransform: 'capitalize',
+            }}>
+              {geom.direction} · {geom.looking}-looking
+            </div>
+          </>
+        ) : (
+          <div style={{ textAlign: 'center', padding: '8px 4px' }}>
+            <div style={{ fontSize: '0.78em', color: 'var(--sb-muted)', marginBottom: 8 }}>
+              No LOS metadata for this dataset.
+            </div>
+            <button
+              className="toggle-pill"
+              style={{ fontSize: '0.75em' }}
+              onClick={() => setManualOn(true)}
+            >Enter manually</button>
+          </div>
+        )}
+
+        {manualOn && !meta && (
+          <div style={{ borderTop: '1px solid var(--sb-border)', paddingTop: 6, display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <div style={{ display: 'flex', gap: 4 }}>
+              <button
+                className={`toggle-pill${direction === 'ascending' ? ' active' : ''}`}
+                style={{ flex: 1, justifyContent: 'center', fontSize: '0.75em' }}
+                onClick={() => setDirection('ascending')}
+              >Ascending</button>
+              <button
+                className={`toggle-pill${direction === 'descending' ? ' active' : ''}`}
+                style={{ flex: 1, justifyContent: 'center', fontSize: '0.75em' }}
+                onClick={() => setDirection('descending')}
+              >Descending</button>
+            </div>
+            <div style={{ display: 'flex', gap: 4 }}>
+              <button
+                className={`toggle-pill${looking === 'right' ? ' active' : ''}`}
+                style={{ flex: 1, justifyContent: 'center', fontSize: '0.75em' }}
+                onClick={() => setLooking('right')}
+              >Right-looking</button>
+              <button
+                className={`toggle-pill${looking === 'left' ? ' active' : ''}`}
+                style={{ flex: 1, justifyContent: 'center', fontSize: '0.75em' }}
+                onClick={() => setLooking('left')}
+              >Left-looking</button>
+            </div>
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.72em', color: 'var(--sb-muted)' }}>
+                <span>Incidence</span><span>{incidence}°</span>
+              </div>
+              <input type="range" min={15} max={60} step={1} value={incidence}
+                className="sidebar-range"
+                onChange={e => setIncidence(parseInt(e.target.value))}
+                onMouseDown={e => e.stopPropagation()} />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {resizeGrip}
+    </div>
+  );
+}

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MapContainer as LeafletMapContainer, TileLayer, Marker, useMapEvents, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -43,33 +43,26 @@ function MapEvents() {
 }
 
 // Syncs map view ↔ state.viewBounds.
-// When viewBounds changes (user edited sidebar), fly to it.
-// When user pans/zooms, update viewBounds in state so sidebar stays in sync.
+// Sidebar Apply / Dataset buttons dispatch APPLY_VIEW_BOUNDS, which bumps
+// viewBoundsApplySeq; this effect flies to the bounds. Plain moveend only
+// dispatches SET_VIEW_BOUNDS (no seq bump), so the map doesn't fly back to
+// itself — that round-trip was drifting the center south on zoom-out because
+// bounds.getCenter() is the arithmetic mean of N/S, not the Mercator center.
 function MapViewController() {
   const { state, dispatch } = useAppContext();
   const map = useMap();
-  const flyingRef = useRef(false);
 
-  // Fly to bounds when state changes (triggered from sidebar "Apply")
   useEffect(() => {
-    if (!state.viewBounds) return;
+    if (!state.viewBounds || state.viewBoundsApplySeq === 0) return;
     const [s, w, n, e] = state.viewBounds;
-    flyingRef.current = true;
     const bounds = L.latLngBounds([[s, w], [n, e]]);
-    const center = bounds.getCenter();
-    // getBoundsZoom with inside=true returns fractional zoom — no integer snapping
     const zoom = map.getBoundsZoom(bounds, true);
-    map.setView(center, zoom, { animate: true });
-    const onEnd = () => { flyingRef.current = false; };
-    map.once('moveend', onEnd);
-    return () => { map.off('moveend', onEnd); };
+    map.setView(bounds.getCenter(), zoom, { animate: true });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.viewBounds]);
+  }, [state.viewBoundsApplySeq]);
 
-  // Update state when user moves map (throttled to moveend only)
   useMapEvents({
     moveend: () => {
-      if (flyingRef.current) return;
       const b = map.getBounds();
       dispatch({
         type: 'SET_VIEW_BOUNDS',

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -52,6 +52,7 @@ const initialState: AppState = {
   dateRangeStart: null,
   dateRangeEnd: null,
   viewBounds: null,
+  viewBoundsApplySeq: 0,
   showColorbar: false,
   showLosIndicator: false,
 };
@@ -238,6 +239,12 @@ function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppSt
       return { ...state, dateRangeEnd: action.payload };
     case 'SET_VIEW_BOUNDS':
       return { ...state, viewBounds: action.payload };
+    case 'APPLY_VIEW_BOUNDS':
+      return {
+        ...state,
+        viewBounds: action.payload,
+        viewBoundsApplySeq: state.viewBoundsApplySeq + 1,
+      };
     case 'TOGGLE_COLORBAR':
       return { ...state, showColorbar: !state.showColorbar };
     case 'TOGGLE_LOS_INDICATOR':

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -53,6 +53,7 @@ const initialState: AppState = {
   dateRangeEnd: null,
   viewBounds: null,
   showColorbar: false,
+  showLosIndicator: false,
 };
 
 function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppState {
@@ -239,6 +240,8 @@ function appReducer(state: AppState, action: AppAction | LegacyAppAction): AppSt
       return { ...state, viewBounds: action.payload };
     case 'TOGGLE_COLORBAR':
       return { ...state, showColorbar: !state.showColorbar };
+    case 'TOGGLE_LOS_INDICATOR':
+      return { ...state, showLosIndicator: !state.showLosIndicator };
     case 'ADD_CHART_WINDOW':
       return { ...state, chartWindows: [...state.chartWindows, action.payload] };
     case 'REMOVE_CHART_WINDOW':

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,12 @@ export interface AppState {
   dateRangeStart: string | null;
   dateRangeEnd: string | null;
   viewBounds: [number, number, number, number] | null; // [south, west, north, east]
+  // Incremented each time the user explicitly applies bounds (sidebar Apply /
+  // Dataset buttons). The map's flyTo effect watches this, not viewBounds
+  // itself — otherwise moveend → SET_VIEW_BOUNDS → effect → setView forms a
+  // loop whose setView re-centers on bounds.getCenter() (arithmetic midpoint
+  // in lat), not the Mercator center, drifting the map toward the equator.
+  viewBoundsApplySeq: number;
   showColorbar: boolean;
   showLosIndicator: boolean;
 }
@@ -151,6 +157,7 @@ export type AppAction =
   | { type: 'SET_DATE_RANGE_START'; payload: string | null }
   | { type: 'SET_DATE_RANGE_END'; payload: string | null }
   | { type: 'SET_VIEW_BOUNDS'; payload: [number, number, number, number] | null }
+  | { type: 'APPLY_VIEW_BOUNDS'; payload: [number, number, number, number] }
   | { type: 'TOGGLE_COLORBAR' }
   | { type: 'TOGGLE_LOS_INDICATOR' }
   | { type: 'ADD_CHART_WINDOW'; payload: ChartWindow }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,17 @@
+export interface LosMetadata {
+  // Satellite ground-track heading, degrees clockwise from north
+  heading_deg: number;
+  // Center-swath incidence angle (degrees). Near/far give the swath extent.
+  incidence_deg: number;
+  incidence_deg_near?: number;
+  incidence_deg_far?: number;
+  // Ground -> satellite ENU unit vectors. Center is the main LOS; near/far
+  // trace the swath and are optional.
+  los_enu_ground_to_sat?: { east: number; north: number; up: number };
+  los_enu_ground_to_sat_near?: { east: number; north: number; up: number };
+  los_enu_ground_to_sat_far?: { east: number; north: number; up: number };
+}
+
 export interface RasterGroup {
   name: string;
   file_list: string[];
@@ -12,6 +26,7 @@ export interface RasterGroup {
   label?: string;
   unit?: string;
   reference_date?: string | null;
+  los_metadata?: LosMetadata;
 }
 
 export interface TimeSeriesPoint {
@@ -93,6 +108,7 @@ export interface AppState {
   dateRangeEnd: string | null;
   viewBounds: [number, number, number, number] | null; // [south, west, north, east]
   showColorbar: boolean;
+  showLosIndicator: boolean;
 }
 
 export type AppAction =
@@ -136,6 +152,7 @@ export type AppAction =
   | { type: 'SET_DATE_RANGE_END'; payload: string | null }
   | { type: 'SET_VIEW_BOUNDS'; payload: [number, number, number, number] | null }
   | { type: 'TOGGLE_COLORBAR' }
+  | { type: 'TOGGLE_LOS_INDICATOR' }
   | { type: 'ADD_CHART_WINDOW'; payload: ChartWindow }
   | { type: 'REMOVE_CHART_WINDOW'; payload: string }
   | { type: 'SET_CHART_WINDOW_DS'; payload: { id: string; dsNames: string[] } };


### PR DESCRIPTION
## Summary

- Map was drifting south on each zoom-out step; the drift went away once you zoomed back in.
- Root cause: a state round-trip. Every `moveend` dispatched `SET_VIEW_BOUNDS`; a `useEffect` watching `state.viewBounds` then called `map.setView(bounds.getCenter(), getBoundsZoom(bounds))` — but `bounds.getCenter()` is the arithmetic mean of `(N+S)/2` in latitude space, not the Mercator projected center. Mercator stretches latitudes away from the equator, so the projected center of `[N, S]` sits closer to the equator than `(N+S)/2`. Each zoom-out step therefore re-centered the map a little toward the equator. At high zoom the N–S span is fractional degrees and the gap is invisible; at low zoom it's many degrees and you see the drift.
- Fix: split the action in two. `SET_VIEW_BOUNDS` (map → state, from `moveend`) no longer triggers a flyTo. A new `APPLY_VIEW_BOUNDS` (sidebar Apply / Dataset buttons) updates `viewBounds` **and** bumps a `viewBoundsApplySeq` counter. The flyTo effect depends only on the counter, so the map never flies back to itself.

## Test plan

- [x] Open map, zoom way out with scroll wheel — center no longer drifts southward with each tick
- [x] Zoom in — no regression
- [x] Sidebar "View Extent → Apply" still flies the map to the typed bounds
- [x] Sidebar "View Extent → Dataset" button still flies to the current dataset's bounds
- [x] N/S/W/E input fields still reflect the current map view as you pan/zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)