### PR TITLE
Design PR 2: Sidebar sections become M3 elevated cards

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -235,20 +235,28 @@ export default function ControlPanel({ title }: { title: string }) {
             }}
           >⇅</button>
         </div>
-        <img src={`/colorbar/${state.colormap}`} className="colorbar-img" alt="Colormap" />
-        <div className="minmax-row">
-          <div className="minmax-field">
-            <label className="minmax-label">Min</label>
-            <input className="sidebar-input" type="text" inputMode="decimal"
-              value={draftVmin} onChange={e => setDraftVmin(e.target.value)}
-              onBlur={commitVmin} onKeyDown={e => e.key === 'Enter' && commitVmin()} />
-          </div>
-          <div className="minmax-field">
-            <label className="minmax-label">Max</label>
-            <input className="sidebar-input" type="text" inputMode="decimal"
-              value={draftVmax} onChange={e => setDraftVmax(e.target.value)}
-              onBlur={commitVmax} onKeyDown={e => e.key === 'Enter' && commitVmax()} />
-          </div>
+        <div className="colorbar-row">
+          <input
+            aria-label="Min value"
+            className="sidebar-input"
+            type="text"
+            inputMode="decimal"
+            value={draftVmin}
+            onChange={e => setDraftVmin(e.target.value)}
+            onBlur={commitVmin}
+            onKeyDown={e => e.key === 'Enter' && commitVmin()}
+          />
+          <img src={`/colorbar/${state.colormap}`} className="colorbar-img" alt="Colormap" />
+          <input
+            aria-label="Max value"
+            className="sidebar-input"
+            type="text"
+            inputMode="decimal"
+            value={draftVmax}
+            onChange={e => setDraftVmax(e.target.value)}
+            onBlur={commitVmax}
+            onKeyDown={e => e.key === 'Enter' && commitVmax()}
+          />
         </div>
         <div className="slider-group">
           <div className="slider-label">

--- a/src/style.css
+++ b/src/style.css
@@ -165,11 +165,23 @@ body {
 }
 
 .sidebar-section {
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--sb-border);
+  /* M3 elevated card — Elevation 1: one scrim shadow + one key shadow.
+   * Horizontal margin (8px) is tighter than vertical (12px) so the
+   * content row stays wide enough for the 5-button histogram row to
+   * fit on one line. */
+  margin: 12px 8px 0;
+  padding: 16px;
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 1px 3px rgba(0, 0, 0, 0.10);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+}
+
+.sidebar-section:last-of-type {
+  margin-bottom: 12px;
 }
 
 .sidebar-section-label {
@@ -230,13 +242,81 @@ body {
   border-color: var(--sb-accent);
 }
 
-/* Range slider */
+/* Range slider — M3 Continuous Slider:
+ * - thin inactive track in --sb-surface2,
+ * - prominent thumb in accent color with ring + elevation,
+ * - no filled-portion color (would require JS-driven --pct on each
+ *   input; the thumb carries the position signal).
+ */
 .sidebar-range {
+  -webkit-appearance: none;
+  appearance: none;
   width: 100%;
-  accent-color: var(--sb-accent);
-  cursor: pointer;
   height: 4px;
+  background: var(--sb-surface2);
   border-radius: 2px;
+  cursor: pointer;
+  outline: none;
+}
+
+/* WebKit (Chrome / Safari) */
+.sidebar-range::-webkit-slider-runnable-track {
+  height: 4px;
+  background: transparent;
+  border-radius: 2px;
+}
+
+.sidebar-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  background: var(--sb-accent);
+  border: 2px solid var(--sb-surface);
+  border-radius: 50%;
+  margin-top: -7px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  cursor: grab;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.sidebar-range:hover::-webkit-slider-thumb,
+.sidebar-range:focus::-webkit-slider-thumb {
+  transform: scale(1.12);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35), 0 0 0 6px rgba(91, 192, 190, 0.12);
+}
+
+.sidebar-range:active::-webkit-slider-thumb {
+  cursor: grabbing;
+  transform: scale(1.12);
+}
+
+/* Firefox */
+.sidebar-range::-moz-range-track {
+  height: 4px;
+  background: var(--sb-surface2);
+  border-radius: 2px;
+}
+
+.sidebar-range::-moz-range-progress {
+  height: 4px;
+  background: var(--sb-accent);
+  border-radius: 2px;
+}
+
+.sidebar-range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  background: var(--sb-accent);
+  border: 2px solid var(--sb-surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  cursor: grab;
+  transition: transform 0.1s ease;
+}
+
+.sidebar-range:hover::-moz-range-thumb {
+  transform: scale(1.12);
 }
 
 .slider-group {
@@ -328,6 +408,24 @@ body {
   display: block;
 }
 
+/* MIN / colorbar / MAX — inputs flank the bar (M3-style compact range UI). */
+.colorbar-row {
+  display: grid;
+  grid-template-columns: 72px 1fr 72px;
+  align-items: center;
+  gap: 8px;
+}
+
+.colorbar-row .sidebar-input {
+  padding: 4px 6px;
+  font-size: 0.78em;
+}
+
+.colorbar-row .colorbar-img {
+  height: 18px;
+  object-fit: fill;
+}
+
 /* ── Histogram ──────────────────────────────────────────────── */
 .histogram-wrapper {
   display: flex;
@@ -337,7 +435,7 @@ body {
 
 .histogram-chart-area {
   height: 64px;
-  background: var(--sb-surface);
+  background: var(--sb-surface2);
   border-radius: 6px;
   overflow: hidden;
   padding: 2px;


### PR DESCRIPTION
Second in the design refresh series. Built on the tokens landed in #43.

This PR turns the flat scroll of sidebar sections into elevated M3 cards and does three structural cleanups that the token PR deferred.

<img width="348" height="836" alt="image" src="https://github.com/user-attachments/assets/67c1eb84-30b6-47f9-ba93-f5041f12fe44" />


## 1. Cards

Each section (Layers, Visualization, Reference Point, Masking, Point Buffer) now sits on an elevated surface with a 1px border, `--radius-md` (12px) corners, and M3 Elevation 1 shadow (one scrim shadow + one key shadow). The previous `border-bottom` divider is gone.

- Internal padding: 16px
- Between cards: 12px vertical
- Horizontal margin: 8px (tighter than vertical on purpose — keeps the 5-button histogram row on one line; 12px horizontal caused wrap)

## 2. Compact Visualization card (MIN / colorbar / MAX on one row)

Collapses the old layout

```
┌──────────────────────────────────┐
│ [colormap select]       [invert] │
├──────────────────────────────────┤
│ [        colorbar image        ] │
├──────────────────────────────────┤
│ MIN             │            MAX │
│ [   0   ]       │        [ 1  ] │
└──────────────────────────────────┘
```

into a single row

```
┌──────────────────────────────────┐
│ [colormap select]       [invert] │
├──────────────────────────────────┤
│ [0] [====colorbar====] [1]       │
└──────────────────────────────────┘
```

- Labels become `aria-label` — position carries the semantics
- Frees ~48px of vertical space
- New CSS: `.colorbar-row { grid-template-columns: 72px 1fr 72px; }`

## 3. M3 Continuous opacity slider

`.sidebar-range` gets the full M3 continuous-slider treatment:

- 4px track in `--sb-surface2`
- 18px teal thumb with `--sb-surface`-color border (ring) and drop shadow
- Focus/hover: 1.12× scale + soft outer ring
- Firefox also fills `::-moz-range-progress` in accent
- Applies to every slider (opacity, time step, buffer radii) — consistent

No filled-track on Chrome — would require `--pct` custom property updated inline on every change. The thumb alone carries the position signal clearly enough; skipped the inline-style work.

## Side-fix

`.histogram-chart-area` was `--sb-surface`; now that cards sit on `--sb-surface` it would vanish. Bumped to `--sb-surface2`.

## Test plan

- [x] `npm run build` passes
- [x] `npm run tsc` passes
- [x] Dark + light + chart-open Playwright screenshots against Palos Verdes data; no regressions. Golden path (theme toggle, open time series chart, colormap change, MIN/MAX commit on Enter/blur) all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)