### PR TITLE
Unbreak pre-commit mypy on utils.py (missing stubs + wrong annotation)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,4 @@ repos:
         - types-requests
         - "pydantic>=2.4"
         - types-simplejson
+        - types-python-dateutil

--- a/src/bowser/utils.py
+++ b/src/bowser/utils.py
@@ -61,9 +61,7 @@ def _parse_x_values(x_values: list[str | int]) -> np.ndarray:
     return datetime_to_float(dates)
 
 
-def calculate_trend(
-    values: np.ndarray, x_values: list[str | int | DateOrDatetimeT]
-) -> dict[str, float]:
+def calculate_trend(values: np.ndarray, x_values: list[str | int]) -> dict[str, float]:
     """Calculate linear trend for time series data.
 
     Parameters
@@ -71,7 +69,9 @@ def calculate_trend(
     values : np.ndarray
         Time series values (e.g., displacement in meters)
     x_values : list[str | int]
-        Time values as strings (datetime format) or integers
+        Time values as strings (datetime format) or integers.
+        Datetime objects aren't supported — ``_parse_x_values`` calls
+        ``parser.parse`` which only accepts strings.
 
     Returns
     -------
@@ -240,7 +240,9 @@ def generate_colorbar(cmap_name: str) -> bytes:
 
 
 def register_custom_colormaps() -> None:
-    """Register cfastie, rplumbo, schwarzwald reversed variants in rio_tiler and matplotlib.
+    """Register reversed cfastie/rplumbo/schwarzwald colormaps.
+
+    Registers the ``_r`` variants in both rio_tiler and matplotlib.
 
     rio_tiler ships cfastie/rplumbo/schwarzwald but not their ``_r`` (reversed)
     counterparts.  This function reads each from rio_tiler's registry, reverses
@@ -278,17 +280,13 @@ def register_custom_colormaps() -> None:
 
         # Also register in matplotlib for the /colorbar/ endpoint
         rgba = np.array([list(rev[i]) for i in range(256)], dtype=np.uint8)
-        mpl_cmap = LinearSegmentedColormap.from_list(
-            rev_name, rgba[:, :3] / 255.0
-        )
+        mpl_cmap = LinearSegmentedColormap.from_list(rev_name, rgba[:, :3] / 255.0)
         if rev_name not in mpl.colormaps:
             mpl.colormaps.register(mpl_cmap, name=rev_name)
 
         # Register the forward matplotlib cmap too (in case it's missing)
         fwd_rgba = np.array([list(fwd[i]) for i in range(256)], dtype=np.uint8)
-        mpl_fwd = LinearSegmentedColormap.from_list(
-            name, fwd_rgba[:, :3] / 255.0
-        )
+        mpl_fwd = LinearSegmentedColormap.from_list(name, fwd_rgba[:, :3] / 255.0)
         if name not in mpl.colormaps:
             mpl.colormaps.register(mpl_fwd, name=name)
 


### PR DESCRIPTION
## Summary

Every commit touching `utils.py` was failing the pre-commit `mypy` hook locally because of two pre-existing issues:

1. **`.pre-commit-config.yaml`** declared `types-setuptools`, `types-requests`, `pydantic>=2.4`, `types-simplejson` in the mypy hook's `additional_dependencies` — but not `types-python-dateutil`. Mypy runs in its own isolated env, so missing that stub tripped *Library stubs not installed for "dateutil"* on every run.

2. **`calculate_trend`'s signature** advertised `list[str | int | DateOrDatetimeT]` but delegated to `_parse_x_values(list[str | int])`. The wider type was wishful — `_parse_x_values` ultimately calls `dateutil.parser.parse`, which only accepts strings; passing a `datetime` object would error at runtime. Narrowed the annotation to match reality.

## Things left alone

- `DateOrDatetimeT` stays in the module — still used by `datetime_to_float`.
- The `# type: ignore[arg-type]` comments on `calculate_trend` callers in `main.py` stay; `list` is invariant, so `list[str]` still isn't assignable to `list[str | int]` without the suppression.

## Drive-by

Fixed one unrelated pre-existing `E501` in a docstring — ruff only flags it on full-file recheck, so any PR editing this file previously had to fix it anyway.

## Test plan

- [x] `pre-commit run mypy --files src/bowser/utils.py` passes
- [x] `pre-commit run mypy --files src/bowser/main.py` still passes (callers' `# type: ignore` comments correctly preserved)
- [x] ruff / ruff-format pass

CI only runs pytest, not pre-commit, so none of this shows in the CI check — but every local commit loop was broken on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)