### PR TITLE
tifs-to-geozarr: lower default workers from cpu_count to 4

### DIFF
--- a/src/bowser/_tifs_to_geozarr.py
+++ b/src/bowser/_tifs_to_geozarr.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import itertools
 import json
 import logging
-import os
 import time
 import warnings
 from collections.abc import Iterable, Iterator
@@ -105,7 +104,15 @@ def convert(
         if pyramid
         else [(ref.y_coords, ref.x_coords)]
     )
-    n_workers = workers or min(len(groups_cfg), os.cpu_count() or 4)
+    # Default to 4 threads, not cpu_count. Each reader holds a whole variable
+    # in RAM (+ its pyramid levels) until the writer drains it, so peak memory
+    # scales as ``(n_workers + 1) × largest_group``. On a 12-core machine with
+    # multi-GB 3D stacks (unwrapped, filtered_time_series), cpu_count was
+    # driving peak RSS to 90+ GB. Rasterio reads are mostly I/O-bound and
+    # release the GIL, so 4 threads already saturate typical disk bandwidth;
+    # going higher trades little wall time for a lot of memory. Callers with
+    # small variables and plenty of RAM can override via ``--workers N``.
+    n_workers = workers or min(len(groups_cfg), 4)
     logger.info(
         "Loading %d variables with %d threads, %d pyramid level(s)",
         len(groups_cfg),

--- a/src/bowser/cli.py
+++ b/src/bowser/cli.py
@@ -1080,7 +1080,9 @@ def register(
     help=(
         "Parallel reader threads — one variable per thread. "
         "rasterio releases the GIL during reads so threads overlap I/O. "
-        "0 = min(len(variables), cpu_count())."
+        "Peak RSS is roughly (workers + 1) × the largest variable, so "
+        "bumping this past a few threads inflates memory quickly for "
+        "multi-GB 3D stacks. 0 = min(len(variables), 4)."
     ),
 )
 @click.option(


### PR DESCRIPTION
## The problem

User reported `bowser tifs-to-geozarr` peaking at 96 GB RSS on a 12-core laptop with a typical dolphin stack. The `(n_workers + 1) × largest_group` bound *is* being honoured — it's just that the default was `os.cpu_count()`, so `(12 + 1) × ~7 GB unwrapped stack ≈ 91 GB`. Matches the reported number exactly.

## Fix

Drop the default to 4. That puts the bound at `5 × largest ≈ 35 GB`, which fits on any reasonable dev machine.

Rationale for 4:
- Rasterio reads release the GIL and are disk-bound; wall-time gains past ~4 parallel readers are minimal on typical SSDs.
- Memory cost of additional workers is linear and often multi-GB each.
- Users with small variables and plenty of RAM can still `--workers 12` for full throughput.

Help text on `--workers` now makes the memory tradeoff explicit:

> Peak RSS is roughly (workers + 1) × the largest variable, so bumping this past a few threads inflates memory quickly for multi-GB 3D stacks.

Dropped the now-unused `os` import.

## Test plan

- [x] ruff / ruff-format / mypy pass
- [x] `bowser tifs-to-geozarr --help` shows the updated guidance
- [ ] Reporter to confirm peak RSS stays under their memory limit on the same dataset after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)