### PR TITLE
Fix layer-mask NoDataInBounds at low zoom (MD mode)

### DIFF
--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -500,20 +500,30 @@ def _apply_layer_masks_md(
     da: "xr.DataArray",
     layer_masks: list[dict],
     time_idx: int | None = None,
+    source_ds: "xr.Dataset | None" = None,
 ) -> "xr.DataArray":
     """Apply a list of layer mask dicts to a DataArray (MD mode).
 
     Each dict has keys: dataset (str), threshold (float), mode ('min'|'max').
     threshold is an absolute value in the mask layer's data units.
     'min' keeps pixels >= threshold; 'max' keeps pixels <= threshold.
+
+    ``source_ds`` is the Dataset to look up mask variables in. Tile-rendering
+    callers MUST pass the same pyramid-level Dataset that ``da`` came from —
+    otherwise ``da.where(mask_da)`` outer-aligns two grids with different
+    cell sizes, producing a coord array that ``rioxarray.rio.bounds()`` can't
+    interpret as monotonic and the request 500s with NoDataInBounds. Defaults
+    to ``state.dataset`` (level 0) for the non-tile callers that already
+    operate at full resolution.
     """
+    ds = source_ds if source_ds is not None else state.dataset
     for m in layer_masks:
         var = m.get("dataset")
         threshold = float(m.get("threshold", 0.5))
         mode = m.get("mode", "min")
-        if not var or var not in state.dataset.data_vars:
+        if not var or var not in ds.data_vars:
             continue
-        mask_da = state.dataset[var]
+        mask_da = ds[var]
         if time_idx is not None:
             mdim = _non_spatial_dim(mask_da)
             if mdim is not None:
@@ -1596,10 +1606,15 @@ def XarrayPathDependency(
     if mask_da is not None:
         da = da.where(mask_da > mask_min_value)
 
-    # Apply layer masks
+    # Apply layer masks. ``source_ds=ds`` is essential here — ``ds`` is the
+    # pyramid-level Dataset selected for ``tile_z``; if we let the helper
+    # default to state.dataset (level 0) the mask grid won't match ``da``'s
+    # grid at low zoom and rioxarray bounds resolution fails downstream.
     if layer_masks:
         try:
-            da = _apply_layer_masks_md(da, json.loads(layer_masks), time_idx)
+            da = _apply_layer_masks_md(
+                da, json.loads(layer_masks), time_idx, source_ds=ds
+            )
         except json.JSONDecodeError as e:
             logger.warning(f"Failed to parse layer_masks JSON: {e}")
 


### PR DESCRIPTION
## Bug

When a layer mask is active and the user zooms out so the entire raster fits the viewport, the velocity overlay disappears and the backend logs:

```
File "/.../titiler/core/factory.py", line 959, in tile
    with self.reader( …
File "<attrs generated methods rio_tiler.io.xarray.XarrayReader>", line 36, in __init__
File "/.../rio_tiler/io/xarray.py", line 84, in __attrs_post_init__
    self.bounds = tuple(self.input.rio.bounds())
File "/.../rioxarray/rioxarray.py", line 1006, in _internal_bounds
    raise NoDataInBounds(
rioxarray.exceptions.NoDataInBounds: Unable to determine bounds from coordinates. Data variable: velocity
```

At high zoom the layer renders fine — symptom only shows once the requested tile is at a low enough zoom that `dataset_for_tile_zoom(tile_z)` returns a coarsened pyramid level.

## Root cause

`_apply_layer_masks_md` looked up mask variables in `state.dataset` (level 0):

```python
mask_da = state.dataset[var]
…
da = da.where(mask_da >= threshold)
```

But the tile-rendering caller in `XarrayPathDependency` resolves `da` from `target.dataset_for_tile_zoom(tile_z)`, which returns a *coarser* Dataset when zoomed out. `da.where(mask_da)` then outer-aligns two y/x grids whose cell centres don't coincide. The resulting coordinates are interleaved and non-monotonic — rioxarray's `_internal_bounds()` can't extract a uniform resolution from them and raises.

`reproject_match` (used by the custom-mask path) doesn't apply here because the layer-mask path went straight through `where`.

## Fix

Added `source_ds` kwarg to `_apply_layer_masks_md`. Tile-rendering callsite now passes the same pyramid-level Dataset that `da` came from. The other three callers (`/point`, `/buffer_timeseries`, `/trend_analysis`) all work on `state.dataset` directly and keep relying on the default — they're at level 0 already, so no behavior change.

## Test plan

- [x] ruff / ruff-format / mypy pass
- [ ] Reviewer to verify on the affected dataset (the test box I had loaded was COG mode, not MD — different code path; couldn't reproduce locally without a Zarr cube). Repro: load a `--stack-file cube.zarr`, apply a `closure_coherence ≥ 0.5` mask, zoom out until the whole raster is in view. Before this PR: overlay vanishes + 500s in log. After: overlay continues to render at every zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)