### PR TITLE
Exclude image/tiff from response compression

### DIFF
--- a/src/bowser/main.py
+++ b/src/bowser/main.py
@@ -1554,6 +1554,7 @@ app.add_middleware(
         "image/png",
         "image/jp2",
         "image/webp",
+        "image/tiff",  # GeoTIFF exports are already (deflate-)compressed binary
     },
     compression_level=6,
 )


### PR DESCRIPTION
GeoTIFF exports (FileResponse, image/tiff) were being run through the gzip/brotli compression middleware, which wastes CPU on already- deflate-compressed binary and can trip starlette-cramjam's Content-Length handling on large payloads. Add image/tiff to exclude_mediatype.